### PR TITLE
Guild invites, kick, leadership transfer, , leaving (sort of), member mottos

### DIFF
--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -5,7 +5,6 @@ using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
 using Microsoft.Extensions.Logging;
 using MapleServer2.Types;
-using System;
 
 namespace MapleServer2.PacketHandlers.Game
 {
@@ -154,8 +153,10 @@ namespace MapleServer2.PacketHandlers.Game
             {
                 short NoticeCode = 1027;
                 session.Send(GuildPacket.ErrorNotice(NoticeCode));
+                return;
             }
-            else if (guild.Members.Count >= guild.MaxMembers)
+
+            if (guild.Members.Count >= guild.MaxMembers)
             {
                 //TODO Plug in 'full guild' error packets
                 return;
@@ -198,10 +199,12 @@ namespace MapleServer2.PacketHandlers.Game
                 guild.BroadcastPacketGuild(GuildPacket.MemberJoin(session.Player, guildName));
                 session.Send(GuildPacket.UpdateGuild(session, guild));
             }
-            else
+
+            if (response == 00)
             {
                 inviter.Session.Send(GuildPacket.InviteNotification(inviteeName, 256));
                 session.Send(GuildPacket.InviteResponseConfirm(inviter, session.Player, guild, response));
+                return;
             }
         }
 
@@ -240,14 +243,13 @@ namespace MapleServer2.PacketHandlers.Game
                 //TODO: Error packets
                 return;
             }
-            else
-            {
-                session.Send(GuildPacket.KickConfirm(member));
-                member.Session.Send(GuildPacket.KickNotification(session.Player));
-                member.Session.Send(GuildPacket.MemberNotice(member));
-                guild.RemoveMember(member);
-                guild.BroadcastPacketGuild(GuildPacket.KickMember(member, session.Player));
-            }
+
+            session.Send(GuildPacket.KickConfirm(member));
+            member.Session.Send(GuildPacket.KickNotification(session.Player));
+            member.Session.Send(GuildPacket.MemberNotice(member));
+            guild.RemoveMember(member);
+            guild.BroadcastPacketGuild(GuildPacket.KickMember(member, session.Player));
+
         }
 
         private void HandlePlayerMessage(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -189,23 +189,20 @@ namespace MapleServer2.PacketHandlers.Game
                 return;
             }
 
-            if (response == 01)
-            {
-                inviter.Session.Send(GuildPacket.InviteNotification(inviteeName, response));
-                session.Send(GuildPacket.InviteResponseConfirm(inviter, session.Player, guild, response));
-                session.FieldManager.BroadcastPacket(GuildPacket.UpdateGuildTag(session.Player, guildName));
-                guild.AddMember(session.Player);
-                guild.BroadcastPacketGuild(GuildPacket.MemberBroadcastJoinNotice(session.Player, inviterName, response));
-                guild.BroadcastPacketGuild(GuildPacket.MemberJoin(session.Player, guildName));
-                session.Send(GuildPacket.UpdateGuild(session, guild));
-            }
-
             if (response == 00)
             {
                 inviter.Session.Send(GuildPacket.InviteNotification(inviteeName, 256));
                 session.Send(GuildPacket.InviteResponseConfirm(inviter, session.Player, guild, response));
                 return;
             }
+
+            inviter.Session.Send(GuildPacket.InviteNotification(inviteeName, response));
+            session.Send(GuildPacket.InviteResponseConfirm(inviter, session.Player, guild, response));
+            session.FieldManager.BroadcastPacket(GuildPacket.UpdateGuildTag(session.Player, guildName));
+            guild.AddMember(session.Player);
+            guild.BroadcastPacketGuild(GuildPacket.MemberBroadcastJoinNotice(session.Player, inviterName, response));
+            guild.BroadcastPacketGuild(GuildPacket.MemberJoin(session.Player, guildName));
+            session.Send(GuildPacket.UpdateGuild(session, guild));
         }
 
         private void HandleLeave(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -5,6 +5,7 @@ using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
 using Microsoft.Extensions.Logging;
 using MapleServer2.Types;
+using System;
 
 namespace MapleServer2.PacketHandlers.Game
 {
@@ -17,8 +18,16 @@ namespace MapleServer2.PacketHandlers.Game
         private enum GuildMode : byte
         {
             Create = 0x1,
+            Disband = 0x2,
+            Invite = 0x3,
+            InviteResponse = 0x5,
+            Leave = 0x7,
+            Kick = 0x8,
+            PlayerMessage = 0xD,
             CheckIn = 0xF,
+            TransferLeader = 0x3D,
             GuildNotice = 0x3E,
+            ListGuild = 0x42,
             GuildWindow = 0x54,
             List = 0x55,
             EnterHouse = 0x64,
@@ -33,11 +42,35 @@ namespace MapleServer2.PacketHandlers.Game
                 case GuildMode.Create:
                     HandleCreate(session, packet);
                     break;
+                case GuildMode.Disband:
+                    HandleDisband(session, packet);
+                    break;
+                case GuildMode.Invite:
+                    HandleInvite(session, packet);
+                    break;
+                case GuildMode.InviteResponse:
+                    HandleInviteResponse(session, packet);
+                    break;
+                case GuildMode.Leave:
+                    HandleLeave(session, packet);
+                    break;
+                case GuildMode.Kick:
+                    HandleKick(session, packet);
+                    break;
+                case GuildMode.PlayerMessage:
+                    HandlePlayerMessage(session, packet);
+                    break;
                 case GuildMode.CheckIn:
                     HandleCheckIn(session, packet);
                     break;
-                case GuildMode.EnterHouse:
-                    HandleEnterHouse(session, packet);
+                case GuildMode.TransferLeader:
+                    HandleTransferLeader(session, packet);
+                    break;
+                case GuildMode.GuildNotice:
+                    HandleGuildNotice(session, packet);
+                    break;
+                case GuildMode.ListGuild:
+                    HandleListGuild(session, packet);
                     break;
                 case GuildMode.GuildWindow:
                     HandleGuildWindowRequest(session, packet);
@@ -45,8 +78,8 @@ namespace MapleServer2.PacketHandlers.Game
                 case GuildMode.List:
                     HandleList(session, packet);
                     break;
-                case GuildMode.GuildNotice:
-                    HandleGuildNotice(session, packet);
+                case GuildMode.EnterHouse:
+                    HandleEnterHouse(session, packet);
                     break;
                 case GuildMode.GuildDonate:
                     HandleGuildDonate(session, packet);
@@ -63,7 +96,8 @@ namespace MapleServer2.PacketHandlers.Game
 
             if (session.Player.Mesos < 2000)
             {
-                // TODO: Reject packets
+                short NoticeCode = 5121;
+                session.Send(GuildPacket.ErrorNotice(NoticeCode));
                 return;
             }
             else
@@ -71,17 +105,155 @@ namespace MapleServer2.PacketHandlers.Game
                 session.Player.Mesos -= 2000;
 
                 session.Send(MesosPacket.UpdateMesos(session));
-                session.Send(GuildPacket.Invite(session.Player, guildName));
+                session.FieldManager.BroadcastPacket(GuildPacket.UpdateGuildTag(session.Player, guildName));
                 session.Send(GuildPacket.Create(guildName));
-                session.Send(GuildPacket.UpdateGuild(session, guildName));
-                session.Send(GuildPacket.Create2(session.Player, guildName));
-                session.Send(GuildPacket.Create3(session.Player, guildName));
+
+                string inviter = ""; // nobody because nobody invited the guild leader
+                byte response = 0; // 0 to not display invite notification
 
                 Guild newGuild = new(guildName, new List<Player> { session.Player });
                 GameServer.GuildManager.AddGuild(newGuild);
 
+                session.Send(GuildPacket.UpdateGuild(session, newGuild));
+                session.Send(GuildPacket.MemberBroadcastJoinNotice(session.Player, inviter, response));
+                session.Send(GuildPacket.MemberJoin(session.Player, guildName));
+            }
+        }
+
+        private void HandleDisband(GameSession session, PacketReader packet)
+        {
+            Guild guild = GameServer.GuildManager.GetGuildByLeader(session.Player);
+            if (guild == null)
+            {
+                return;
             }
 
+            session.Send(GuildPacket.DisbandConfirm());
+            guild.BroadcastPacketGuild(GuildPacket.MemberNotice(session.Player));
+            GameServer.GuildManager.RemoveGuild(guild);
+        }
+
+        private void HandleInvite(GameSession session, PacketReader packet)
+        {
+            // TODO: Check if user is online. Check if guild is full.
+            string invitee = packet.ReadUnicodeString();
+
+            Player other = GameServer.Storage.GetPlayerByName(invitee);
+            if (other == null)
+            {
+                return;
+            }
+
+            Guild guild = GameServer.GuildManager.GetGuildByLeader(session.Player);
+            if (guild == null)
+            {
+                return;
+            }
+
+            if (other.GuildId != 0)
+            {
+                short NoticeCode = 1027;
+                session.Send(GuildPacket.ErrorNotice(NoticeCode));
+            }
+            else
+            {
+                session.Send(GuildPacket.InviteConfirm(other));
+                other.Session.Send(GuildPacket.SendInvite(session.Player, other, guild));
+            }
+            // TODO check if player is online, else send an error
+        }
+
+        private void HandleInviteResponse(GameSession session, PacketReader packet)
+        {
+            long guildId = packet.ReadLong();
+            string guildName = packet.ReadUnicodeString();
+            packet.ReadShort();
+            string inviterName = packet.ReadUnicodeString();
+            string inviteeName = packet.ReadUnicodeString();
+            byte response = packet.ReadByte(); // 01 accept 
+
+            Guild guild = GameServer.GuildManager.GetGuildById(guildId);
+            if (guild == null)
+            {
+                return;
+            }
+
+            Player inviter = GameServer.Storage.GetPlayerByName(inviterName);
+            if (inviter == null)
+            {
+                return;
+            }
+
+            if (response == 01)
+            {
+
+                inviter.Session.Send(GuildPacket.InviteNotification(inviteeName, response));
+                session.Send(GuildPacket.InviteResponseConfirm(inviter, session.Player, guild, response));
+                session.FieldManager.BroadcastPacket(GuildPacket.UpdateGuildTag(session.Player, guildName));
+                guild.AddMember(session.Player);
+                guild.BroadcastPacketGuild(GuildPacket.MemberBroadcastJoinNotice(session.Player, inviterName, response));
+                guild.BroadcastPacketGuild(GuildPacket.MemberJoin(session.Player, guildName));
+                session.Send(GuildPacket.UpdateGuild(session, guild));
+            }
+            else
+            {
+                inviter.Session.Send(GuildPacket.InviteNotification(inviteeName, 256));
+                session.Send(GuildPacket.InviteResponseConfirm(inviter, session.Player, guild, response));
+            }
+        }
+
+        private void HandleLeave(GameSession session, PacketReader packet)
+        {
+            Guild guild = GameServer.GuildManager.GetGuildById(session.Player.GuildId);
+            if (guild == null)
+            {
+                return;
+            }
+
+            session.Send(GuildPacket.LeaveConfirm());
+            session.Send(GuildPacket.MemberNotice(session.Player));
+            guild.BroadcastPacketGuild(GuildPacket.MemberLeaveNotice(session.Player));
+            guild.RemoveMember(session.Player);
+        }
+
+        private void HandleKick(GameSession session, PacketReader packet)
+        {
+            string target = packet.ReadUnicodeString();
+
+            Player member = GameServer.Storage.GetPlayerByName(target);
+            if (member == null)
+            {
+                return;
+            }
+
+            Guild guild = GameServer.GuildManager.GetGuildByLeader(session.Player);
+            if (guild == null)
+            {
+                return;
+            }
+
+            if (member.CharacterId == guild.Leader.CharacterId)
+            {
+                //TODO: Error packets
+                return;
+            }
+            else
+            {
+                session.Send(GuildPacket.KickConfirm(member));
+
+
+                member.Session.Send(GuildPacket.KickNotification(session.Player));
+                member.Session.Send(GuildPacket.MemberNotice(member));
+                guild.RemoveMember(member);
+                guild.BroadcastPacketGuild(GuildPacket.KickMember(member, session.Player));
+            }
+        }
+
+        private void HandlePlayerMessage(GameSession session, PacketReader packet)
+        {
+            string message = packet.ReadUnicodeString();
+
+            session.Send(GuildPacket.UpdatePlayerMessage(session.Player, message));
         }
 
         private void HandleCheckIn(GameSession session, PacketReader packet)
@@ -96,13 +268,59 @@ namespace MapleServer2.PacketHandlers.Game
             session.Send(GuildPacket.UpdatePlayerContribution(session.Player));
         }
 
+        private void HandleTransferLeader(GameSession session, PacketReader packet)
+        {
+            string target = packet.ReadUnicodeString();
+
+            Player newLeader = GameServer.Storage.GetPlayerByName(target);
+            if (newLeader == null)
+            {
+                return;
+            }
+
+            GameSession oldLeader = session;
+
+            Guild guild = GameServer.GuildManager.GetGuildByLeader(oldLeader.Player);
+            if (guild == null)
+            {
+                return;
+            }
+
+            session.Send(GuildPacket.TransferLeaderConfirm(newLeader));
+            guild.BroadcastPacketGuild(GuildPacket.AssignNewLeader(newLeader, oldLeader.Player));
+            guild.Members.Insert(0, newLeader);
+            guild.Members.Remove(oldLeader.Player);
+            guild.Members.Add(oldLeader.Player);
+        }
+
         private void HandleGuildNotice(GameSession session, PacketReader packet)
         {
             packet.ReadByte();
             string notice = packet.ReadUnicodeString();
 
+            Guild guild = GameServer.GuildManager.GetGuildById(session.Player.GuildId);
+            if (guild == null)
+            {
+                return;
+            }
+
             session.Send(GuildPacket.GuildNoticeConfirm(notice));
-            session.Send(GuildPacket.GuildNoticeChange(session.Player, notice)); // TODO: Change to Broadcast to Guild
+            guild.BroadcastPacketGuild(GuildPacket.GuildNoticeChange(session.Player, notice));
+        }
+
+        private void HandleListGuild(GameSession session, PacketReader packet)
+        {
+            byte toggle = packet.ReadByte(); // 00 = unlist, 01 = list
+
+            Guild guild = GameServer.GuildManager.GetGuildByLeader(session.Player);
+            if (guild == null)
+            {
+                return;
+            }
+
+            session.Send(GuildPacket.ListGuildConfirm(toggle));
+            session.Send(GuildPacket.ListGuildUpdate(session.Player, toggle));
+            // TODO: update guild listing
         }
 
         private void HandleGuildWindowRequest(GameSession session, PacketReader packet)

--- a/MapleServer2/Tools/GuildManager.cs
+++ b/MapleServer2/Tools/GuildManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using MapleServer2.Types;
 
@@ -17,7 +16,6 @@ namespace MapleServer2.Tools
         public void AddGuild(Guild guild)
         {
             guildList.Add(guild.Id, guild);
-            Console.WriteLine(string.Join(Environment.NewLine, guild.Id));
         }
 
         public void RemoveGuild(Guild guild)

--- a/MapleServer2/Tools/GuildManager.cs
+++ b/MapleServer2/Tools/GuildManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using MapleServer2.Types;
 
@@ -16,6 +17,7 @@ namespace MapleServer2.Tools
         public void AddGuild(Guild guild)
         {
             guildList.Add(guild.Id, guild);
+            Console.WriteLine(string.Join(Environment.NewLine, guild.Id));
         }
 
         public void RemoveGuild(Guild guild)

--- a/MapleServer2/Types/Guild.cs
+++ b/MapleServer2/Types/Guild.cs
@@ -10,13 +10,16 @@ namespace MapleServer2.Types
 {
     public class Guild
     {
-        // TODO: Add ranks, rank names, guildExp, guildFunds, Member contribution
+        // TODO: Add ranks, rank names, Member contribution
         public long Id { get; }
         public string Name { get; set; }
         public bool Approval { get; set; } //Require approval before someone can join
         public Player Leader { get; set; }
         public int MaxMembers { get; set; }
         public List<Player> Members { get; }
+        public int Funds { get; set; }
+        public int Exp { get; set; }
+        public bool Searchable { get; set; }
 
         public Guild(string name, List<Player> gPlayers)
         {
@@ -26,13 +29,22 @@ namespace MapleServer2.Types
             Leader = gPlayers.First();
             Members = gPlayers;
             Approval = false;
-            Members.Add(Leader);
+            Exp = 0;
+            Funds = 0;
+            Searchable = true;
         }
 
         public void AddMember(Player player)
         {
             Members.Add(player);
         }
+
+        public void RemoveMember(Player player)
+        {
+            Members.Remove(player);
+            player.ClubId = 0;
+        }
+
 
         public void BroadcastPacketGuild(Packet packet, GameSession sender = null)
         {

--- a/MapleServer2/Types/Guild.cs
+++ b/MapleServer2/Types/Guild.cs
@@ -42,7 +42,7 @@ namespace MapleServer2.Types
         public void RemoveMember(Player player)
         {
             Members.Remove(player);
-            player.ClubId = 0;
+            player.GuildId = 0;
         }
 
 


### PR DESCRIPTION
Added:

- Guild inviting
- Kicking
- Re-assigning leader
- Leaving (ish)
- Member mottos/messages

Leaving is sort of broken at the moment because of a bigger issue - Guild Ids are not being stored in a players information, so there is a mismatch on Ids until that is fixed.. somehow 
#83 