### PR TITLE
Separating Mob from Npc, Handle Damage & Stat for Mobs

### DIFF
--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -23,7 +23,7 @@ namespace MapleServer2.PacketHandlers.Game
             // SendBreakable
             // Self
             session.EnterField(session.Player.MapId);
-            session.Send(FieldObjectPacket.SetStats(session.FieldPlayer));
+            session.Send(StatPacket.SetStats(session.FieldPlayer));
             session.Send(StatPointPacket.WriteTotalStatPoints(session.Player));
             session.Send(EmotePacket.LoadEmotes());
 

--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -66,7 +66,10 @@ namespace MapleServer2.PacketHandlers.Game
             session.Player.Stats.MaxAtk.Max += 17;
             session.Player.Stats.MaxAtk.Total += 17;
 
-            session.Send(FieldObjectPacket.SetStats(session.FieldPlayer));
+            session.Player.Stats.MagAtk.Max += 15;
+            session.Player.Stats.MagAtk.Total += 15;
+
+            session.Send(StatPacket.SetStats(session.FieldPlayer));
         }
 
         private void HandleUnequipItem(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -30,10 +30,6 @@ namespace MapleServer2.PacketHandlers.Game
             TypeOfDamage2 = 0x2
         }
 
-        private long skillUid;
-        private int skillId;
-        private short skillLevel;
-
         public override void Handle(GameSession session, PacketReader packet)
         {
             SkillHandlerMode mode = (SkillHandlerMode) packet.ReadByte();
@@ -59,14 +55,14 @@ namespace MapleServer2.PacketHandlers.Game
 
         private void HandleFirstSent(GameSession session, PacketReader packet)
         {
-            skillUid = packet.ReadLong();
+            long skillUid = packet.ReadLong();
             int value = packet.ReadInt();
-            skillId = packet.ReadInt();
-            skillLevel = packet.ReadShort();
+            int skillId = packet.ReadInt();
+            short skillLevel = packet.ReadShort();
             packet.ReadByte();
             CoordF coords = packet.Read<CoordF>();
             packet.ReadShort();
-            session.Send(SkillUsePacket.SkillUse(value, skillUid, skillId, skillLevel, coords));
+            session.Send(SkillUsePacket.SkillUse(session.FieldPlayer, value, skillUid, coords));
         }
 
         private void HandleDamage(GameSession session, PacketReader packet)
@@ -102,7 +98,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         private void HandleTypeOfDamage(GameSession session, PacketReader packet)
         {
-            skillUid = packet.ReadLong();
+            long skillUid = packet.ReadLong();
             packet.ReadByte();
             CoordF coords = packet.Read<CoordF>();
             CoordF coords2 = packet.Read<CoordF>();
@@ -123,7 +119,7 @@ namespace MapleServer2.PacketHandlers.Game
         private void HandleAoeDamage(GameSession session, PacketReader packet)
         {
             List<IFieldObject<Mob>> mobs = new List<IFieldObject<Mob>>();
-            skillUid = packet.ReadLong();
+            long skillUid = packet.ReadLong();
             int someValue = packet.ReadInt();
             int playerObjectId = packet.ReadInt();
             CoordF coords = packet.Read<CoordF>();
@@ -136,15 +132,15 @@ namespace MapleServer2.PacketHandlers.Game
             {
                 mobs.Add(session.FieldManager.State.Mobs.GetValueOrDefault(packet.ReadInt()));
                 packet.ReadByte();
-                session.Send(StatPacket.UpdateMobStats(mobs[i], 1));
+                session.Send(StatPacket.UpdateMobStats(mobs[i]));
             }
 
-            session.Send(SkillDamagePacket.ApplyDamage(session.FieldPlayer, skillUid, someValue, skillId, skillLevel, coords, mobs));
+            session.Send(SkillDamagePacket.ApplyDamage(session.FieldPlayer, skillUid, someValue, coords, mobs));
         }
 
         private void HandleTypeOfDamage2(GameSession session, PacketReader packet)
         {
-            skillUid = packet.ReadLong();
+            long skillUid = packet.ReadLong();
             packet.ReadByte();
             packet.ReadInt();
             packet.ReadInt();

--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -1,8 +1,10 @@
-﻿using Maple2Storage.Types;
+﻿using System.Collections.Generic;
+using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
+using MapleServer2.Types;
 using Microsoft.Extensions.Logging;
 
 namespace MapleServer2.PacketHandlers.Game
@@ -27,6 +29,10 @@ namespace MapleServer2.PacketHandlers.Game
             AoeDamage = 0x1,
             TypeOfDamage2 = 0x2
         }
+
+        private long skillUid;
+        private int skillId;
+        private short skillLevel;
 
         public override void Handle(GameSession session, PacketReader packet)
         {
@@ -53,14 +59,14 @@ namespace MapleServer2.PacketHandlers.Game
 
         private void HandleFirstSent(GameSession session, PacketReader packet)
         {
-            long skillCount = packet.ReadLong();
+            skillUid = packet.ReadLong();
             int value = packet.ReadInt();
-            int skillId = packet.ReadInt();
-            short skillLevel = packet.ReadShort();
+            skillId = packet.ReadInt();
+            skillLevel = packet.ReadShort();
             packet.ReadByte();
             CoordF coords = packet.Read<CoordF>();
             packet.ReadShort();
-            session.Send(SkillUsePacket.SkillUse(value, skillCount, skillId, skillLevel, coords));
+            session.Send(SkillUsePacket.SkillUse(value, skillUid, skillId, skillLevel, coords));
         }
 
         private void HandleDamage(GameSession session, PacketReader packet)
@@ -96,7 +102,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         private void HandleTypeOfDamage(GameSession session, PacketReader packet)
         {
-            long skillCount = packet.ReadLong();
+            skillUid = packet.ReadLong();
             packet.ReadByte();
             CoordF coords = packet.Read<CoordF>();
             CoordF coords2 = packet.Read<CoordF>();
@@ -116,7 +122,8 @@ namespace MapleServer2.PacketHandlers.Game
 
         private void HandleAoeDamage(GameSession session, PacketReader packet)
         {
-            long skillUid = packet.ReadLong();
+            List<IFieldObject<Mob>> mobs = new List<IFieldObject<Mob>>();
+            skillUid = packet.ReadLong();
             int someValue = packet.ReadInt();
             int playerObjectId = packet.ReadInt();
             CoordF coords = packet.Read<CoordF>();
@@ -125,25 +132,19 @@ namespace MapleServer2.PacketHandlers.Game
             packet.ReadByte();
             byte count = packet.ReadByte();
             packet.ReadInt();
-            /*for (int i = 0; i < count3; i++)
+            for (int i = 0; i < count; i++)
             {
-                EntityNpc.Add(session.FieldNpc);
+                mobs.Add(session.FieldManager.State.Mobs.GetValueOrDefault(packet.ReadInt()));
                 packet.ReadByte();
+                session.Send(StatPacket.UpdateMobStats(mobs[i], 1));
             }
-            if (EntityNpc.Count > 0)
-            {
-                logger.LogInformation($"entities: "+ EntityNpc.Count);
-            }*/
-            int objectId = packet.ReadInt();
-            packet.ReadByte();
 
-            // Hardcoded SkillId(bow), SkillLeve(1)
-            session.Send(SkillDamagePacket.SkillDamage(session.FieldPlayer, skillUid, someValue, 600001, 1, coords, objectId));
+            session.Send(SkillDamagePacket.ApplyDamage(session.FieldPlayer, skillUid, someValue, skillId, skillLevel, coords, mobs));
         }
 
         private void HandleTypeOfDamage2(GameSession session, PacketReader packet)
         {
-            long skillCount = packet.ReadLong();
+            skillUid = packet.ReadLong();
             packet.ReadByte();
             packet.ReadInt();
             packet.ReadInt();

--- a/MapleServer2/Packets/FieldObjectPacket.cs
+++ b/MapleServer2/Packets/FieldObjectPacket.cs
@@ -90,6 +90,17 @@ namespace MapleServer2.Packets
                 .Write(npc.Coord);
         }
 
+        public static Packet LoadMob(IFieldObject<Mob> mob)
+        {
+            return PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
+                .WriteByte(0x6)
+                .WriteInt(mob.ObjectId)
+                .WriteInt(mob.Value.Id)
+                .WriteByte()
+                .WriteInt(200)
+                .Write(mob.Coord);
+        }
+
         public static Packet ControlNpc(IFieldObject<Npc> npc)
         {
             PacketWriter npcBuffer = new PacketWriter()
@@ -110,6 +121,26 @@ namespace MapleServer2.Packets
                 .Write(npcBuffer.ToArray());
         }
 
+        public static Packet ControlMob(IFieldObject<Mob> mob)
+        {
+            PacketWriter npcBuffer = new PacketWriter()
+                .WriteInt(mob.ObjectId)
+                .WriteByte()
+                .Write(mob.Coord.ToShort())
+                .WriteShort(mob.Value.Rotation)
+                .Write(mob.Value.Speed) // XYZ Speed
+                .WriteShort(100) // Unknown
+                .WriteByte(1) // Flag ?
+                .WriteShort(mob.Value.Animation)
+                .WriteShort(1); // counter (increments every packet)
+            // There can be more to this packet, probably dependent on Flag.
+
+            return PacketWriter.Of(SendOp.NPC_CONTROL)
+                .WriteShort(1) // Segments
+                .WriteShort((short) npcBuffer.Length)
+                .Write(npcBuffer.ToArray());
+        }
+
         public static Packet MoveNpc(int objectId, CoordF coord)
         {
             return PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
@@ -117,15 +148,6 @@ namespace MapleServer2.Packets
                 .WriteInt(objectId)
                 .WriteByte()
                 .Write(coord);
-        }
-
-        public static Packet SetStats(IFieldObject<Player> player)
-        {
-            return PacketWriter.Of(SendOp.STAT)
-                .WriteInt(player.ObjectId)
-                .WriteByte()
-                .WriteByte(0x23)
-                .Write(player.Value.Stats);
         }
     }
 

--- a/MapleServer2/Packets/FieldObjectPacket.cs
+++ b/MapleServer2/Packets/FieldObjectPacket.cs
@@ -8,11 +8,18 @@ namespace MapleServer2.Packets
 {
     public static class FieldObjectPacket
     {
+        private enum ProxyGameObjMode : byte
+        {
+            LoadPlayer = 0x03,
+            UpdateEntity = 0x05,
+            LoadNpc = 0x6,
+        }
+
         public static Packet LoadPlayer(IFieldObject<Player> fieldPlayer)
         {
             Player player = fieldPlayer.Value;
             PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
-            pWriter.WriteByte(0x03);
+            pWriter.WriteMode(ProxyGameObjMode.LoadPlayer);
             pWriter.WriteInt(fieldPlayer.ObjectId);
             pWriter.WriteLong(player.AccountId);
             pWriter.WriteLong(player.CharacterId);
@@ -42,7 +49,7 @@ namespace MapleServer2.Packets
         {
             FieldObjectUpdate flag = FieldObjectUpdate.Move | FieldObjectUpdate.Animate;
             PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
-            pWriter.WriteByte(0x05);
+            pWriter.WriteMode(ProxyGameObjMode.UpdateEntity);
             pWriter.WriteInt(player.ObjectId);
             pWriter.WriteByte((byte) flag);
 
@@ -82,7 +89,7 @@ namespace MapleServer2.Packets
         public static Packet LoadNpc(IFieldObject<Npc> npc)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
-            pWriter.WriteByte(0x6);
+            pWriter.WriteMode(ProxyGameObjMode.LoadNpc);
             pWriter.WriteInt(npc.ObjectId);
             pWriter.WriteInt(npc.Value.Id);
             pWriter.WriteByte();
@@ -94,7 +101,7 @@ namespace MapleServer2.Packets
         public static Packet LoadMob(IFieldObject<Mob> mob)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
-            pWriter.WriteByte(0x6);
+            pWriter.WriteMode(ProxyGameObjMode.LoadNpc);
             pWriter.WriteInt(mob.ObjectId);
             pWriter.WriteInt(mob.Value.Id);
             pWriter.WriteByte();
@@ -148,7 +155,7 @@ namespace MapleServer2.Packets
         public static Packet MoveNpc(int objectId, CoordF coord)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
-            pWriter.WriteByte(0x05);
+            pWriter.WriteMode(ProxyGameObjMode.UpdateEntity);
             pWriter.WriteInt(objectId);
             pWriter.WriteByte();
             pWriter.Write(coord);

--- a/MapleServer2/Packets/FieldObjectPacket.cs
+++ b/MapleServer2/Packets/FieldObjectPacket.cs
@@ -11,25 +11,25 @@ namespace MapleServer2.Packets
         public static Packet LoadPlayer(IFieldObject<Player> fieldPlayer)
         {
             Player player = fieldPlayer.Value;
-            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
-                .WriteByte(0x03)
-                .WriteInt(fieldPlayer.ObjectId)
-                .WriteLong(player.AccountId)
-                .WriteLong(player.CharacterId)
-                .WriteUnicodeString(player.Name)
-                .WriteUnicodeString(player.ProfileUrl)
-                .WriteUnicodeString(player.Motto)
-                .WriteByte()
-                .Write(fieldPlayer.Coord)
-                .WriteShort(player.Level)
-                .WriteShort((short) player.JobGroupId)
-                .WriteInt(player.JobId)
-                .WriteInt()
-                .WriteInt()
-                .WriteInt()
-                .WriteUnicodeString(player.HomeName)
-                .WriteInt()
-                .WriteShort();
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
+            pWriter.WriteByte(0x03);
+            pWriter.WriteInt(fieldPlayer.ObjectId);
+            pWriter.WriteLong(player.AccountId);
+            pWriter.WriteLong(player.CharacterId);
+            pWriter.WriteUnicodeString(player.Name);
+            pWriter.WriteUnicodeString(player.ProfileUrl);
+            pWriter.WriteUnicodeString(player.Motto);
+            pWriter.WriteByte();
+            pWriter.Write(fieldPlayer.Coord);
+            pWriter.WriteShort(player.Level);
+            pWriter.WriteShort((short) player.JobGroupId);
+            pWriter.WriteInt(player.JobId);
+            pWriter.WriteInt();
+            pWriter.WriteInt();
+            pWriter.WriteInt();
+            pWriter.WriteUnicodeString(player.HomeName);
+            pWriter.WriteInt();
+            pWriter.WriteShort();
             foreach (int trophyCount in player.Trophy)
             {
                 pWriter.WriteInt(trophyCount);
@@ -41,10 +41,10 @@ namespace MapleServer2.Packets
         public static Packet UpdatePlayer(IFieldObject<Player> player)
         {
             FieldObjectUpdate flag = FieldObjectUpdate.Move | FieldObjectUpdate.Animate;
-            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
-                .WriteByte(0x05)
-                .WriteInt(player.ObjectId)
-                .WriteByte((byte) flag);
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
+            pWriter.WriteByte(0x05);
+            pWriter.WriteInt(player.ObjectId);
+            pWriter.WriteByte((byte) flag);
 
             if (flag.HasFlag(FieldObjectUpdate.Type1))
             {
@@ -81,73 +81,78 @@ namespace MapleServer2.Packets
 
         public static Packet LoadNpc(IFieldObject<Npc> npc)
         {
-            return PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
-                .WriteByte(0x6)
-                .WriteInt(npc.ObjectId)
-                .WriteInt(npc.Value.Id)
-                .WriteByte()
-                .WriteInt(200)
-                .Write(npc.Coord);
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
+            pWriter.WriteByte(0x6);
+            pWriter.WriteInt(npc.ObjectId);
+            pWriter.WriteInt(npc.Value.Id);
+            pWriter.WriteByte();
+            pWriter.WriteInt(200);
+            pWriter.Write(npc.Coord);
+            return pWriter;
         }
 
         public static Packet LoadMob(IFieldObject<Mob> mob)
         {
-            return PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
-                .WriteByte(0x6)
-                .WriteInt(mob.ObjectId)
-                .WriteInt(mob.Value.Id)
-                .WriteByte()
-                .WriteInt(200)
-                .Write(mob.Coord);
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
+            pWriter.WriteByte(0x6);
+            pWriter.WriteInt(mob.ObjectId);
+            pWriter.WriteInt(mob.Value.Id);
+            pWriter.WriteByte();
+            pWriter.WriteInt(200);
+            pWriter.Write(mob.Coord);
+            return pWriter;
         }
 
         public static Packet ControlNpc(IFieldObject<Npc> npc)
         {
-            PacketWriter npcBuffer = new PacketWriter()
-                .WriteInt(npc.ObjectId)
-                .WriteByte()
-                .Write(npc.Coord.ToShort())
-                .WriteShort(npc.Value.Rotation)
-                .Write(npc.Value.Speed) // XYZ Speed
-                .WriteShort(100) // Unknown
-                .WriteByte(1) // Flag ?
-                .WriteShort(npc.Value.Animation)
-                .WriteShort(1); // counter (increments every packet)
+            PacketWriter npcBuffer = new PacketWriter();
+            npcBuffer.WriteInt(npc.ObjectId);
+            npcBuffer.WriteByte();
+            npcBuffer.Write(npc.Coord.ToShort());
+            npcBuffer.WriteShort(npc.Value.Rotation);
+            npcBuffer.Write(npc.Value.Speed); // XYZ Speed
+            npcBuffer.WriteShort(100); // Unknown
+            npcBuffer.WriteByte(1); // Flag ?
+            npcBuffer.WriteShort(npc.Value.Animation);
+            npcBuffer.WriteShort(1); // counter (increments every packet)
             // There can be more to this packet, probably dependent on Flag.
 
-            return PacketWriter.Of(SendOp.NPC_CONTROL)
-                .WriteShort(1) // Segments
-                .WriteShort((short) npcBuffer.Length)
-                .Write(npcBuffer.ToArray());
+            PacketWriter pWriter = PacketWriter.Of(SendOp.NPC_CONTROL);
+            pWriter.WriteShort(1); // Segments
+            pWriter.WriteShort((short) npcBuffer.Length);
+            pWriter.Write(npcBuffer.ToArray());
+            return pWriter;
         }
 
         public static Packet ControlMob(IFieldObject<Mob> mob)
         {
-            PacketWriter npcBuffer = new PacketWriter()
-                .WriteInt(mob.ObjectId)
-                .WriteByte()
-                .Write(mob.Coord.ToShort())
-                .WriteShort(mob.Value.Rotation)
-                .Write(mob.Value.Speed) // XYZ Speed
-                .WriteShort(100) // Unknown
-                .WriteByte(1) // Flag ?
-                .WriteShort(mob.Value.Animation)
-                .WriteShort(1); // counter (increments every packet)
+            PacketWriter npcBuffer = new PacketWriter();
+            npcBuffer.WriteInt(mob.ObjectId);
+            npcBuffer.WriteByte();
+            npcBuffer.Write(mob.Coord.ToShort());
+            npcBuffer.WriteShort(mob.Value.Rotation);
+            npcBuffer.Write(mob.Value.Speed); // XYZ Speed
+            npcBuffer.WriteShort(100); // Unknown
+            npcBuffer.WriteByte(1); // Flag ?
+            npcBuffer.WriteShort(mob.Value.Animation);
+            npcBuffer.WriteShort(1); // counter (increments every packet)
             // There can be more to this packet, probably dependent on Flag.
 
-            return PacketWriter.Of(SendOp.NPC_CONTROL)
-                .WriteShort(1) // Segments
-                .WriteShort((short) npcBuffer.Length)
-                .Write(npcBuffer.ToArray());
+            PacketWriter pWriter = PacketWriter.Of(SendOp.NPC_CONTROL);
+            pWriter.WriteShort(1); // Segments
+            pWriter.WriteShort((short) npcBuffer.Length);
+            pWriter.Write(npcBuffer.ToArray());
+            return pWriter;
         }
 
         public static Packet MoveNpc(int objectId, CoordF coord)
         {
-            return PacketWriter.Of(SendOp.PROXY_GAME_OBJ)
-                .WriteByte(0x05)
-                .WriteInt(objectId)
-                .WriteByte()
-                .Write(coord);
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PROXY_GAME_OBJ);
+            pWriter.WriteByte(0x05);
+            pWriter.WriteInt(objectId);
+            pWriter.WriteByte();
+            pWriter.Write(coord);
+            return pWriter;
         }
     }
 

--- a/MapleServer2/Packets/FieldPacket.cs
+++ b/MapleServer2/Packets/FieldPacket.cs
@@ -42,7 +42,9 @@ namespace MapleServer2.Packets
             pWriter.Write(player.Rotation);
             pWriter.WriteByte();
 
-            pWriter.WriteTotalStats(ref player.Stats);
+            // Stats
+            StatPacket.WriteTotalStats(pWriter, ref player.Stats);
+
             pWriter.WriteByte();
             pWriter.WriteByte();
             pWriter.WriteInt();
@@ -146,28 +148,6 @@ namespace MapleServer2.Packets
                 .WriteInt(player.ObjectId);
         }
 
-        private static void WriteTotalStats(this PacketWriter pWriter, ref PlayerStats stats)
-        {
-            pWriter.WriteByte(0x23);
-            for (int i = 0; i < 3; i++)
-            {
-                pWriter.WriteLong(stats.Hp[i])
-                    .WriteInt(stats.AtkSpd[i])
-                    .WriteInt(stats.MoveSpd[i])
-                    .WriteInt(stats.MountSpeed[i])
-                    .WriteInt(stats.JumpHeight[i]);
-            }
-
-            /* Alternative Stat Struct
-            pWriter.WriteByte(); // Count
-            for (int i = 0; i < count; i++) {
-                pWriter.WriteByte(); // Type
-                if (type == 4) pWriter.WriteLong();
-                else pWriter.WriteInt();
-            }
-            */
-        }
-
         private static void WritePassiveSkills(PacketWriter pWriter)
         {
             pWriter.Write(
@@ -238,38 +218,10 @@ namespace MapleServer2.Packets
             // If NPC is not valid, the packet seems to stop here
 
             // NPC Stat
-            byte flag = 0x23;
-            pWriter.WriteByte(flag);
-            if (flag == 1)
-            {
-                byte value = 0;
-                pWriter.WriteByte(value); // value
-                if (value == 4)
-                {
-                    pWriter.WriteLong()
-                        .WriteLong()
-                        .WriteLong();
-                }
-                else
-                {
-                    pWriter.WriteInt()
-                        .WriteInt()
-                        .WriteInt();
-                }
-            }
-            else
-            {
-                pWriter.WriteLong(29)
-                    .WriteInt()
-                    .WriteLong(29)
-                    .WriteInt()
-                    .WriteLong(29)
-                    .WriteInt();
-            }
+            StatPacket.DefaultStatsNpc(pWriter);
             // NPC Stat
 
             pWriter.WriteByte();
-
             short count = 0;
             pWriter.WriteShort(count); // branch
             for (int i = 0; i < count; i++)
@@ -286,6 +238,44 @@ namespace MapleServer2.Packets
                     .WriteLong();
             }
 
+            pWriter.WriteLong() // uid
+                .WriteByte()
+                .WriteInt(1)
+                .WriteInt()
+                .WriteByte();
+
+            return pWriter;
+        }
+
+        public static Packet AddMob(IFieldObject<Mob> mob)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.FIELD_ADD_NPC)
+                .WriteInt(mob.ObjectId)
+                .WriteInt(mob.Value.Id)
+                .Write(mob.Coord)
+                .Write(CoordF.From(0, 0, 0)); // Unknown
+            // If NPC is not valid, the packet seems to stop here
+
+            // NPC Stat
+            StatPacket.DefaultStatsMob(pWriter, mob);
+            // NPC Stat
+
+            pWriter.WriteByte();
+            short count = 0;
+            pWriter.WriteShort(count); // branch
+            for (int i = 0; i < count; i++)
+            {
+                pWriter.WriteInt()
+                    .WriteInt()
+                    .WriteInt()
+                    .WriteInt()
+                    .WriteInt()
+                    .WriteInt()
+                    .WriteShort()
+                    .WriteInt()
+                    .WriteByte()
+                    .WriteLong();
+            }
             pWriter.WriteLong() // uid
                 .WriteByte()
                 .WriteInt(1)

--- a/MapleServer2/Packets/SkillDamagePacket.cs
+++ b/MapleServer2/Packets/SkillDamagePacket.cs
@@ -1,4 +1,5 @@
-﻿using Maple2Storage.Types;
+﻿using System.Collections.Generic;
+using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Types;
@@ -7,7 +8,7 @@ namespace MapleServer2.Packets
 {
     public static class SkillDamagePacket
     {
-        public static Packet SkillDamage(IFieldObject<Player> player, long skillUid, int someValue, int skillId, short skillLevel, CoordF coords, int objectId)
+        public static Packet ApplyDamage(IFieldObject<Player> player, long skillUid, int someValue, int skillId, short skillLevel, CoordF coords, List<IFieldObject<Mob>> mobs)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.SKILL_DAMAGE);
             pWriter.WriteByte(1);
@@ -18,14 +19,31 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(skillId);
             pWriter.WriteInt(skillLevel);
             pWriter.Write(coords.ToShort());
-            pWriter.WriteShort(); // coords2
-            pWriter.WriteShort(); // coords2
-            pWriter.WriteShort(); // coords2 not always 0? 2B 01 => 11009
-            pWriter.WriteByte(1); // Mob count
-            pWriter.WriteInt(objectId);
-            pWriter.WriteByte(1); // Unknown
-            pWriter.WriteBool(false); // Crit flag
-            pWriter.WriteLong(-1 * 1); // Damage
+            pWriter.Write(CoordS.From(0, 0, 0));
+            /*pWriter.WriteInt(0); // Set as Int because 2 bytes after will set something.
+            pWriter.WriteByte(0); // Define is (59 heal) or (9 damage). Not always the case
+            pWriter.WriteByte(0); // Unknown - count?*/
+            pWriter.WriteByte((byte) mobs.Count); // Mob count
+            for (int i = 0; i < mobs.Count; i++)
+            {
+                pWriter.WriteInt(mobs[i].ObjectId);
+                pWriter.WriteByte(1); // Unknown
+                pWriter.WriteBool(false); // Crit flag 
+                pWriter.WriteLong(-1 * 1); // TODO: Calculate damage
+            }
+            return pWriter;
+        }
+
+        public static Packet ApplyHeal(IFieldObject<Player> player, int statusUid, int sourceId, int amount)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.SKILL_DAMAGE);
+            pWriter.WriteByte(4);
+            pWriter.WriteInt(player.ObjectId);
+            pWriter.WriteInt(sourceId);
+            pWriter.WriteInt(statusUid);
+            pWriter.WriteInt(amount);
+            pWriter.WriteLong();
+            pWriter.WriteByte(1);
             return pWriter;
         }
     }

--- a/MapleServer2/Packets/SkillDamagePacket.cs
+++ b/MapleServer2/Packets/SkillDamagePacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets
 {
     public static class SkillDamagePacket
     {
-        public static Packet ApplyDamage(IFieldObject<Player> player, long skillUid, int someValue, int skillId, short skillLevel, CoordF coords, List<IFieldObject<Mob>> mobs)
+        public static Packet ApplyDamage(IFieldObject<Player> player, long skillUid, int someValue, CoordF coords, List<IFieldObject<Mob>> mobs)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.SKILL_DAMAGE);
             pWriter.WriteByte(1);
@@ -16,8 +16,8 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(someValue);
             pWriter.WriteInt(player.ObjectId);
             pWriter.WriteInt(player.ObjectId);
-            pWriter.WriteInt(skillId);
-            pWriter.WriteInt(skillLevel);
+            pWriter.WriteInt(player.Value.ActiveSkillId);
+            pWriter.WriteInt(player.Value.ActiveSkillLevel);
             pWriter.Write(coords.ToShort());
             pWriter.Write(CoordS.From(0, 0, 0));
             /*pWriter.WriteInt(0); // Set as Int because 2 bytes after will set something.

--- a/MapleServer2/Packets/SkillUsePacket.cs
+++ b/MapleServer2/Packets/SkillUsePacket.cs
@@ -8,13 +8,13 @@ namespace MapleServer2.Packets
 {
     public static class SkillUsePacket
     {
-        public static Packet SkillUse(int value, long count, int skillId, short skillLevel, CoordF coords)
+        public static Packet SkillUse(IFieldObject<Player> player, int value, long count, CoordF coords)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.SKILL_USE);
             pWriter.WriteLong(count);
             pWriter.WriteInt(value);    // Unknown
-            pWriter.WriteInt(skillId);
-            pWriter.WriteShort(skillLevel);
+            pWriter.WriteInt(player.Value.ActiveSkillId);
+            pWriter.WriteShort(player.Value.ActiveSkillLevel);
             pWriter.WriteByte();
             pWriter.Write(coords);
             pWriter.WriteLong();

--- a/MapleServer2/Packets/SkillUsePacket.cs
+++ b/MapleServer2/Packets/SkillUsePacket.cs
@@ -1,6 +1,8 @@
-﻿using Maple2Storage.Types;
+﻿using System;
+using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Types;
 
 namespace MapleServer2.Packets
 {
@@ -22,6 +24,25 @@ namespace MapleServer2.Packets
             pWriter.WriteInt();
             pWriter.WriteByte();
             pWriter.WriteByte();
+            return pWriter;
+        }
+
+        public static Packet MobSkillUse(IFieldObject<Mob> mob, int skillId, short skillLevel, byte part)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.SKILL_USE);
+            pWriter.WriteInt(new Random().Next()); // Seems to be an incrementing number - unique id
+            pWriter.WriteInt(mob.ObjectId);
+            pWriter.WriteInt();
+            pWriter.WriteInt(mob.ObjectId);
+            pWriter.WriteInt(skillId);
+            pWriter.WriteShort(skillLevel);
+            pWriter.WriteByte(part);
+            pWriter.Write(mob.Coord.ToShort());
+            pWriter.WriteLong();
+            pWriter.WriteLong();
+            pWriter.WriteInt();
+            pWriter.WriteShort();
+            pWriter.Write(mob.Coord.X);
             return pWriter;
         }
     }

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -8,11 +8,12 @@ namespace MapleServer2.Packets
     {
         public static Packet SetStats(IFieldObject<Player> player)
         {
-            return PacketWriter.Of(SendOp.STAT)
-                .WriteInt(player.ObjectId)
-                .WriteByte()
-                .WriteByte(0x23)
-                .Write(player.Value.Stats);
+            PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
+            pWriter.WriteInt(player.ObjectId);
+            pWriter.WriteByte();
+            pWriter.WriteByte(0x23);
+            pWriter.Write(player.Value.Stats);
+            return pWriter;
         }
 
         public static Packet UpdateMobStats(IFieldObject<Mob> mob)

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -15,7 +15,7 @@ namespace MapleServer2.Packets
                 .Write(player.Value.Stats);
         }
 
-        public static Packet UpdateMobStats(IFieldObject<Mob> mob, int damage)
+        public static Packet UpdateMobStats(IFieldObject<Mob> mob)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
             pWriter.WriteInt(mob.ObjectId);
@@ -23,13 +23,10 @@ namespace MapleServer2.Packets
             pWriter.WriteByte(1);
             pWriter.WriteByte(4); // value
             // Stats 
-            pWriter.WriteLong(mob.Value.stats.Hp.Total);
-            pWriter.WriteLong(mob.Value.stats.Hp.Max);
-            pWriter.WriteLong(mob.Value.stats.CurrentHp.Min -= damage);
-            // Reset to 0 for each mob when dead.
-            if (mob.Value.stats.CurrentHp.Min == 0)
+            // Damage should be update through this packet
+            for (int i = 0; i < 3; i++)
             {
-                mob.Value.stats.CurrentHp.Min = 10;
+                pWriter.WriteLong(mob.Value.stats.Hp[i]);
             }
             return pWriter;
         }

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -1,0 +1,104 @@
+﻿using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Types;
+
+namespace MapleServer2.Packets
+{
+    public static class StatPacket
+    {
+        public static Packet SetStats(IFieldObject<Player> player)
+        {
+            return PacketWriter.Of(SendOp.STAT)
+                .WriteInt(player.ObjectId)
+                .WriteByte()
+                .WriteByte(0x23)
+                .Write(player.Value.Stats);
+        }
+
+        public static Packet UpdateMobStats(IFieldObject<Mob> mob, int damage)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
+            pWriter.WriteInt(mob.ObjectId);
+            pWriter.WriteByte();
+            pWriter.WriteByte(1);
+            pWriter.WriteByte(4); // value
+            // Stats 
+            pWriter.WriteLong(mob.Value.stats.Hp.Total);
+            pWriter.WriteLong(mob.Value.stats.Hp.Max);
+            pWriter.WriteLong(mob.Value.stats.CurrentHp.Min -= damage);
+            // Reset to 0 for each mob when dead.
+            if (mob.Value.stats.CurrentHp.Min == 0)
+            {
+                mob.Value.stats.CurrentHp.Min = 10;
+            }
+            return pWriter;
+        }
+
+        public static void DefaultStatsMob(this PacketWriter pWriter, IFieldObject<Mob> mob)
+        {
+            pWriter.WriteByte(0x23);
+            // Flag dependent
+            for (int i = 0; i < 3; i++)
+            {
+                pWriter.WriteLong(mob.Value.stats.Hp[i])
+                    .WriteInt();
+            }
+        }
+
+        public static void DefaultStatsNpc(this PacketWriter pWriter)
+        {
+            byte flag = 0x23;
+            pWriter.WriteByte(flag);
+            if (flag == 1)
+            {
+                byte value = 0;
+                pWriter.WriteByte(value); // value
+                if (value == 4)
+                {
+                    pWriter.WriteLong()
+                        .WriteLong()
+                        .WriteLong();
+                }
+                else
+                {
+                    pWriter.WriteInt()
+                        .WriteInt()
+                        .WriteInt();
+                }
+            }
+            else
+            {
+                pWriter.WriteLong(5)
+                    .WriteInt()
+                    .WriteLong(5)
+                    .WriteInt()
+                    .WriteLong(5)
+                    .WriteInt();
+            }
+        }
+
+        public static void WriteTotalStats(this PacketWriter pWriter, ref PlayerStats stats)
+        {
+            pWriter.WriteByte(0x23);
+            for (int i = 0; i < 3; i++)
+            {
+                pWriter.WriteLong(stats.Hp[i])
+                    .WriteInt(stats.AtkSpd[i])
+                    .WriteInt(stats.MoveSpd[i])
+                    .WriteInt(stats.MountSpeed[i])
+                    .WriteInt(stats.JumpHeight[i]);
+            }
+
+            /* Alternative Stat Struct
+            pWriter.WriteByte(); // Count
+            for (int i = 0; i < count; i++) {
+                pWriter.WriteByte(); // Type
+                if (type == 4) pWriter.WriteLong();
+                else pWriter.WriteInt();
+            }
+            */
+        }
+
+
+    }
+}

--- a/MapleServer2/Packets/UserBattlePacket.cs
+++ b/MapleServer2/Packets/UserBattlePacket.cs
@@ -10,14 +10,7 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.USER_BATTLE);
             pWriter.WriteInt(player.ObjectId);
-            if (flag)
-            {
-                pWriter.WriteBool(flag);
-            }
-            else
-            {
-                pWriter.WriteBool(flag);
-            }
+            pWriter.WriteBool(flag);
             return pWriter;
         }
     }

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -69,7 +69,10 @@ namespace MapleServer2.Servers.Game
             {
                 updates.Add(FieldObjectPacket.UpdatePlayer(player));
             }
-
+            foreach (IFieldObject<Mob> mob in State.Mobs.Values)
+            {
+                updates.Add(FieldObjectPacket.ControlMob(mob));
+            }
             return updates;
         }
 
@@ -107,6 +110,11 @@ namespace MapleServer2.Servers.Game
             foreach (IFieldObject<Portal> existingPortal in State.Portals.Values)
             {
                 sender.Send(FieldPacket.AddPortal(existingPortal));
+            }
+            foreach (IFieldObject<Mob> existingMob in State.Mobs.Values)
+            {
+                sender.Send(FieldPacket.AddMob(existingMob));
+                sender.Send(FieldObjectPacket.LoadMob(existingMob));
             }
             State.AddPlayer(player);
 
@@ -153,7 +161,8 @@ namespace MapleServer2.Servers.Game
 
             Broadcast(session =>
             {
-
+                session.Send(FieldPacket.AddMob(fieldMob));
+                session.Send(FieldObjectPacket.LoadMob(fieldMob));
             });
         }
 

--- a/MapleServer2/Tools/GameCommandActions.cs
+++ b/MapleServer2/Tools/GameCommandActions.cs
@@ -29,13 +29,16 @@ namespace MapleServer2.Tools
                 case "npc":
                     ProcessNpcCommand(session, args.Length > 1 ? args[1] : "");
                     break;
+                case "mob":
+                    ProcessMobCommand(session, args.Length > 1 ? args[1] : "");
+                    break;
                 case "map":
                     ProcessMapCommand(session, args.Length > 1 ? args[1] : "");
                     break;
                 case "coord":
                     session.SendNotice(session.FieldPlayer.Coord.ToString());
                     break;
-                case "battleof":
+                case "battleoff":
                     session.Send(UserBattlePacket.UserBattle(session.FieldPlayer, false));
                     break;
                 case "notice":
@@ -140,6 +143,27 @@ namespace MapleServer2.Tools
             }
 
             session.FieldManager.AddNpc(fieldNpc);
+        }
+
+        private static void ProcessMobCommand(GameSession session, string command)
+        {
+            Dictionary<string, string> config = command.ToMap();
+            int.TryParse(config.GetValueOrDefault("id", "11003146"), out int mobId);
+            Mob mob = new Mob(mobId);
+            byte.TryParse(config.GetValueOrDefault("ani", "-1"), out mob.Animation);
+            short.TryParse(config.GetValueOrDefault("dir", "2700"), out mob.Rotation);
+
+            IFieldObject<Mob> fieldMob = session.FieldManager.RequestFieldObject(mob);
+            if (TryParseCoord(config.GetValueOrDefault("coord", ""), out CoordF coord))
+            {
+                fieldMob.Coord = coord;
+            }
+            else
+            {
+                fieldMob.Coord = session.FieldPlayer.Coord;
+            }
+
+            session.FieldManager.AddMob(fieldMob);
         }
 
         private static Dictionary<string, string> ToMap(this string command)

--- a/MapleServer2/Types/Mob.cs
+++ b/MapleServer2/Types/Mob.cs
@@ -14,6 +14,11 @@ namespace MapleServer2.Types
         {
             Id = id;
             Animation = 255;
+            stats = new PlayerStats()
+            {
+                Hp = new PlayerStat(10, 0, 10),
+                CurrentHp = new PlayerStat(0, 10, 0),
+            };
         }
     }
 }

--- a/MapleServer2/Types/Npc.cs
+++ b/MapleServer2/Types/Npc.cs
@@ -14,7 +14,6 @@ namespace MapleServer2.Types
         {
             Id = id;
             Animation = 255;
-            stats = PlayerStats.Default();
         }
     }
 }

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -62,6 +62,10 @@ namespace MapleServer2.Types
 
         public int MaxSkillTabs;
         public long ActiveSkillTabId;
+
+        public int ActiveSkillId = 1;
+        public short ActiveSkillLevel = 1;
+
         public List<SkillTab> SkillTabs = new List<SkillTab>();
         public StatDistribution StatPointDistribution = new StatDistribution();
 


### PR DESCRIPTION
- Passing a list of mobs from the field to the SkillDamagePacket
- Adding `AddMob, LoadMob & ControlMob` to be use for the Mob class
- Adding `ApplyHeal` to the Packet
- Adding `MobSkillUse` to the Packet
- Adding `StatPacket` into the proper Packet class
- Adding `mob` calling on `GameCommandAction`
- Adding spawing mobs to into the state of the field.
- Minor other fix