### PR TITLE
Stat points increment and reset: implementation

### DIFF
--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -24,6 +24,7 @@ namespace MapleServer2.PacketHandlers.Game
             // Self
             session.EnterField(session.Player.MapId);
             session.Send(FieldObjectPacket.SetStats(session.FieldPlayer));
+            session.Send(StatPointPacket.WriteTotalStatPoints(session.Player));
             session.Send(EmotePacket.LoadEmotes());
 
             // Normally skill layout would be loaded from a database

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.Logging;
+using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Servers.Game;
+using MapleServer2.Packets;
+using System;
+
+namespace MapleServer2.PacketHandlers.Game
+{
+    public class StatPointHandler : GamePacketHandler
+    {
+        public override RecvOp OpCode => RecvOp.STAT_POINT;
+
+        public StatPointHandler(ILogger<StatPointHandler> logger) : base(logger) { }
+
+        public override void Handle(GameSession session, PacketReader packet)
+        {
+            byte mode = packet.ReadByte();
+
+            switch (mode)
+            {
+                case 2: 
+                // Increment attribute point
+                    HandleStatIncrement(session, packet);
+                    // follow up SendStat packet to refresh updated stats
+                    break;
+                case 3:
+                // Reset attribute distribution
+                    HandleResetStatDistribtuion(session, packet);
+                    // follow up SendStat packet to refresh updated stats
+                    break;
+            }
+        }
+
+        private void HandleStatIncrement(GameSession session, PacketReader packet)
+        {
+            byte statTypeIndex = packet.ReadByte();
+            Console.WriteLine("statIndex value: " + statTypeIndex);
+            StatPointPacket.AddStatPoint(session.Player, statTypeIndex);
+            session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
+        }
+        private void HandleResetStatDistribtuion(GameSession session, PacketReader packet)
+        {
+            StatPointPacket.ResetStatPoints(session.Player);
+            session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
+        }
+    }
+}

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -22,12 +22,10 @@ namespace MapleServer2.PacketHandlers.Game
                 case 2: 
                 // Increment attribute point
                     HandleStatIncrement(session, packet);
-                    // follow up SendStat packet to refresh updated stats
                     break;
                 case 3:
                 // Reset attribute distribution
                     HandleResetStatDistribtuion(session, packet);
-                    // follow up SendStat packet to refresh updated stats
                     break;
             }
         }
@@ -35,7 +33,6 @@ namespace MapleServer2.PacketHandlers.Game
         private void HandleStatIncrement(GameSession session, PacketReader packet)
         {
             byte statTypeIndex = packet.ReadByte();
-            Console.WriteLine("statIndex value: " + statTypeIndex);
             StatPointPacket.AddStatPoint(session.Player, statTypeIndex);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
         }

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -31,19 +31,22 @@ namespace MapleServer2.PacketHandlers.Game
                 case StatPointMode.Reset:
                     HandleResetStatDistribution(session);
                     break;
+                default:
+                    IPacketHandler<GameSession>.LogUnknownMode(mode);
+                    break;
             }
         }
 
         private void HandleStatIncrement(GameSession session, PacketReader packet)
         {
             byte statTypeIndex = packet.ReadByte();
-            StatPointPacket.AddStatPoint(session.Player, statTypeIndex);
+            session.Player.StatPointDistribution.AddPoint(statTypeIndex);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
         }
 
         private void HandleResetStatDistribution(GameSession session)
         {
-            StatPointPacket.ResetStatPoints(session.Player);
+            session.Player.StatPointDistribution.ResetPoints();
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
         }
     }

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -13,19 +13,23 @@ namespace MapleServer2.PacketHandlers.Game
 
         public StatPointHandler(ILogger<StatPointHandler> logger) : base(logger) { }
 
+        private enum StatPointMode : byte
+        {
+            Increment = 0x2,
+            Reset = 0x3
+        }
+
         public override void Handle(GameSession session, PacketReader packet)
         {
-            byte mode = packet.ReadByte();
+            StatPointMode mode = (StatPointMode) packet.ReadByte();
 
             switch (mode)
             {
-                case 2: 
-                    // Increment attribute point
+                case StatPointMode.Increment:
                     HandleStatIncrement(session, packet);
                     break;
-                case 3:
-                    // Reset attribute distribution
-                    HandleResetStatDistribtuion(session, packet);
+                case StatPointMode.Reset:
+                    HandleResetStatDistribution(session);
                     break;
             }
         }
@@ -35,14 +39,12 @@ namespace MapleServer2.PacketHandlers.Game
             byte statTypeIndex = packet.ReadByte();
             StatPointPacket.AddStatPoint(session.Player, statTypeIndex);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
-            session.Send(SendStatPacket.WriteCharacterStats(session.Player));
         }
 
-        private void HandleResetStatDistribtuion(GameSession session, PacketReader packet)
+        private void HandleResetStatDistribution(GameSession session)
         {
             StatPointPacket.ResetStatPoints(session.Player);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
-            session.Send(SendStatPacket.WriteCharacterStats(session.Player));
         }
     }
 }

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -20,11 +20,11 @@ namespace MapleServer2.PacketHandlers.Game
             switch (mode)
             {
                 case 2: 
-                // Increment attribute point
+                    // Increment attribute point
                     HandleStatIncrement(session, packet);
                     break;
                 case 3:
-                // Reset attribute distribution
+                    // Reset attribute distribution
                     HandleResetStatDistribtuion(session, packet);
                     break;
             }
@@ -35,11 +35,14 @@ namespace MapleServer2.PacketHandlers.Game
             byte statTypeIndex = packet.ReadByte();
             StatPointPacket.AddStatPoint(session.Player, statTypeIndex);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
+            session.Send(SendStatPacket.WriteCharacterStats(session.Player));
         }
+
         private void HandleResetStatDistribtuion(GameSession session, PacketReader packet)
         {
             StatPointPacket.ResetStatPoints(session.Player);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
+            session.Send(SendStatPacket.WriteCharacterStats(session.Player));
         }
     }
 }

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -47,15 +47,5 @@ namespace MapleServer2.Packets
 
             return pWriter;
         }
-
-        public static void AddStatPoint(Player character, byte statType)
-        {
-            character.StatPointDistribution.AddPoint(statType);
-        }
-
-        public static void ResetStatPoints(Player character)
-        {
-            character.StatPointDistribution.ResetPoints();
-        }
     }
 }

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Types;
+
+namespace MapleServer2.Packets
+{
+    public static class StatPointPacket
+    {
+        public static Packet WriteTotalStatPoints(Player character)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.STAT_POINT);
+            // sends back some 41 character length packet with mode 00
+            // this represents the total number of stat points gained and how each stat point was obtained (ie quest, trophy, exploration, prestige)
+            // sent when FieldEnterHandler is called?
+            pWriter.WriteByte(0);
+            pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints);
+
+
+            return pWriter;
+        }
+
+        public static Packet WriteStatPointDistribution(Player character)
+        {
+            // sends back a packet that updates or loads the character's current stat distribution
+            PacketWriter pWriter = PacketWriter.Of(SendOp.STAT_POINT);
+
+            // write mode
+            pWriter.WriteByte(1);
+            // write number of attribute points the character has
+            pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints); //TODO: FIGURE OUT HOW TO SAVE TOTAL NUMBER OF ATTRIBUTE POINTS 
+
+            // write the number of types of stat points that have points allocated
+            pWriter.WriteInt(character.StatPointDistribution.GetStatTypeCount());
+
+            // run through each entry in the character's AllocatedStats dictionary
+            foreach (var StatType in character.StatPointDistribution.AllocatedStats.Keys.ToList())
+            {
+                // write the Stat Type (ex. Strength), then int value of points allocated
+                pWriter.WriteByte(StatType);
+                pWriter.WriteInt(character.StatPointDistribution.AllocatedStats[StatType]);
+            }
+
+            return pWriter;
+        }
+
+        public static void AddStatPoint(Player character, byte statType)
+        {
+            character.StatPointDistribution.AddPoint(statType);
+            //call WriteStatPointDistribution - it takes the character's StatDistribution and converts it to a packet
+        }
+
+        public static void ResetStatPoints(Player character)
+        {
+            character.StatPointDistribution.ResetPoints();
+            //call WriteStatPointDistribution
+
+        }
+    }
+}

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -17,7 +17,6 @@ namespace MapleServer2.Packets
             pWriter.WriteByte(0);
             pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints);
 
-
             return pWriter;
         }
 

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -48,13 +48,11 @@ namespace MapleServer2.Packets
         public static void AddStatPoint(Player character, byte statType)
         {
             character.StatPointDistribution.AddPoint(statType);
-            //call WriteStatPointDistribution - it takes the character's StatDistribution and converts it to a packet
         }
 
         public static void ResetStatPoints(Player character)
         {
             character.StatPointDistribution.ResetPoints();
-            //call WriteStatPointDistribution
 
         }
     }

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -52,7 +52,6 @@ namespace MapleServer2.Packets
         public static void ResetStatPoints(Player character)
         {
             character.StatPointDistribution.ResetPoints();
-
         }
     }
 }

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -19,6 +19,7 @@ namespace MapleServer2.Packets
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT_POINT);
             // sends back 41 character length packet which represents the total number of stat points gained and
             // how each stat point was obtained (ie quest, trophy, exploration, prestige)
+
             pWriter.WriteByte((byte) StatPointPacketMode.TotalPoints);
             pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints);
 

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -8,13 +8,18 @@ namespace MapleServer2.Packets
 {
     public static class StatPointPacket
     {
+        private enum StatPointPacketMode : byte
+        {
+            TotalPoints = 0x0,
+            StatDistribution = 0x1
+        }
+
         public static Packet WriteTotalStatPoints(Player character)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT_POINT);
-            // sends back some 41 character length packet with mode 00
-            // this represents the total number of stat points gained and how each stat point was obtained (ie quest, trophy, exploration, prestige)
-            // sent when FieldEnterHandler is called?
-            pWriter.WriteByte(0);
+            // sends back 41 character length packet which represents the total number of stat points gained and
+            // how each stat point was obtained (ie quest, trophy, exploration, prestige)
+            pWriter.WriteByte((byte) StatPointPacketMode.TotalPoints);
             pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints);
 
             return pWriter;
@@ -25,20 +30,18 @@ namespace MapleServer2.Packets
             // sends back a packet that updates or loads the character's current stat distribution
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT_POINT);
 
-            // write mode
-            pWriter.WriteByte(1);
+            pWriter.WriteByte((byte) StatPointPacketMode.StatDistribution);
             // write number of attribute points the character has
             pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints); //TODO: FIGURE OUT HOW TO SAVE TOTAL NUMBER OF ATTRIBUTE POINTS 
 
             // write the number of types of stat points that have points allocated
             pWriter.WriteInt(character.StatPointDistribution.GetStatTypeCount());
 
-            // run through each entry in the character's AllocatedStats dictionary
-            foreach (var StatType in character.StatPointDistribution.AllocatedStats.Keys.ToList())
+            foreach (byte statType in character.StatPointDistribution.AllocatedStats.Keys.ToList())
             {
                 // write the Stat Type (ex. Strength), then int value of points allocated
-                pWriter.WriteByte(StatType);
-                pWriter.WriteInt(character.StatPointDistribution.AllocatedStats[StatType]);
+                pWriter.WriteByte(statType);
+                pWriter.WriteInt(character.StatPointDistribution.AllocatedStats[statType]);
             }
 
             return pWriter;

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -112,7 +112,6 @@ namespace MapleServer2.Types
                 XmlParser.ParseSkills(job)
             };
 
-
             Player player = new Player
             {
                 SkillTabs = skillTabs,

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -71,6 +71,7 @@ namespace MapleServer2.Types
         public int MaxSkillTabs;
         public long ActiveSkillTabId;
         public List<SkillTab> SkillTabs = new List<SkillTab>();
+        public StatDistribution StatPointDistribution = new StatDistribution();
 
         public Dictionary<ItemSlot, Item> Equips = new Dictionary<ItemSlot, Item>();
         public List<Item> Badges = new List<Item>();
@@ -104,15 +105,18 @@ namespace MapleServer2.Types
             int job = 50; // Archer
 
             PlayerStats stats = PlayerStats.Default();
+            StatDistribution StatPointDistribution = new StatDistribution();
 
             List<SkillTab> skillTabs = new List<SkillTab>
             {
                 XmlParser.ParseSkills(job)
             };
 
+
             Player player = new Player
             {
                 SkillTabs = skillTabs,
+                StatPointDistribution = StatPointDistribution,
                 MapId = 2000062,
                 AccountId = accountId,
                 CharacterId = characterId,

--- a/MapleServer2/Types/StatDistribution.cs
+++ b/MapleServer2/Types/StatDistribution.cs
@@ -28,16 +28,15 @@ namespace MapleServer2.Types
             this.AllocatedStats = AllocatedStats;
         }
 
-        public void AddPoint(byte StatType)
+        public void AddPoint(byte statType)
         {
-            int statCount;
-            if (AllocatedStats.TryGetValue(StatType, out statCount))
+            if (AllocatedStats.ContainsKey(statType))
             {
-                AllocatedStats[StatType] = statCount + 1;
+                AllocatedStats[statType] += 1;
             }
             else
             {
-                AllocatedStats[StatType] = 1;
+                AllocatedStats[statType] = 1;
             }
         }
 

--- a/MapleServer2/Types/StatDistribution.cs
+++ b/MapleServer2/Types/StatDistribution.cs
@@ -8,7 +8,6 @@ namespace MapleServer2.Types
 {
     public class StatDistribution
     {
-
         public int TotalStatPoints { get; private set; }
         // TODO: implement Dictionary to keep track of points earned from quest, trophy, exploration, prestige
         // naming convention: PointsFromQuest, PointsFromTrophy, PointsFromExploration, PointsFromPrestige

--- a/MapleServer2/Types/StatDistribution.cs
+++ b/MapleServer2/Types/StatDistribution.cs
@@ -13,7 +13,7 @@ namespace MapleServer2.Types
         // naming convention: PointsFromQuest, PointsFromTrophy, PointsFromExploration, PointsFromPrestige
 
         public Dictionary<byte, int> AllocatedStats { get; private set; }
-        // key = index of the stat 
+        // key = index representing the stat type (ie. a value of 00 corresponds to Str)
         // value = number of points allocated to the stat
 
         public StatDistribution()

--- a/MapleServer2/Types/StatDistribution.cs
+++ b/MapleServer2/Types/StatDistribution.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MapleServer2.Types
+{
+    public class StatDistribution    {
+
+        public int TotalStatPoints { get; private set; }
+        // TODO: implement Dictionary to keep track of points earned from quest, trophy, exploration, prestige
+        // naming convention: PointsFromQuest, PointsFromTrophy, PointsFromExploration, PointsFromPrestige
+
+        public Dictionary<byte, int> AllocatedStats { get; private set; }
+        // key = index of the stat 
+        // value = number of points allocated to the stat
+
+        public StatDistribution()
+        {
+            // hardcode the amount of stat points the character starts with temporarily
+            this.TotalStatPoints = 18;
+            this.AllocatedStats = new Dictionary<byte, int>();
+        }
+
+        public StatDistribution(Dictionary<byte, int> AllocatedStats)
+        {
+            this.AllocatedStats = AllocatedStats;
+        }
+
+        public void AddPoint(byte StatType)
+        {
+            int statCount;
+            if (AllocatedStats.TryGetValue(StatType, out statCount))
+            {
+                AllocatedStats[StatType] = statCount + 1;
+            }
+            else
+            {
+                AllocatedStats[StatType] = 1;
+            }
+
+            Console.WriteLine("Stat Distribution: " + ToDebugString(AllocatedStats));
+
+        }
+
+        public void ResetPoints()
+        {
+            AllocatedStats.Clear();
+        }
+
+        public byte GetStatTypeCount()
+        {
+            // returns a count of how many types of Stats have had points added to them
+            // ex. a character has Strength and Intelligence points allocated - function returns 2 
+            byte statTypeCount = (byte)AllocatedStats.Count; ;
+
+            return statTypeCount;
+        }
+
+        public static string ToDebugString<TKey, TValue>(Dictionary<TKey, TValue> dictionary)
+        {
+            return "{" + string.Join(",", dictionary.Select(kv => kv.Key + "=" + kv.Value).ToArray()) + "}";
+        }
+    }
+}

--- a/MapleServer2/Types/StatDistribution.cs
+++ b/MapleServer2/Types/StatDistribution.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace MapleServer2.Types
 {
-    public class StatDistribution    {
+    public class StatDistribution
+    {
 
         public int TotalStatPoints { get; private set; }
         // TODO: implement Dictionary to keep track of points earned from quest, trophy, exploration, prestige
@@ -39,9 +40,6 @@ namespace MapleServer2.Types
             {
                 AllocatedStats[StatType] = 1;
             }
-
-            Console.WriteLine("Stat Distribution: " + ToDebugString(AllocatedStats));
-
         }
 
         public void ResetPoints()
@@ -53,9 +51,8 @@ namespace MapleServer2.Types
         {
             // returns a count of how many types of Stats have had points added to them
             // ex. a character has Strength and Intelligence points allocated - function returns 2 
-            byte statTypeCount = (byte) AllocatedStats.Count;
 
-            return statTypeCount;
+            return (byte) AllocatedStats.Count;
         }
 
         public static string ToDebugString<TKey, TValue>(Dictionary<TKey, TValue> dictionary)

--- a/MapleServer2/Types/StatDistribution.cs
+++ b/MapleServer2/Types/StatDistribution.cs
@@ -53,7 +53,7 @@ namespace MapleServer2.Types
         {
             // returns a count of how many types of Stats have had points added to them
             // ex. a character has Strength and Intelligence points allocated - function returns 2 
-            byte statTypeCount = (byte)AllocatedStats.Count; ;
+            byte statTypeCount = (byte) AllocatedStats.Count;
 
             return statTypeCount;
         }


### PR DESCRIPTION
###### This PR is NOT ready for merging! Needs review.
###### To be implemented: The remainder of the `WriteTotalStatPoints` method in `StatPointPacket` class and a functioning version of the `SendStatPacket` class. The incremented stats will currently not appear in the character window because the SendStat packet is not sent to update the character's information.
---
## Stat Points Implementation
### Class: StatPointHandler 
Catches packets (RecvOp code 0x009A) requesting an increment in a stat value (ie +1 to Strength, Dex, Luck, Int, Health, or Crit Rate)
  * Packet format: `<mode byte> <stat index>`
    * Example packet: `02 00` (translated: increment the strength stat)
  * Mode byte - `02` represents the increment command
  * Mode byte - `03` represents the reset stat distribution command
  * Stat index - the indices represented by this byte include   
    * Strength - `00`
    * Dex - `01`
    * Int - `02`
    * Luck - `03`
    * Health - `04`
    * Crit Rate - `0x11` (17 in decimal form)
### Class: StatPointPacket 
Generates a packet (SendOp code 0x0046) in response to a request for StatPoints. 
Contains the following modes:
  * Mode byte - `00` requests the total stat points a player has
  * Mode byte - `01` requests the player's stat distribution

Consists of the following methods:
  * WriteTotalAttributePoints
    * Method that sends the number of attribute points a character has gained and tracks of how each stat point was obtained (ie quest, trophy, exploration, prestige) 
    * This method is called when your character enters the field (ie logs in or new map)
      * ie. server emulator receives a `RESPONSE_FIELD_ENTER` (RecvOp) code from the client
      * result: server emulator sends back `STAT_POINT` packet (SendOp) with information to the client
      * client updates character window with total attribute points
  * WriteAttributePointDistribution
      * Method that sends the distribution of attribute points a character has
      * This packet is sent in response to an incrementation in the player's stats
      * After this stat distribution packet is sent, a follow up packet with op code 0x002F (SendStat) is sent. It contains the player's total stats and displays the updated information in the character's window.
### Class: StatDistribution 
Class that represents the Strength, Dex, Int, Luck, Health, and Crit Rate points a character has allocated to their stats.
* Allows Player to add points to their stats via `AddPoint(byte statType)` or reset their stat distribution via `ResetPoints()`