### PR TITLE
Fix: #198 (Shops - Item stacks do not multiply with amount purchased)

### DIFF
--- a/MapleServer2/PacketHandlers/Game/ShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ShopHandler.cs
@@ -125,7 +125,7 @@ namespace MapleServer2.PacketHandlers.Game
             // add item to inventory
             Item item = new(shopItem.ItemId)
             {
-                Amount = quantity
+                Amount = quantity * shopItem.Quantity
             };
             InventoryController.Add(session, item, true);
 


### PR DESCRIPTION
### Bug fix
Fixed issue #198 where item stacks for shops didn't multiple with amount purchased.

Confirmed in-client that it is now working.