### PR TITLE
fix: Explicit casting for ternary operators

### DIFF
--- a/GameDataParser/Parsers/ItemStatsParser.cs
+++ b/GameDataParser/Parsers/ItemStatsParser.cs
@@ -38,7 +38,7 @@ namespace GameDataParser.Parsers
                     int itemId = string.IsNullOrEmpty(node.Attributes["code"]?.Value) ? 0 : int.Parse(node.Attributes["code"].Value);
                     metadata.ItemId = itemId;
 
-                    byte grade = string.IsNullOrEmpty(node.Attributes["grade"]?.Value) ? 0 : byte.Parse(node.Attributes["grade"].Value);
+                    byte grade = (byte) (string.IsNullOrEmpty(node.Attributes["grade"]?.Value) ? 0 : byte.Parse(node.Attributes["grade"].Value));
                     optionsMetadata.Rarity = grade;
 
                     if (!string.IsNullOrEmpty(node.Attributes["optionNumPick"]?.Value))

--- a/GameDataParser/Parsers/QuestParser.cs
+++ b/GameDataParser/Parsers/QuestParser.cs
@@ -41,18 +41,18 @@ namespace GameDataParser.Parsers
                         {
                             metadata.Basic.ChapterID = string.IsNullOrEmpty(node.Attributes["chapterID"]?.Value) ? 0 : int.Parse(node.Attributes["chapterID"].Value);
                             metadata.Basic.QuestID = string.IsNullOrEmpty(node.Attributes["questID"]?.Value) ? 0 : int.Parse(node.Attributes["questID"].Value);
-                            metadata.Basic.QuestType = string.IsNullOrEmpty(node.Attributes["questType"]?.Value) ? 0 : byte.Parse(node.Attributes["questType"].Value);
-                            metadata.Basic.Account = string.IsNullOrEmpty(node.Attributes["account"]?.Value) ? 0 : byte.Parse(node.Attributes["account"].Value);
+                            metadata.Basic.QuestType = string.IsNullOrEmpty(node.Attributes["questType"]?.Value) ? (byte) 0 : byte.Parse(node.Attributes["questType"].Value);
+                            metadata.Basic.Account = (byte) (string.IsNullOrEmpty(node.Attributes["account"]?.Value) ? 0 : byte.Parse(node.Attributes["account"].Value));
                             metadata.Basic.StandardLevel = string.IsNullOrEmpty(node.Attributes["standardLevel"]?.Value) ? 0 : int.Parse(node.Attributes["standardLevel"].Value);
-                            metadata.Basic.AutoStart = string.IsNullOrEmpty(node.Attributes["autoStart"]?.Value) ? 0 : byte.Parse(node.Attributes["autoStart"].Value);
-                            metadata.Basic.DisableGiveup = string.IsNullOrEmpty(node.Attributes["disableGiveup"]?.Value) ? 0 : byte.Parse(node.Attributes["disableGiveup"].Value);
+                            metadata.Basic.AutoStart = (byte) (string.IsNullOrEmpty(node.Attributes["autoStart"]?.Value) ? 0 : byte.Parse(node.Attributes["autoStart"].Value));
+                            metadata.Basic.DisableGiveup = (byte) (string.IsNullOrEmpty(node.Attributes["disableGiveup"]?.Value) ? 0 : byte.Parse(node.Attributes["disableGiveup"].Value));
                             metadata.Basic.ExceptChapterClear = string.IsNullOrEmpty(node.Attributes["exceptChapterClear"]?.Value) ? 0 : int.Parse(node.Attributes["exceptChapterClear"].Value);
-                            metadata.Basic.Repeatable = string.IsNullOrEmpty(node.Attributes["repeatable"]?.Value) ? 0 : byte.Parse(node.Attributes["repeatable"].Value);
+                            metadata.Basic.Repeatable = (byte) (string.IsNullOrEmpty(node.Attributes["repeatable"]?.Value) ? 0 : byte.Parse(node.Attributes["repeatable"].Value));
                             metadata.Basic.UsePeriod = node.Attributes["usePeriod"].Value;
                             metadata.Basic.EventTag = node.Attributes["eventTag"].Value;
-                            metadata.Basic.Locking = string.IsNullOrEmpty(node.Attributes["locking"]?.Value) ? 0 : byte.Parse(node.Attributes["locking"].Value);
+                            metadata.Basic.Locking = (byte) (string.IsNullOrEmpty(node.Attributes["locking"]?.Value) ? 0 : byte.Parse(node.Attributes["locking"].Value));
                             metadata.Basic.TabIndex = string.IsNullOrEmpty(node.Attributes["tabIndex"]?.Value) ? 0 : int.Parse(node.Attributes["tabIndex"].Value);
-                            metadata.Basic.ForceRegistGuide = string.IsNullOrEmpty(node.Attributes["forceRegistGuide"]?.Value) ? 0 : byte.Parse(node.Attributes["forceRegistGuide"].Value);
+                            metadata.Basic.ForceRegistGuide = (byte) (string.IsNullOrEmpty(node.Attributes["forceRegistGuide"]?.Value) ? 0 : byte.Parse(node.Attributes["forceRegistGuide"].Value));
                             metadata.Basic.UseNavigation = !(node.Attributes["useNavi"].Value == "FALSE");
                         }
                         else if (node.Name == "notify")
@@ -63,8 +63,8 @@ namespace GameDataParser.Parsers
                         }
                         else if (node.Name == "require")
                         {
-                            metadata.Require.Level = string.IsNullOrEmpty(node.Attributes["level"]?.Value) ? 0 : short.Parse(node.Attributes["level"].Value);
-                            metadata.Require.MaxLevel = string.IsNullOrEmpty(node.Attributes["maxLevel"]?.Value) ? 0 : short.Parse(node.Attributes["maxLevel"].Value);
+                            metadata.Require.Level = (short) (string.IsNullOrEmpty(node.Attributes["level"]?.Value) ? 0 : short.Parse(node.Attributes["level"].Value));
+                            metadata.Require.MaxLevel = (short) (string.IsNullOrEmpty(node.Attributes["maxLevel"]?.Value) ? 0 : short.Parse(node.Attributes["maxLevel"].Value));
 
                             if (!string.IsNullOrEmpty(node.Attributes["job"]?.Value))
                             {
@@ -137,7 +137,7 @@ namespace GameDataParser.Parsers
                             foreach (XmlNode reward in node.ChildNodes)
                             {
                                 int itemid = string.IsNullOrEmpty(reward.Attributes["code"]?.Value) ? 0 : int.Parse(reward.Attributes["code"].Value);
-                                byte rank = string.IsNullOrEmpty(reward.Attributes["rank"]?.Value) ? 0 : byte.Parse(reward.Attributes["rank"].Value);
+                                byte rank = (byte) (string.IsNullOrEmpty(reward.Attributes["rank"]?.Value) ? 0 : byte.Parse(reward.Attributes["rank"].Value));
                                 int count = string.IsNullOrEmpty(reward.Attributes["count"]?.Value) ? 0 : int.Parse(reward.Attributes["count"].Value);
                                 QuestRewardItem item = new QuestRewardItem(itemid, rank, count);
                                 metadata.RewardItem.Add(item);
@@ -158,19 +158,19 @@ namespace GameDataParser.Parsers
                         {
                             metadata.Guide.Type = node.Attributes["guideType"].Value;
                             metadata.Guide.Icon = node.Attributes["guideIcon"].Value;
-                            metadata.Guide.MinLevel = string.IsNullOrEmpty(node.Attributes["guideMinLevel"]?.Value) ? 0 : byte.Parse(node.Attributes["guideMinLevel"].Value);
-                            metadata.Guide.MaxLevel = string.IsNullOrEmpty(node.Attributes["guideMaxLevel"]?.Value) ? 0 : byte.Parse(node.Attributes["guideMaxLevel"].Value);
+                            metadata.Guide.MinLevel = (short) (string.IsNullOrEmpty(node.Attributes["guideMinLevel"]?.Value) ? 0 : byte.Parse(node.Attributes["guideMinLevel"].Value));
+                            metadata.Guide.MaxLevel = (short) (string.IsNullOrEmpty(node.Attributes["guideMaxLevel"]?.Value) ? 0 : byte.Parse(node.Attributes["guideMaxLevel"].Value));
                             metadata.Guide.Group = node.Attributes["guideGroup"]?.Value;
                         }
                         else if (node.Name == "gotoNpc")
                         {
-                            metadata.Npc.Enable = string.IsNullOrEmpty(node.Attributes["enable"]?.Value) ? 0 : byte.Parse(node.Attributes["enable"].Value);
+                            metadata.Npc.Enable = (byte) (string.IsNullOrEmpty(node.Attributes["enable"]?.Value) ? 0 : byte.Parse(node.Attributes["enable"].Value));
                             metadata.Npc.GoToField = string.IsNullOrEmpty(node.Attributes["gotoField"]?.Value) ? 0 : int.Parse(node.Attributes["gotoField"].Value);
                             metadata.Npc.GoToPortal = string.IsNullOrEmpty(node.Attributes["gotoPortal"]?.Value) ? 0 : int.Parse(node.Attributes["gotoPortal"].Value);
                         }
                         else if (node.Name == "gotoDungeon")
                         {
-                            metadata.Dungeon.State = string.IsNullOrEmpty(node.Attributes["state"]?.Value) ? 0 : byte.Parse(node.Attributes["state"].Value);
+                            metadata.Dungeon.State = (byte) (string.IsNullOrEmpty(node.Attributes["state"]?.Value) ? 0 : byte.Parse(node.Attributes["state"].Value));
                             metadata.Dungeon.GoToDungeon = string.IsNullOrEmpty(node.Attributes["gotoDungeon"]?.Value) ? 0 : int.Parse(node.Attributes["gotoDungeon"].Value);
                             metadata.Dungeon.GoToInstanceID = string.IsNullOrEmpty(node.Attributes["gotoInstanceID"]?.Value) ? 0 : int.Parse(node.Attributes["gotoInstanceID"].Value);
                         }

--- a/GameDataParser/Parsers/ScriptParser.cs
+++ b/GameDataParser/Parsers/ScriptParser.cs
@@ -57,7 +57,7 @@ namespace GameDataParser.Parsers
                         string illust = string.IsNullOrEmpty(content.Attributes["illust"]?.Value) ? "" : content.Attributes["illust"].Value;
                         string speakerIllust = string.IsNullOrEmpty(content.Attributes["speakerIllust"]?.Value) ? "" : content.Attributes["speakerIllust"].Value;
                         bool myTalk = !string.IsNullOrEmpty(content.Attributes["myTalk"]?.Value);
-                        byte functionID = string.IsNullOrEmpty(content.Attributes["functionID"]?.Value) ? 0 : byte.Parse(content.Attributes["functionID"].Value);
+                        byte functionID = (byte) (string.IsNullOrEmpty(content.Attributes["functionID"]?.Value) ? 0 : byte.Parse(content.Attributes["functionID"].Value));
 
                         List<Distractor> distractors = new List<Distractor>();
                         List<Event> events = new List<Event>();
@@ -76,7 +76,7 @@ namespace GameDataParser.Parsers
                                     string illust2 = string.IsNullOrEmpty(item.Attributes["illust"]?.Value) ? "" : item.Attributes["illust"].Value;
                                     string speakerIllust2 = string.IsNullOrEmpty(item.Attributes["speakerIllust"]?.Value) ? "" : item.Attributes["speakerIllust"].Value;
                                     bool myTalk2 = !string.IsNullOrEmpty(item.Attributes["myTalk"]?.Value);
-                                    byte functionID2 = string.IsNullOrEmpty(item.Attributes["functionID"]?.Value) ? 0 : byte.Parse(item.Attributes["functionID"].Value);
+                                    byte functionID2 = (byte) (string.IsNullOrEmpty(item.Attributes["functionID"]?.Value) ? 0 : byte.Parse(item.Attributes["functionID"].Value));
 
                                     contents2.Add(new Content(voiceID2, functionID2, leftIllust2, speakerIllust2, otherNpcTalk2, myTalk2, illust2, null));
                                 }
@@ -178,7 +178,7 @@ namespace GameDataParser.Parsers
                             string illust = string.IsNullOrEmpty(content.Attributes["illust"]?.Value) ? "" : content.Attributes["illust"].Value;
                             string speakerIllust = string.IsNullOrEmpty(content.Attributes["speakerIllust"]?.Value) ? "" : content.Attributes["speakerIllust"].Value;
                             bool myTalk = !string.IsNullOrEmpty(content.Attributes["myTalk"]?.Value);
-                            byte functionID = string.IsNullOrEmpty(content.Attributes["functionID"]?.Value) ? 0 : byte.Parse(content.Attributes["functionID"].Value);
+                            byte functionID = (byte) (string.IsNullOrEmpty(content.Attributes["functionID"]?.Value) ? 0 : byte.Parse(content.Attributes["functionID"].Value));
 
                             List<Distractor> distractors = new List<Distractor>();
                             List<Event> events = new List<Event>();
@@ -197,7 +197,7 @@ namespace GameDataParser.Parsers
                                         string illust2 = string.IsNullOrEmpty(item.Attributes["illust"]?.Value) ? "" : item.Attributes["illust"].Value;
                                         string speakerIllust2 = string.IsNullOrEmpty(item.Attributes["speakerIllust"]?.Value) ? "" : item.Attributes["speakerIllust"].Value;
                                         bool myTalk2 = !string.IsNullOrEmpty(item.Attributes["myTalk"]?.Value);
-                                        byte functionID2 = string.IsNullOrEmpty(item.Attributes["functionID"]?.Value) ? 0 : byte.Parse(item.Attributes["functionID"].Value);
+                                        byte functionID2 = (byte) (string.IsNullOrEmpty(item.Attributes["functionID"]?.Value) ? 0 : byte.Parse(item.Attributes["functionID"].Value));
 
                                         contents2.Add(new Content(voiceID2, functionID2, leftIllust2, speakerIllust2, otherNpcTalk2, myTalk2, illust2, null));
                                     }


### PR DESCRIPTION
This should cover every ternary operator together with #210 