### PR TITLE
Guild data parsing and other fixes

### DIFF
--- a/GameDataParser/Files/Export/GuildMetadataExport.cs
+++ b/GameDataParser/Files/Export/GuildMetadataExport.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO.MemoryMappedFiles;
 using GameDataParser.Crypto.Common;
 using GameDataParser.Parsers;
@@ -10,9 +11,16 @@ namespace GameDataParser.Files.Export
     {
         public static void Export(List<PackFileEntry> files, MemoryMappedFile memFile)
         {
+            if (Hash.CheckHash(VariableDefines.OUTPUT + "ms2-guild-metadata"))
+            {
+                Console.WriteLine("\rSkipping guild metadata!");
+                return;
+            }
+
             // Parse and save some item data from xml file
-            GuildMetadata GuildMetadata = GuildParser.Parse(memFile, files);
-            GuildParser.Write(GuildMetadata);
+            PrestigeMetadata GuildMetadata = PrestigeParser.Parse(memFile, files);
+            PrestigeParser.Write(GuildMetadata);
+            Hash.WriteHash(VariableDefines.OUTPUT + "ms2-guild-metadata");
         }
     }
 }

--- a/GameDataParser/Files/Export/GuildMetadataExport.cs
+++ b/GameDataParser/Files/Export/GuildMetadataExport.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.IO.MemoryMappedFiles;
+using GameDataParser.Crypto.Common;
+using GameDataParser.Parsers;
+using Maple2Storage.Types.Metadata;
+
+namespace GameDataParser.Files.Export
+{
+    public static class GuildMetadataExport
+    {
+        public static void Export(List<PackFileEntry> files, MemoryMappedFile memFile)
+        {
+            // Parse and save some item data from xml file
+            GuildMetadata GuildMetadata = GuildParser.Parse(memFile, files);
+            GuildParser.Write(GuildMetadata);
+        }
+    }
+}

--- a/GameDataParser/Parsers/GuildParser.cs
+++ b/GameDataParser/Parsers/GuildParser.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Xml;
+using GameDataParser.Crypto.Common;
+using GameDataParser.Files;
+using Maple2Storage.Types.Metadata;
+using ProtoBuf;
+
+namespace GameDataParser.Parsers
+{
+    public static class GuildParser
+    {
+        public static GuildMetadata Parse(MemoryMappedFile m2dFile, IEnumerable<PackFileEntry> entries)
+        {
+            GuildMetadata guildMetadata = new GuildMetadata();
+
+            foreach (PackFileEntry entry in entries)
+            {
+                if (!entry.Name.StartsWith("table/guildcontribution"))
+                {
+                    continue;
+                }
+
+                // Parse XML
+                XmlDocument document = m2dFile.GetDocument(entry.FileHeader);
+                XmlNodeList contributions = document.SelectNodes("/ms2/contribution");
+
+                foreach (XmlNode contribution in contributions)
+                {
+                    string type = contribution.Attributes["type"].Value;
+                    int value = int.Parse(contribution.Attributes["value"].Value);
+
+                    guildMetadata.Contribution.Add(new GuildContribution(type, value));
+                }
+            }
+
+            foreach (PackFileEntry entry in entries)
+            {
+                if (!entry.Name.StartsWith("table/guildbuff"))
+                {
+                    continue;
+                }
+
+                // Parse XML
+                XmlDocument document = m2dFile.GetDocument(entry.FileHeader);
+                XmlNodeList buffs = document.SelectNodes("/ms2/guildBuff");
+
+                foreach (XmlNode buff in buffs)
+                {
+                    int id = int.Parse(buff.Attributes["id"].Value);
+                    byte level = byte.Parse(buff.Attributes["level"].Value);
+                    int effectId = int.Parse(buff.Attributes["additionalEffectId"].Value);
+                    byte effectLevel = byte.Parse(buff.Attributes["additionalEffectLevel"].Value);
+                    byte levelRequirement = byte.Parse(buff.Attributes["requireLevel"].Value);
+                    int upgradeCost = int.Parse(buff.Attributes["upgradeCost"].Value);
+                    int cost = int.Parse(buff.Attributes["cost"].Value);
+                    short duration = short.Parse(buff.Attributes["duration"].Value);
+
+                    guildMetadata.Buff.Add(new GuildBuff(id, level, effectId, effectLevel, levelRequirement, upgradeCost, cost, duration));
+                }
+            }
+
+            return guildMetadata;
+        }
+
+        public static void Write(GuildMetadata guildMetadata)
+        {
+            using (FileStream writeStream = File.Create(VariableDefines.OUTPUT + "ms2-guild-metadata"))
+            {
+                Serializer.Serialize(writeStream, guildMetadata);
+            }
+            using (FileStream readStream = File.OpenRead(VariableDefines.OUTPUT + "ms2-guild-metadata"))
+            {
+                // Ensure the file is read equivalent
+                // Debug.Assert(skills.SequenceEqual(Serializer.Deserialize<List<SkillMetadata>>(readStream)));
+            }
+            Console.WriteLine("\rSuccessfully parsed guild metadata!");
+        }
+    }
+}

--- a/GameDataParser/Program.cs
+++ b/GameDataParser/Program.cs
@@ -37,6 +37,7 @@ namespace GameDataParser
             Thread insigniaThread = new Thread(() => InsigniaMetadataExport.Export(xmlFiles, xmlMemFile));
             Thread prestigeThread = new Thread(() => PrestigeMetadataExport.Export(xmlFiles, xmlMemFile));
             Thread expThread = new Thread(() => ExpMetadataExport.Export(xmlFiles, xmlMemFile));
+            Thread guildThread = new Thread(() => GuildMetadataExport.Export(xmlFiles, xmlMemFile));
 
             Spinner spinner = new Spinner();
             spinner.Start();
@@ -47,6 +48,7 @@ namespace GameDataParser
             insigniaThread.Start();
             prestigeThread.Start();
             expThread.Start();
+            guildThread.Start();
 
             itemThread.Join();
             mapEntityThread.Join();
@@ -54,6 +56,7 @@ namespace GameDataParser
             insigniaThread.Join();
             prestigeThread.Join();
             expThread.Join();
+            guildThread.Join();
 
             spinner.Stop();
         }

--- a/Maple2Storage/Types/Metadata/GuildMetadata.cs
+++ b/Maple2Storage/Types/Metadata/GuildMetadata.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Maple2Storage.Types.Metadata
+{
+    [XmlType]
+    public class GuildMetadata
+    {
+        [XmlElement(Order = 1)]
+        public readonly List<GuildContribution> Contribution;
+        [XmlElement(Order = 2)]
+        public readonly List<GuildBuff> Buff;
+
+        // Required for deserialization
+        public GuildMetadata()
+        {
+            this.Contribution = new List<GuildContribution>();
+            this.Buff = new List<GuildBuff>();
+        }
+
+        public override string ToString() =>
+            $"GuildMetadata(Contribution:{string.Join(",", Contribution)},Buff{string.Join(",",Buff)}";
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Contribution);
+        }
+    }
+
+    [XmlType]
+    public class GuildContribution
+    {
+        [XmlElement(Order = 1)]
+        public readonly string Type;
+        [XmlElement(Order = 2)]
+        public readonly int Value;
+
+        // Required for deserialization
+        public GuildContribution() { }
+
+        public GuildContribution(string type, int value)
+        {
+            this.Type = type;
+            this.Value = value;
+        }
+
+        public override string ToString() =>
+            $"GuildContribution(Type:{Type},Value:{Value})";
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Type, Value);
+        }
+    }
+
+    [XmlType]
+    public class GuildBuff
+    {
+        [XmlElement(Order = 1)]
+        public readonly int Id;
+        [XmlElement(Order = 2)]
+        public readonly byte Level;
+        [XmlElement(Order = 3)]
+        public readonly int EffectId;
+        [XmlElement(Order = 4)]
+        public readonly byte EffectLevel;
+        [XmlElement(Order = 5)]
+        public readonly byte LevelRequirement;
+        [XmlElement(Order = 6)]
+        public readonly int UpgradeCost;
+        [XmlElement(Order = 7)]
+        public readonly int Cost;
+        [XmlElement(Order = 8)]
+        public readonly short Duration;
+
+        public GuildBuff() { }
+
+        public GuildBuff(int id, byte level, int effectId, byte effectLevel, byte levelRequirement, int upgradeCost, int cost, short duration)
+        {
+            this.Id = id;
+            this.Level = level;
+            this.EffectId = effectId;
+            this.EffectLevel = effectLevel;
+            this.LevelRequirement = levelRequirement;
+            this.UpgradeCost = upgradeCost;
+            this.Cost = cost;
+            this.Duration = duration;
+        }
+
+        public override string ToString() =>
+            $"GuildContribution(Id:{Id},Level:{Level},EffectId:{EffectId},EffectLevel:{EffectLevel},LevelRequirement:{LevelRequirement},UpgradeCost:{UpgradeCost},Cost:{Cost},Duration:{Duration}";
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, Level, EffectId, EffectLevel, LevelRequirement, UpgradeCost, Cost, Duration);
+        }
+    }
+}

--- a/MapleServer2/Data/Static/GuildMetadataStorage.cs
+++ b/MapleServer2/Data/Static/GuildMetadataStorage.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Maple2Storage.Types.Metadata;
+using ProtoBuf;
+
+namespace MapleServer2.Data.Static
+{
+    public static class GuildMetadataStorage
+    {
+        private static readonly Dictionary<string, GuildContribution> contributions = new Dictionary<string, GuildContribution>();
+        private static readonly Dictionary<int, GuildBuff> buffs = new Dictionary<int, GuildBuff>();
+
+        static GuildMetadataStorage()
+        {
+            using FileStream stream = File.OpenRead("Maple2Storage/Resources/ms2-guild-metadata");
+            GuildMetadata metadata = Serializer.Deserialize<GuildMetadata>(stream);
+            foreach (GuildContribution contribution in metadata.Contribution)
+            {
+                contributions.Add(contribution.Type, contribution);
+            }
+
+            foreach (GuildBuff buff in metadata.Buff)
+            {
+                buffs.Add(buff.Id, buff);
+            }
+        }
+
+        public static GuildContribution GetContribution(string type)
+        {
+            return contributions.GetValueOrDefault(type);
+        }
+
+        public static GuildBuff GetBuff(int id)
+        {
+            return buffs.GetValueOrDefault(id);
+        }
+    }
+}

--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -26,6 +26,7 @@ namespace MapleServer2.PacketHandlers.Game
             session.Send(StatPacket.SetStats(session.FieldPlayer));
             session.Send(StatPointPacket.WriteTotalStatPoints(session.Player));
             session.Send(EmotePacket.LoadEmotes());
+            session.Send(ChatStickerPacket.LoadChatSticker(session.Player));
 
             // Normally skill layout would be loaded from a database
             QuickSlot arrowStream = QuickSlot.From(10500001);

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -459,10 +459,7 @@ namespace MapleServer2.PacketHandlers.Game
                 {
                     return;
                 }
-                else
-                {
-                    guild.Funds -= buff.Cost;
-                }
+                guild.Funds -= buff.Cost;
             }
 
             session.Send(GuildPacket.ActivateBuff(buffId));

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -451,7 +451,7 @@ namespace MapleServer2.PacketHandlers.Game
                 if (!session.Player.Wallet.Meso.Modify(-buff.Cost))
                 {
                     return;
-                };
+                }
             }
             else
             {
@@ -478,6 +478,7 @@ namespace MapleServer2.PacketHandlers.Game
         {
             int donateQuantity = packet.ReadInt();
             int donationAmount = donateQuantity * 10000;
+
             Guild guild = GameServer.GuildManager.GetGuildById(session.Player.GuildId);
             if (guild == null)
             {
@@ -493,7 +494,7 @@ namespace MapleServer2.PacketHandlers.Game
             GuildContribution contribution = GuildMetadataStorage.GetContribution("donation");
 
             session.Player.GuildContribution += contribution.Value * donateQuantity;
-            int guildFunds = guild.Funds + donateQuantity * 10000;
+            int guildFunds = guild.Funds + donationAmount;
             guild.Funds = guildFunds;
 
             session.Send(GuildPacket.UpdateGuildFunds(guild.Funds));

--- a/MapleServer2/Packets/GuildPacket.cs
+++ b/MapleServer2/Packets/GuildPacket.cs
@@ -574,7 +574,7 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
             pWriter.WriteEnum(GuildPacketMode.DisplayGuildList);
-            pWriter.WriteInt(guilds.Count); // guild count to display
+            pWriter.WriteInt(guilds.Count);
 
             foreach (Guild guild in guilds)
             {

--- a/MapleServer2/Packets/GuildPacket.cs
+++ b/MapleServer2/Packets/GuildPacket.cs
@@ -33,7 +33,6 @@ namespace MapleServer2.Packets
             GuildNoticeChange = 0x1A,
             ListGuildUpdate = 0x1E,
             MemberJoin = 0x20,
-            Unk1 = 0x24,
             SendApplication = 0x2D,
             UpdateGuildExp = 0x31,
             UpdateGuildFunds = 0x32,
@@ -51,7 +50,7 @@ namespace MapleServer2.Packets
             DisplayGuildList = 0x55,
             ActivateBuff = 0x59,
             List = 0x5A,
-            UpdateGuildFunds2 = 0x60,
+            UpdateGuildStatsNotice = 0x5F,
             UpdatePlayerDonation = 0x6E,
         }
 
@@ -430,16 +429,6 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet Unk1(Player player)
-        {
-            PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
-            pWriter.WriteEnum(GuildPacketMode.Unk1);
-            pWriter.WriteUnicodeString(player.Name);
-            pWriter.WriteInt();
-            pWriter.WriteInt();
-            return pWriter;
-        }
-
         public static Packet SendApplication(long guildApplicationId, Player player)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
@@ -460,30 +449,30 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet UpdateGuildExp()
+        public static Packet UpdateGuildExp(int guildExp)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
             pWriter.WriteEnum(GuildPacketMode.UpdateGuildExp);
-            pWriter.WriteInt(50000); // new guildExp total
+            pWriter.WriteInt(guildExp);
             return pWriter;
         }
 
-        public static Packet UpdateGuildFunds()
+        public static Packet UpdateGuildFunds(int guildFunds)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
             pWriter.WriteEnum(GuildPacketMode.UpdateGuildFunds);
-            pWriter.WriteInt(10000000); // new guildFunds total
+            pWriter.WriteInt(guildFunds);
             return pWriter;
         }
 
-        public static Packet UpdatePlayerContribution(Player player)
+        public static Packet UpdatePlayerContribution(Player player, int contribution)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
             pWriter.WriteEnum(GuildPacketMode.UpdatePlayerContribution);
             pWriter.WriteUnicodeString(player.Name);
-            pWriter.WriteInt();
-            pWriter.WriteInt(20); // Contribution today
-            pWriter.WriteInt(100); // Total contribution
+            pWriter.WriteInt(contribution);
+            pWriter.WriteInt(contribution);
+            pWriter.WriteInt(player.GuildContribution);
             return pWriter;
         }
 
@@ -585,7 +574,7 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
             pWriter.WriteEnum(GuildPacketMode.DisplayGuildList);
-            pWriter.WriteInt(1); // guild count to display
+            pWriter.WriteInt(guilds.Count); // guild count to display
 
             foreach (Guild guild in guilds)
             {
@@ -631,16 +620,16 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet UpdateGuildFunds2()
+        public static Packet UpdateGuildStatsNotice(int exp, int funds)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
-            pWriter.WriteEnum(GuildPacketMode.UpdateGuildFunds2);
-            pWriter.WriteInt(80); //guildExp gain
-            pWriter.WriteInt(10000); // guildFunds gain
+            pWriter.WriteEnum(GuildPacketMode.UpdateGuildStatsNotice);
+            pWriter.WriteInt(exp);
+            pWriter.WriteInt(funds);
             return pWriter;
         }
 
-        public static Packet UpdatePlayerDonation()
+        public static Packet UpdatePlayerDonation(int totalDonationAmount)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.GUILD);
             pWriter.WriteEnum(GuildPacketMode.UpdatePlayerDonation);

--- a/MapleServer2/Types/Guild.cs
+++ b/MapleServer2/Types/Guild.cs
@@ -21,6 +21,7 @@ namespace MapleServer2.Types
         public int Funds { get; set; }
         public int Exp { get; set; }
         public bool Searchable { get; set; }
+        public int HouseMapId { get; set; }
 
         public Guild(string name, List<Player> gPlayers)
         {
@@ -33,6 +34,7 @@ namespace MapleServer2.Types
             Exp = 0;
             Funds = 0;
             Searchable = true;
+            HouseMapId = 66100001;
             CreationTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + Environment.TickCount;
         }
 
@@ -45,6 +47,7 @@ namespace MapleServer2.Types
         {
             Members.Remove(player);
             player.GuildId = 0;
+            player.GuildContribution = 0;
         }
 
 

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -93,6 +93,7 @@ namespace MapleServer2.Types
         // TODO make this as an array
 
         public long GuildId;
+        public int GuildContribution;
         public Wallet Wallet { get; private set; }
 
         public Player()


### PR DESCRIPTION
Parsing some data for guild contributions and buffs. Submitting this to see if I'm doing it correctly before diving deeper.

Buffs are a bit odd. both personal and guild buffs are in the same table. Personal buffs take meso to use while guild buffs take guild funds. I'm differentiating them by just the id number.

At the moment if you're trying to use a buff, you'll get an error because there's multiple entries of the same buff (due to levels). I'll probably need assistance on how to properly implement guild buffs and their levels. And also calling out the correct buff and level from the parsed data.

Oh, also, I forgot to push out the fieldhandler update from my last PR so stickers can load, so there's that.