### PR TITLE
Feat: Stat allocation/updates + Cleanup: PlayerStats

### DIFF
--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -104,17 +104,10 @@ namespace MapleServer2.PacketHandlers.Game
             if (item.InventoryTab == InventoryTab.Gear)
             {
                 // TODO - Increase stats based on the item stats itself
-                session.Player.Stats.CritRate.Max += 12;
-                session.Player.Stats.CritRate.Total += 12;
-
-                session.Player.Stats.MinAtk.Max += 15;
-                session.Player.Stats.MinAtk.Total += 15;
-
-                session.Player.Stats.MaxAtk.Max += 17;
-                session.Player.Stats.MaxAtk.Total += 17;
-
-                session.Player.Stats.MagAtk.Max += 15;
-                session.Player.Stats.MagAtk.Total += 15;
+                session.Player.Stats.Increase(PlayerStatId.CritRate, 12);
+                session.Player.Stats.Increase(PlayerStatId.MinAtk, 15);
+                session.Player.Stats.Increase(PlayerStatId.MaxAtk, 17);
+                session.Player.Stats.Increase(PlayerStatId.MagAtk, 15);
 
                 session.Send(StatPacket.SetStats(session.FieldPlayer));
             }

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Types;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
 using Microsoft.Extensions.Logging;
@@ -39,14 +40,17 @@ namespace MapleServer2.PacketHandlers.Game
         private static void HandleStatIncrement(GameSession session, PacketReader packet)
         {
             byte statTypeIndex = packet.ReadByte();
-            session.Player.StatPointDistribution.AddPoint(statTypeIndex);
+            session.Player.StatPointDistribution.AddPoint(statTypeIndex);   // Deprecate?
+            session.Player.Stats.Increase((PlayerStatId) statTypeIndex, 1);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
+            session.Send(StatPacket.UpdateStats(session.FieldPlayer));
         }
 
         private static void HandleResetStatDistribution(GameSession session)
         {
-            session.Player.StatPointDistribution.ResetPoints();
-            session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
+            session.Player.Stats.ResetAllocations(session.Player.StatPointDistribution);
+            session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));   // Deprecate?
+            session.Send(StatPacket.UpdateStats(session.FieldPlayer));
         }
     }
 }

--- a/MapleServer2/Packets/FieldPacket.cs
+++ b/MapleServer2/Packets/FieldPacket.cs
@@ -45,7 +45,7 @@ namespace MapleServer2.Packets
             pWriter.WriteByte();
 
             // Stats
-            StatPacket.WriteTotalStats(pWriter, ref player.Stats);
+            StatPacket.WriteFieldStats(pWriter, player.Stats);
 
             pWriter.WriteByte();
             pWriter.WriteByte();

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -152,8 +152,8 @@ namespace MapleServer2.Packets
             pWriter.WriteEnum(PartyPacketMode.UpdateHitpoints);
             pWriter.WriteLong(player.CharacterId);
             pWriter.WriteLong(player.AccountId);
-            pWriter.WriteInt(player.Stats.Hp.Total);
-            pWriter.WriteInt(player.Stats.CurrentHp.Min);
+            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Total);
+            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Min);
             pWriter.WriteShort();
 
             return pWriter;

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -29,7 +29,7 @@ namespace MapleServer2.Packets
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
             pWriter.WriteInt(player.ObjectId);
             pWriter.WriteByte();                // Unknown (0x00/0x01)
-            pWriter.WriteByte(0x23);            // Unknown
+            pWriter.WriteEnum(StatsMode.SendStats);
             WriteStats(ref pWriter, player.Value.Stats);
 
             return pWriter;

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -1,4 +1,5 @@
-﻿using MaplePacketLib2.Tools;
+﻿using System.Collections;
+using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Types;
 
@@ -18,7 +19,7 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(player.ObjectId);
             pWriter.WriteByte();
             pWriter.WriteEnum(StatsMode.SendStats);
-            pWriter.Write(player.Value.Stats);
+            WriteStats(ref pWriter, player.Value.Stats);
 
             return pWriter;
         }
@@ -79,16 +80,35 @@ namespace MapleServer2.Packets
             }
         }
 
-        public static void WriteTotalStats(this PacketWriter pWriter, ref PlayerStats stats)
+        public static void WriteStats(ref PacketWriter pWriter, PlayerStats stats)
+        {
+            foreach (DictionaryEntry entry in stats.Data)
+            {
+                if (entry.Key.Equals(PlayerStatId.Hp))
+                {
+                    // Iterate through Bonuses, Base, Capped. "(Normal, Min, Max)"
+                    for (int i = 0; i < 3; i++)
+                    {
+                        pWriter.WriteLong(((PlayerStat) entry.Value)[i]);
+                    }
+                }
+                else
+                {
+                    pWriter.Write((PlayerStat) entry.Value);
+                }
+            }
+        }
+
+        public static void WriteFieldStats(this PacketWriter pWriter, PlayerStats stats)
         {
             pWriter.WriteEnum(StatsMode.SendStats);
             for (int i = 0; i < 3; i++)
             {
-                pWriter.WriteLong(stats.Hp[i]);
-                pWriter.WriteInt(stats.AtkSpd[i]);
-                pWriter.WriteInt(stats.MoveSpd[i]);
-                pWriter.WriteInt(stats.MountSpeed[i]);
-                pWriter.WriteInt(stats.JumpHeight[i]);
+                pWriter.WriteLong(stats[PlayerStatId.Hp][i]);
+                pWriter.WriteInt(stats[PlayerStatId.AtkSpd][i]);
+                pWriter.WriteInt(stats[PlayerStatId.MoveSpd][i]);
+                pWriter.WriteInt(stats[PlayerStatId.MountSpeed][i]);
+                pWriter.WriteInt(stats[PlayerStatId.JumpHeight][i]);
             }
         }
     }

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -27,7 +27,7 @@ namespace MapleServer2.Packets
         public static Packet UpdateStats(IFieldObject<Player> player)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
-            pWriter.WriteInt(player.ObjectId);  // ObjectId (?)
+            pWriter.WriteInt(player.ObjectId);
             pWriter.WriteByte();                // Unknown (0x00/0x01)
             pWriter.WriteByte(0x23);            // Unknown
             WriteStats(ref pWriter, player.Value.Stats);
@@ -102,11 +102,9 @@ namespace MapleServer2.Packets
                     {
                         pWriter.WriteLong(((PlayerStat) entry.Value)[i]);
                     }
+                    continue;
                 }
-                else
-                {
-                    pWriter.Write((PlayerStat) entry.Value);
-                }
+                pWriter.Write((PlayerStat) entry.Value);
             }
         }
 

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -10,7 +10,7 @@ namespace MapleServer2.Packets
         private enum StatsMode : byte
         {
             SendStats = 0x23,
-            UpdateStats = 0x4
+            UpdateMobStats = 0x4
         }
 
         public static Packet SetStats(IFieldObject<Player> player)
@@ -24,13 +24,24 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
+        public static Packet UpdateStats(IFieldObject<Player> player)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
+            pWriter.WriteInt(player.ObjectId);  // ObjectId (?)
+            pWriter.WriteByte();                // Unknown (0x00/0x01)
+            pWriter.WriteByte(0x23);            // Unknown
+            WriteStats(ref pWriter, player.Value.Stats);
+
+            return pWriter;
+        }
+
         public static Packet UpdateMobStats(IFieldObject<Mob> mob)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
             pWriter.WriteInt(mob.ObjectId);
             pWriter.WriteByte();
             pWriter.WriteByte(1);
-            pWriter.WriteEnum(StatsMode.UpdateStats);
+            pWriter.WriteEnum(StatsMode.UpdateMobStats);
             pWriter.WriteLong(mob.Value.Stats.Hp.Total);
             pWriter.WriteLong(mob.Value.Stats.Hp.Min);
             pWriter.WriteLong(mob.Value.Stats.Hp.Max);

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -115,7 +115,7 @@ namespace MapleServer2.Types
         public static Player Char1(long accountId, long characterId, string name = "Char1")
         {
             Job job = Job.Archer;
-            PlayerStats stats = PlayerStats.Default();
+            PlayerStats stats = new PlayerStats();
             StatDistribution statPointDistribution = new StatDistribution(totalStats: 18);
             List<SkillTab> skillTabs = new List<SkillTab>
             {
@@ -177,7 +177,7 @@ namespace MapleServer2.Types
         public static Player Char2(long accountId, long characterId, string name = "Char2")
         {
             Job job = Job.Archer;
-            PlayerStats stats = PlayerStats.Default();
+            PlayerStats stats = new PlayerStats();
 
             List<SkillTab> skillTabs = new List<SkillTab>
             {
@@ -216,7 +216,7 @@ namespace MapleServer2.Types
 
         public static Player NewCharacter(byte gender, Job job, string name, SkinColor skinColor, object equips)
         {
-            PlayerStats stats = PlayerStats.Default();
+            PlayerStats stats = new PlayerStats();
 
             List<SkillTab> skillTabs = new List<SkillTab>
             {
@@ -245,7 +245,7 @@ namespace MapleServer2.Types
         public static Player Priest(long accountId, long characterId, string name = "Priest")
         {
             Job job = Job.Priest;
-            PlayerStats stats = PlayerStats.Default();
+            PlayerStats stats = new PlayerStats();
             StatDistribution statPointDistribution = new StatDistribution(totalStats: 18);
             List<SkillTab> skillTabs = new List<SkillTab>
             {

--- a/MapleServer2/Types/PlayerStats.cs
+++ b/MapleServer2/Types/PlayerStats.cs
@@ -89,7 +89,6 @@ namespace MapleServer2.Types
     {
         // TOOD: Handle stat allocation in here?
         public readonly OrderedDictionary Data;
-        private readonly int[] Allocations;
 
         public PlayerStats()
         {

--- a/MapleServer2/Types/PlayerStats.cs
+++ b/MapleServer2/Types/PlayerStats.cs
@@ -1,72 +1,54 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Runtime.InteropServices;
 
 namespace MapleServer2.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 432)]
-    public struct PlayerStats
+    public enum PlayerStatId : byte
     {
-        // Total 36 Stats MUST be in this order (Struct)
-        public PlayerStat Str;
-        public PlayerStat Dex;
-        public PlayerStat Int;
-        public PlayerStat Luk;
-        public PlayerStat Hp;
-        public PlayerStat CurrentHp;
-        public PlayerStat HpRegen;
-        public PlayerStat Unknown7;     // (3000, 3000, 3000)
-        public PlayerStat Spirit;
-        public PlayerStat Unknown9;     // (10, 10, 10)
-        public PlayerStat Unknown10;    // (500, 500, 500)
-        public PlayerStat Stamina;      // (10, 10, 10)
-        public PlayerStat Unknown12;    // (500, 500, 500)
-        public PlayerStat Unknown13;
-        public PlayerStat AtkSpd;
-        public PlayerStat MoveSpd;
-        public PlayerStat Acc;
-        public PlayerStat Eva;
-        public PlayerStat CritRate;
-        public PlayerStat CritDmg;
-        public PlayerStat CritEva;
-        public PlayerStat Def;
-        public PlayerStat Guard;
-        public PlayerStat JumpHeight;
-        public PlayerStat PhysAtk;
-        public PlayerStat MagAtk;
-        public PlayerStat PhysRes;
-        public PlayerStat MagRes;
-        public PlayerStat MinAtk;
-        public PlayerStat MaxAtk;
-        public PlayerStat Unknown30;
-        public PlayerStat Unknown31;
-        public PlayerStat Pierce;
-        public PlayerStat MountSpeed;
-        public PlayerStat BonusAtk;
-        public PlayerStat Unknown35;
-
-        public static PlayerStats Default()
-        {
-            return new PlayerStats
-            {
-                Hp = new PlayerStat(1000, 0, 1000),
-                CurrentHp = new PlayerStat(0, 500, 0),
-                Spirit = new PlayerStat(100, 100, 100),
-                Stamina = new PlayerStat(120, 120, 120),
-                AtkSpd = new PlayerStat(120, 100, 130),
-                MoveSpd = new PlayerStat(110, 100, 150),
-                JumpHeight = new PlayerStat(110, 100, 130),
-                MountSpeed = new PlayerStat(100, 100, 100),
-
-            };
-        }
+        Str = 0x00,
+        Dex = 0x01,
+        Int = 0x02,
+        Luk = 0x03,
+        Hp = 0x04,           // long
+        HpRegen = 0x05,
+        Unknown7 = 0x06,     // base 3000
+        Spirit = 0x07,
+        SpRegen = 0x08,      // (10, 10, 10)
+        Unknown10 = 0x09,    // base 500
+        Unknown11 = 0x0A,    // base 120
+        Stamina = 0x0B,      // (10, 10, 10)
+        Unknown13 = 0x0C,    // base 500
+        AtkSpd = 0x0D,
+        MoveSpd = 0x0E,
+        Acc = 0x0F,
+        Eva = 0x10,
+        CritRate = 0x11,
+        CritDmg = 0x12,
+        CritEva = 0x13,
+        Def = 0x14,
+        Guard = 0x15,
+        JumpHeight = 0x16,
+        PhysAtk = 0x17,
+        MagAtk = 0x18,
+        PhysRes = 0x19,
+        MagRes = 0x1A,
+        MinAtk = 0x1B,
+        MaxAtk = 0x1C,
+        Unknown30 = 0x1D,
+        Unknown31 = 0x1E,
+        Pierce = 0x1F,
+        MountSpeed = 0x20,
+        BonusAtk = 0x21,
+        Unknown35 = 0x22,   // can be increased, base stays 0
     }
 
-    /* Total = Min + stat bonuses
-     * Min = Base stat amount
-     * Max = Cap on stat (Example: MoveSpd)
+    /* Total = Base + stat allocations + bonuses.
+     * Min = Base stat amount.
+     * Max = Final value, capped. (Example: MoveSpd)
      *
-     * For stuff like Spirit/Stamina, you decrease Max when it is consumed
-     * For Hp, Min should always be 0. For CurrentHp, Total & Max should always be 0.
-     * Decrease CurrentHp Min when you lose Hp.
+     * For stuff like Spirit/Stamina, you decrease Max when it is consumed.
+     * Decrease Hp.Total and Hp.Max when you lose Hp.
      */
     [StructLayout(LayoutKind.Sequential, Size = 12)]
     public struct PlayerStat
@@ -93,6 +75,108 @@ namespace MapleServer2.Types
             Total = total;
             Min = min;
             Max = max;
+        }
+
+        public PlayerStat(PlayerStat copy, int increase)
+        {
+            Total = copy.Total + increase;
+            Min = copy.Min + increase;
+            Max = copy.Max + increase;
+        }
+    }
+
+    public class PlayerStats
+    {
+        // TOOD: Handle stat allocation in here?
+        public readonly OrderedDictionary Data;
+        private readonly int[] Allocations;
+
+        public PlayerStats()
+        {
+            Data = new OrderedDictionary
+            {
+                { PlayerStatId.Str, new PlayerStat(9, 9, 9) },
+                { PlayerStatId.Dex, new PlayerStat(9, 9, 9) },
+                { PlayerStatId.Int, new PlayerStat(9, 9, 9) },
+                { PlayerStatId.Luk, new PlayerStat(9, 9, 9) },
+                { PlayerStatId.Hp, new PlayerStat(500, 500, 500) },         // Max = 0 on login
+                { PlayerStatId.HpRegen, new PlayerStat(10, 10, 10) },
+                { PlayerStatId.Unknown7, new PlayerStat(3000, 3000, 3000) },
+                { PlayerStatId.Spirit, new PlayerStat(100, 100, 100) },     // Max = 0 on login
+                { PlayerStatId.SpRegen, new PlayerStat(1, 1, 1) },
+                { PlayerStatId.Unknown10, new PlayerStat(200, 200, 200) },
+                { PlayerStatId.Unknown11, new PlayerStat(120, 120, 120) },  // Max = 0 on login
+                { PlayerStatId.Stamina, new PlayerStat(10, 10, 10) },       // (10, 10, 10)
+                { PlayerStatId.Unknown13, new PlayerStat(500, 500, 500) },  // (500, 500, 500)
+                { PlayerStatId.AtkSpd, new PlayerStat(100, 100, 100) },
+                { PlayerStatId.MoveSpd, new PlayerStat(100, 100, 100) },
+                { PlayerStatId.Acc, new PlayerStat(82, 82, 82) },
+                { PlayerStatId.Eva, new PlayerStat(70, 70, 70) },           // changes with job
+                { PlayerStatId.CritRate, new PlayerStat(45, 45, 45) },      // changes with job
+                { PlayerStatId.CritDmg, new PlayerStat(250, 250, 250) },
+                { PlayerStatId.CritEva, new PlayerStat(50, 50, 50) },
+                { PlayerStatId.Def, new PlayerStat(16, 16, 16) },           // base affected by something?
+                { PlayerStatId.Guard, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.JumpHeight, new PlayerStat(100, 100, 100) },
+                { PlayerStatId.PhysAtk, new PlayerStat(10, 10, 10) },       // base for mage, 74 thief
+                { PlayerStatId.MagAtk, new PlayerStat(2, 2, 2) },           // base for thief, 216 mage
+                { PlayerStatId.PhysRes, new PlayerStat(5, 5, 5) },
+                { PlayerStatId.MagRes, new PlayerStat(4, 4, 4) },
+                { PlayerStatId.MinAtk, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.MaxAtk, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.Unknown30, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.Unknown31, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.Pierce, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.MountSpeed, new PlayerStat(100, 100, 100) },
+                { PlayerStatId.BonusAtk, new PlayerStat(0, 0, 0) },
+                { PlayerStatId.Unknown35, new PlayerStat(0, 0, 0) }
+            };
+        }
+
+        public PlayerStat this[PlayerStatId statIndex]
+        {
+            get
+            {
+                return (PlayerStat) Data[statIndex];
+            }
+
+            set
+            {
+                Data[statIndex] = value;
+            }
+        }
+
+        public void IncreaseBase(PlayerStatId statIndex, int amount)
+        {
+            PlayerStat stat = this[statIndex];
+            Data[statIndex] = new PlayerStat(stat, amount);
+        }
+
+        public void Increase(PlayerStatId statIndex, int amount)
+        {
+            PlayerStat stat = this[statIndex];
+            Data[statIndex] = new PlayerStat(stat.Total + amount, stat.Min, stat.Max + amount);
+        }
+
+        public void DecreaseBase(PlayerStatId statIndex, int amount)
+        {
+            PlayerStat stat = this[statIndex];
+            Data[statIndex] = new PlayerStat(stat, -amount);
+        }
+
+        public void Decrease(PlayerStatId statIndex, int amount)
+        {
+            PlayerStat stat = this[statIndex];
+            Data[statIndex] = new PlayerStat(stat.Total - amount, stat.Min, stat.Max - amount);
+        }
+
+        public void ResetAllocations(StatDistribution statDist)
+        {
+            foreach (KeyValuePair<byte, int> entry in statDist.AllocatedStats)
+            {
+                Decrease((PlayerStatId) entry.Key, entry.Value);
+            }
+            statDist.ResetPoints();
         }
     }
 }


### PR DESCRIPTION
Includes a working implementation of player stats and stat point allocation; includes a basic rewrite of `PlayerStats`.

- Rewrite `PlayerStats` struct to a class.
   - Mimics order and behavior using the non-generic `OrderedDictionary`.
   - Includes stat Increase, Decrease methods, used to apply stat bonuses (e.g. gear).
   - Includes stat IncreaseBase, DecreaseBase methods, used to increase base stats.
   - Uses a `StatDistribution` to account for allocated points (at the moment).
   - Removes `CurrentHp` (use Hp, instead).
- Adds enum `PlayerStatId` to reference player stats.
- Add server packet to update player's stats in a field in `StatPacket.cs`.
- Add logic to update player's stats on stat allocation in `StatPointHandler.cs`.