### PR TITLE
Feat: Add HP/SP/Stamina regen + skill SP consumption.

### DIFF
--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -62,9 +62,16 @@ namespace MapleServer2.PacketHandlers.Game
             packet.ReadByte();
             CoordF coords = packet.Read<CoordF>();
             packet.ReadShort();
+
             SkillCast skillCast = new SkillCast(skillId, skillLevel, skillSN, unkValue);
-            session.FieldPlayer.Value.SkillCast = skillCast;
-            session.Send(SkillUsePacket.SkillUse(skillCast, coords));
+            int skillCost = skillCast.GetCost();
+            if (session.Player.Stats[PlayerStatId.Spirit].Current >= skillCost)
+            {
+                session.FieldPlayer.Value.SkillCast = skillCast;
+                session.Player.ConsumeSp(skillCost);
+                session.Send(SkillUsePacket.SkillUse(skillCast, coords));
+                session.Send(StatPacket.SetStats(session.FieldPlayer));
+            }
         }
 
         private static void HandleDamage(GameSession session, PacketReader packet)

--- a/MapleServer2/Types/SkillCast.cs
+++ b/MapleServer2/Types/SkillCast.cs
@@ -45,5 +45,7 @@ namespace MapleServer2.Types
             double roll = rnd.NextDouble();
             return roll > 0.5;
         }
+
+        public int GetCost() => SkillMetadataStorage.GetSkill(SkillId).SkillLevels.Find(s => s.Level == SkillLevel).Spirit;
     }
 }


### PR DESCRIPTION
Basic implementation of HP/SP/Stamina consumption + regeneration. Consuming a stat means decreasing the stat **temporarily**. 

## Additions
- Skills consume SP now. 😢
   - Skills only activate when enough SP is available.
- Player
   - `ConsumeHp` for consuming health (e.g. damage).
   - `ConsumeSp` for consuming spirit (e.g. skill use).
   - `ConsumeStamina` for consuming stamina (e.g. mount dashing).
- SkillCast
   - `GetCost` method for getting SP cost from skills metadata