### PR TITLE
Suggestion: Minor changes for Linux compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ MapleServer2/Properties
 Maple2Storage/Resources
 Ms2Database/Migrations
 workspace.code-workspace
-build.bat

--- a/GameDataParser/Files/Paths.cs
+++ b/GameDataParser/Files/Paths.cs
@@ -5,7 +5,7 @@ namespace GameDataParser.Files
 {
     public static class Paths
     {
-        public static readonly string SOLUTION_DIR = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..\\..\\..\\..\\"));
+        public static readonly string SOLUTION_DIR = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
         public static readonly string INPUT = $"{SOLUTION_DIR}/GameDataParser/Resources";
         public static readonly string OUTPUT = $"{SOLUTION_DIR}/Maple2Storage/Resources";
         public static readonly string HASH = $"{SOLUTION_DIR}/GameDataParser/Hash";

--- a/MapleServer2/Constants/Paths.cs
+++ b/MapleServer2/Constants/Paths.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Constants
 {
     public static class Paths
     {
-        public static readonly string SOLUTION_DIR = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..\\..\\..\\..\\"));
+        public static readonly string SOLUTION_DIR = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
         public static readonly string RESOURCES = $"{SOLUTION_DIR}/Maple2Storage/Resources";
     }
 }

--- a/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
@@ -125,7 +125,7 @@ namespace MapleServer2.PacketHandlers.Game
                     session.Player.Levels.GainMasteryExp(type, recipe.RewardMastery);
                 }
             }
-            session.Send(InteractActorPacket.UseObject(actor, numDrop > 0 ? 0 : 1, numDrop));
+            session.Send(InteractActorPacket.UseObject(actor, (short) (numDrop > 0 ? 0 : 1), numDrop));
             session.Send(InteractActorPacket.Extra(actor));
         }
     }

--- a/MapleServer2/Packets/SkillDamagePacket.cs
+++ b/MapleServer2/Packets/SkillDamagePacket.cs
@@ -37,7 +37,7 @@ namespace MapleServer2.Packets
                     continue;
                 }
                 pWriter.WriteInt(mobs[i].ObjectId);
-                pWriter.WriteByte((byte) damage.GetDamage() > 0 ? 1 : 0);
+                pWriter.WriteByte((byte) (damage.GetDamage() > 0 ? 1 : 0));
                 pWriter.WriteBool(damage.IsCritical());
                 if (damage.GetDamage() != 0)
                 {

--- a/MapleServer2/Tools/InventoryController.cs
+++ b/MapleServer2/Tools/InventoryController.cs
@@ -57,7 +57,7 @@ namespace MapleServer2.Tools
                     Item newItem = new Item(item)
                     {
                         Amount = 1,
-                        Slot = session.Player.Inventory.SlotTaken(item, item.Slot) ? -1 : item.Slot,
+                        Slot = session.Player.Inventory.SlotTaken(item, item.Slot) ? (short)-1 : item.Slot,
                         Uid = GuidGenerator.Long()
                     };
                     if (!session.Player.Inventory.Add(newItem))


### PR DESCRIPTION
### Changes required for emulator to run on Linux
Linux distribution: Ubuntu 20.04 LTS
Architecture: x86_64
Dotnet Framework: .NET 5.0

### Explicit casting for ternary operators
- ternary operators cannot be implicitly casted to another type

### Path strings to use forward slash
- Windows recognises both '/' and '\\' whereas Linux only recognises the former

Tested modified code on Linux and Windows and seemed to work