### PR TITLE
Fix: force en-US globalization

### DIFF
--- a/GameDataParser/Program.cs
+++ b/GameDataParser/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Globalization;
+using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Xml;
 using GameDataParser.Crypto;
@@ -16,6 +17,9 @@ namespace GameDataParser
 
         private static void Main()
         {
+            // Force Globalization to en-US because we use periods instead of commas for decimals
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
             Item.Export();
             MapEntity.Export();
             Skill.Export();

--- a/MapleServer2/MapleServer.cs
+++ b/MapleServer2/MapleServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using Autofac;
@@ -17,6 +18,9 @@ namespace MapleServer2
         private static GameServer gameServer;
         public static void Main(string[] args)
         {
+            // Force Globalization to en-US because we use periods instead of commas for decimals
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
             // No DI here because MapleServer is static
             Logger logger = LogManager.GetCurrentClassLogger();
             logger.Info($"MapleServer started with {args.Length} args: {string.Join(", ", args)}");


### PR DESCRIPTION
`type.Parse()` uses OS globalization to determine whether to use `,` or `.` for decimal points, this change forces it to use `.` for decimal points.