### PR TITLE
Feat: Add more robust PlayerStats

### DIFF
--- a/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
@@ -54,7 +54,9 @@ namespace MapleServer2.PacketHandlers.Common
             TimeSyncPacket.SetInitial1();
             TimeSyncPacket.SetInitial2();
             TimeSyncPacket.Request();
-            // SendStat 0x2F (How to send here without ObjectId?, Seems fine to send after entering field)
+            session.Send(StatPacket.SetStats(session.FieldPlayer));
+            // TODO: Grab Hp/Spirit/Stam from last login
+            player.Stats.InitializePools(player.Stats[PlayerStatId.Hp].Max, player.Stats[PlayerStatId.Spirit].Max, player.Stats[PlayerStatId.Stamina].Max);
 
             session.SyncTicks();
             session.Send(DynamicChannelPacket.DynamicChannel());

--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -104,10 +104,10 @@ namespace MapleServer2.PacketHandlers.Game
             if (item.InventoryTab == InventoryTab.Gear)
             {
                 // TODO - Increase stats based on the item stats itself
-                session.Player.Stats.Increase(PlayerStatId.CritRate, 12);
-                session.Player.Stats.Increase(PlayerStatId.MinAtk, 15);
-                session.Player.Stats.Increase(PlayerStatId.MaxAtk, 17);
-                session.Player.Stats.Increase(PlayerStatId.MagAtk, 15);
+                session.Player.Stats.IncreaseMax(PlayerStatId.CritRate, 12);
+                session.Player.Stats.IncreaseMax(PlayerStatId.MinAtk, 15);
+                session.Player.Stats.IncreaseMax(PlayerStatId.MaxAtk, 17);
+                session.Player.Stats.IncreaseMax(PlayerStatId.MagAtk, 15);
 
                 session.Send(StatPacket.SetStats(session.FieldPlayer));
             }

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -41,16 +41,16 @@ namespace MapleServer2.PacketHandlers.Game
         {
             byte statTypeIndex = packet.ReadByte();
             session.Player.StatPointDistribution.AddPoint(statTypeIndex);   // Deprecate?
-            session.Player.Stats.Increase((PlayerStatId) statTypeIndex, 1);
+            session.Player.Stats.IncreaseMax((PlayerStatId) statTypeIndex, 1);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));
-            session.Send(StatPacket.UpdateStats(session.FieldPlayer));
+            session.Send(StatPacket.SetStats(session.FieldPlayer));
         }
 
         private static void HandleResetStatDistribution(GameSession session)
         {
             session.Player.Stats.ResetAllocations(session.Player.StatPointDistribution);
             session.Send(StatPointPacket.WriteStatPointDistribution(session.Player));   // Deprecate?
-            session.Send(StatPacket.UpdateStats(session.FieldPlayer));
+            session.Send(StatPacket.SetStats(session.FieldPlayer));
         }
     }
 }

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -152,7 +152,7 @@ namespace MapleServer2.Packets
             pWriter.WriteEnum(PartyPacketMode.UpdateHitpoints);
             pWriter.WriteLong(player.CharacterId);
             pWriter.WriteLong(player.AccountId);
-            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Total);
+            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Max);
             pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Min);
             pWriter.WriteShort();
 

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Types;
@@ -9,22 +10,44 @@ namespace MapleServer2.Packets
     {
         private enum StatsMode : byte
         {
+            UpdateStats = 0x01,
             SendStats = 0x23,
             UpdateMobStats = 0x4
         }
 
-        public static Packet SetStats(IFieldObject<Player> player)
+        public static Packet UpdateStats(IFieldObject<Player> player, PlayerStatId statId, params PlayerStatId[] otherIds)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
             pWriter.WriteInt(player.ObjectId);
-            pWriter.WriteByte();
-            pWriter.WriteEnum(StatsMode.SendStats);
-            WriteStats(ref pWriter, player.Value.Stats);
+            pWriter.WriteEnum(StatsMode.UpdateStats);
+            pWriter.WriteByte((byte) (1 + otherIds.Length));
+            pWriter.WriteEnum(statId);
+            pWriter.Write(player.Value.Stats[statId]);
+            foreach (PlayerStatId otherId in otherIds)
+            {
+                pWriter.WriteEnum(otherId);
+                pWriter.Write(player.Value.Stats[otherId]);
+            }
 
             return pWriter;
         }
 
-        public static Packet UpdateStats(IFieldObject<Player> player)
+        public static Packet UpdateStats(IFieldObject<Player> player, List<PlayerStatId> statIds)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
+            pWriter.WriteInt(player.ObjectId);
+            pWriter.WriteEnum(StatsMode.UpdateStats);
+            pWriter.WriteByte((byte) statIds.Count);
+            foreach (PlayerStatId statId in statIds)
+            {
+                pWriter.WriteEnum(statId);
+                pWriter.Write(player.Value.Stats[statId]);
+            }
+
+            return pWriter;
+        }
+
+        public static Packet SetStats(IFieldObject<Player> player)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
             pWriter.WriteInt(player.ObjectId);


### PR DESCRIPTION
Includes a more robust PlayerStats implementation. Further stats identified including Stamina's stats and Hp/Sp/Sta regen times in milliseconds (ms).

## Additions
- Stats sent on login.
- PlayerStats
   - New constructor to assign base stat attribute distributions.
   - `HpRegenTime` identified in milliseconds.
   - `SpRegenTime` identified in milliseconds.
   - `Stamina`, `StaRegen`, `StaRegenTime` correctly identified.
      - 20 Stamina = 1 Block in-game
   - `Increase`/`Decrease` methods used for temporary changes or effects.
   - `IncreaseMax`/`DecreaseMax` methods used for stat bonuses (e.g. gear).
      - On decrease, current Health/Spirit stay unaffected or capped to max value.
   - `IncreaseBase`/`DecreaseBase` methods used for permanent stat bonuses (attributes).
   - `InitializePool` method initializes Hp/Sp/Stamina with given values.
- StatPacket
   - `UpdateStats` method used to set a subset of the player's stats.

## Changes
- PlayerStat (struct)
   - Renamed members `Total`, `Min`, `Max` => `Max`, `Min`, `Current`
      - `PlayerStat.Current` can drop below Min.