### PR TITLE
Party fixes

### DIFF
--- a/MapleServer2/Enums/PartyNotice.cs
+++ b/MapleServer2/Enums/PartyNotice.cs
@@ -1,0 +1,39 @@
+﻿namespace MapleServer2.Enums
+{
+    public enum PartyNotice : byte
+    {
+        AcceptedInvite = 0x1,  //needs confirmation?
+        NotLeader = 0x4,
+        PartyAlreadyMade = 0x5,
+        RefusedInvite = 0x9,
+        InviteSelf = 0xB,
+        NoResponseInvite = 0xC,
+        UnableToInvite = 0xD,
+        CannotAcceptInvite = 0xE,
+        UserAlreadyReceivedRequest = 0xF,
+        EntryRequirementsNotMet = 0x10,
+        MinimumLevelNotMet = 0x11,
+        MinimumGearScoreNotMet = 0x12,
+        FullParty = 0x13,
+        RecruitmentListingDeleted = 0x16,
+        OutdatedRecruitmentListing = 0x17,
+        InsufficientMerets = 0x1B,
+        InviteAlreadyReceived = 0x1C,
+        UnableToResetDungeon = 0x1D,
+        UnableToInviteInDungeonBoss = 0x1E,
+        PartyNotFound = 0x1F,
+        RequestToJoin = 0x20,
+        AnotherRequestInProgress = 0x21,
+        InsufficientMemberCountForKickVote = 0x22,
+        KickVoteCooldown = 0x23,
+        UnableToKickInDungeonBoss = 0x26,
+        UnableToKickUserInMushkingRoyale = 0x27,
+        LeaderOnlyRequest = 0x28,
+        MemberDisconnected = 0x29, // pop up notice
+        MemberInDungeon = 0x2A,
+        CurrentlyMatching = 0x2B,
+        MemberOffline = 0x2D,
+        MemberInMushkingRoyale = 0x30,
+        MushkingRoyaleMaxSquad = 0x31,
+    }
+}

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -51,7 +51,6 @@ namespace MapleServer2.PacketHandlers.Game
 
             session.Send(DungeonPacket.UpdateDungeonInfo(3, dungeonId));
             // session.Send(DungeonPacket.UpdateDungeon(dungeonId, toggle));
-
         }
 
         private static void HandleGetHelp(GameSession session, PacketReader packet)
@@ -66,14 +65,14 @@ namespace MapleServer2.PacketHandlers.Game
                 session.Send(PartyPacket.Create(newParty));
                 session.Send(PartyPacket.PartyHelp(dungeonId));
                 MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(newParty, dungeonId));
-            }
-            else
-            {
-                Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
 
-                party.BroadcastPacketParty(PartyPacket.PartyHelp(dungeonId));
-                MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(party, dungeonId));
+                return;
             }
+
+            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+
+            party.BroadcastPacketParty(PartyPacket.PartyHelp(dungeonId));
+            MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(party, dungeonId));
         }
 
         private static void HandleVeteran(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -1,0 +1,96 @@
+﻿using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Packets;
+using MapleServer2.Servers.Game;
+using MapleServer2.Types;
+using Microsoft.Extensions.Logging;
+
+namespace MapleServer2.PacketHandlers.Game
+{
+    public class DungeonHandler : GamePacketHandler
+    {
+        public override RecvOp OpCode => RecvOp.ROOM_DUNGEON;
+
+        public DungeonHandler(ILogger<DungeonHandler> logger) : base(logger) { }
+
+        private enum DungeonMode : byte
+        {
+            AddRewards = 0x8,
+            GetHelp = 0x10,
+            Veteran = 0x11,
+            Favorite = 0x19,
+        }
+
+        public override void Handle(GameSession session, PacketReader packet)
+        {
+            DungeonMode mode = (DungeonMode) packet.ReadByte();
+
+            switch (mode)
+            {
+                case DungeonMode.AddRewards:
+                    HandleAddRewards(session, packet);
+                    break;
+                case DungeonMode.GetHelp:
+                    HandleGetHelp(session, packet);
+                    break;
+                case DungeonMode.Veteran:
+                    HandleVeteran(session, packet);
+                    break;
+                case DungeonMode.Favorite:
+                    HandleFavorite(session, packet);
+                    break;
+                default:
+                    IPacketHandler<GameSession>.LogUnknownMode(mode);
+                    break;
+            }
+        }
+
+        private static void HandleAddRewards(GameSession session, PacketReader packet)
+        {
+            int dungeonId = packet.ReadInt();
+
+            session.Send(DungeonPacket.UpdateDungeonInfo(3, dungeonId));
+            // session.Send(DungeonPacket.UpdateDungeon(dungeonId, toggle));
+
+        }
+
+        private static void HandleGetHelp(GameSession session, PacketReader packet)
+        {
+            int dungeonId = packet.ReadInt();
+
+            if (session.Player.PartyId == 0)
+            {
+                Party newParty = new(session.Player);
+                GameServer.PartyManager.AddParty(newParty);
+
+                session.Send(PartyPacket.Create(newParty));
+                session.Send(PartyPacket.PartyHelp(dungeonId));
+                MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(newParty, dungeonId));
+            }
+            else
+            {
+                Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+
+                party.BroadcastPacketParty(PartyPacket.PartyHelp(dungeonId));
+                MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(party, dungeonId));
+            }
+        }
+
+        private static void HandleVeteran(GameSession session, PacketReader packet)
+        {
+            int dungeonId = packet.ReadInt();
+
+            session.Send(DungeonPacket.UpdateDungeonInfo(4, dungeonId));
+            // session.Send(DungeonPacket.UpdateDungeon(dungeonId, toggle));
+        }
+
+        private static void HandleFavorite(GameSession session, PacketReader packet)
+        {
+            int dungeonId = packet.ReadInt();
+            byte toggle = packet.ReadByte();
+
+            session.Send(DungeonPacket.UpdateDungeonInfo(5, dungeonId));
+            // session.Send(DungeonPacket.UpdateDungeon(dungeonId, toggle));
+        }
+    }
+}

--- a/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
@@ -55,16 +55,16 @@ namespace MapleServer2.PacketHandlers.Game
         {
             string partyName = packet.ReadUnicodeString();
             bool approval = packet.ReadBool();
-            int maxMembers = packet.ReadInt();
+            int memberCountRecruit = packet.ReadInt();
 
             Party party = GameServer.PartyManager.GetPartyByLeader(session.Player);
 
             if (party == null)
             {
-                Party newParty = new(maxMembers, new List<Player> { session.Player }, partyName, approval);
+                Party newParty = new(partyName, approval, session.Player, memberCountRecruit);
                 GameServer.PartyManager.AddParty(newParty);
 
-                session.Send(PartyPacket.Create(session.Player));
+                session.Send(PartyPacket.Create(newParty));
                 session.Send(PartyPacket.UpdateHitpoints(session.Player));
 
                 session.Player.PartyId = newParty.Id;
@@ -72,22 +72,18 @@ namespace MapleServer2.PacketHandlers.Game
             }
             else
             {
+                if (party.Members.Count >= memberCountRecruit)
+                {
+                    return;
+                }
                 party.PartyFinderId = GuidGenerator.Long();
                 party.Name = partyName;
                 party.Approval = approval;
-                party.MaxMembers = maxMembers;
+                party.RecruitMemberCount = memberCountRecruit;
             }
 
             party.BroadcastPacketParty(MatchPartyPacket.CreateListing(party));
-            party.BroadcastPacketParty(PartyPacket.MatchParty(party));
-
-            if (party.Members.Count < maxMembers)
-            {
-                return;
-            }
-
-            session.Send(ChatPacket.Send(session.Player, "The party is full.", ChatType.NoticeAlert2));
-            HandleRemoveListing(session);
+            party.BroadcastPacketParty(PartyPacket.MatchParty(party, true));
         }
 
         public static void HandleRemoveListing(GameSession session)
@@ -99,10 +95,15 @@ namespace MapleServer2.PacketHandlers.Game
             }
 
             party.BroadcastPacketParty(MatchPartyPacket.RemoveListing(party));
-            party.PartyFinderId = 0;
-            party.BroadcastPacketParty(PartyPacket.MatchParty(null));
 
-            party.CheckDisband();
+            if (party.Members.Count == 1)
+            {
+                party.RemoveMember(session.Player);
+                return;
+            }
+
+            party.PartyFinderId = 0;
+            party.BroadcastPacketParty(PartyPacket.MatchParty(null, false));
         }
 
         public static void HandleRefresh(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
-using MapleServer2.Enums;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
 using MapleServer2.Tools;

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MaplePacketLib2.Tools;
+﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Enums;
 using MapleServer2.Packets;
@@ -112,7 +109,7 @@ namespace MapleServer2.PacketHandlers.Game
 
                 other.Session.Send(PartyPacket.SendInvite(session.Player, party));
             }
-            else if (session.Player.PartyId == 0)
+            else
             {
                 if (other.PartyId != 0)
                 {
@@ -130,7 +127,6 @@ namespace MapleServer2.PacketHandlers.Game
 
                     session.Send(PartyPacket.Notice(other, PartyNotice.RequestToJoin));
                     otherParty.Leader.Session.Send(PartyPacket.JoinRequest(session.Player));
-
                     return;
                 }
                 else
@@ -355,7 +351,7 @@ namespace MapleServer2.PacketHandlers.Game
             session.Send(PartyPacket.DungeonFindParty());
         }
 
-        private static void CancelFindDungeonParty(GameSession session, PacketReader packet)
+        private static void CancelFindDungeonParty(GameSession session)
         {
             Party party = GameServer.PartyManager.GetPartyByLeader(session.Player);
             if (party == null)

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -193,20 +193,19 @@ namespace MapleServer2.PacketHandlers.Game
                 session.Send(PartyPacket.Create(party));
                 party.BroadcastPacketParty(PartyPacket.UpdateHitpoints(party.Leader));
                 party.BroadcastPacketParty(PartyPacket.UpdatePlayer(session.Player));
+                return;
             }
-            else
-            {
-                party.BroadcastPacketParty(PartyPacket.Join(session.Player));
-                party.AddMember(session.Player);
-                session.Send(PartyPacket.Create(party));
-                party.BroadcastPacketParty(PartyPacket.UpdatePlayer(session.Player));
 
-                foreach (Player member in party.Members)
+            party.BroadcastPacketParty(PartyPacket.Join(session.Player));
+            party.AddMember(session.Player);
+            session.Send(PartyPacket.Create(party));
+            party.BroadcastPacketParty(PartyPacket.UpdatePlayer(session.Player));
+
+            foreach (Player member in party.Members)
+            {
+                if (member != session.Player)
                 {
-                    if (member != session.Player)
-                    {
-                        party.BroadcastPacketParty(PartyPacket.UpdateHitpoints(member));
-                    }
+                    party.BroadcastPacketParty(PartyPacket.UpdateHitpoints(member));
                 }
             }
         }

--- a/MapleServer2/Packets/CharacterListPacket.cs
+++ b/MapleServer2/Packets/CharacterListPacket.cs
@@ -106,8 +106,8 @@ namespace MapleServer2.Packets
             pWriter.WriteShort();
             pWriter.WriteEnum(player.Job);
             pWriter.WriteEnum(player.JobCode);
-            pWriter.WriteInt(); // CurHp?
-            pWriter.WriteInt(); // MaxHp?
+            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Current);
+            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Max);
             pWriter.WriteShort();
             pWriter.WriteLong();
             pWriter.WriteLong(); // Some timestamp

--- a/MapleServer2/Packets/DungeonHelperPacket.cs
+++ b/MapleServer2/Packets/DungeonHelperPacket.cs
@@ -1,0 +1,44 @@
+﻿using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Types;
+
+namespace MapleServer2.Packets
+{
+
+    public static class DungeonHelperPacket
+    {
+        private enum DungeonHelperPacketMode : byte
+        {
+            BroadcastAssist = 0x0,
+            DisplayVetAndRookie = 0x1,
+        }
+
+        public static Packet BroadcastAssist(Party party, int dungeonId)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.DUNGEON_HELPER);
+            pWriter.WriteEnum(DungeonHelperPacketMode.BroadcastAssist);
+            pWriter.WriteInt(party.Id);
+            pWriter.WriteUnicodeString("");
+            pWriter.WriteLong(); // unk
+            pWriter.WriteLong(); // unk
+            pWriter.WriteInt(dungeonId);
+            pWriter.WriteByte((byte) party.Members.Count);
+            return pWriter;
+        }
+
+        public static Packet DisplayVetAndRookie(Party party)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.DUNGEON_HELPER);
+            pWriter.WriteEnum(DungeonHelperPacketMode.DisplayVetAndRookie);
+            pWriter.WriteByte(); // rookie count
+            pWriter.WriteByte(); // veteran count
+            pWriter.WriteInt(party.Id);
+            pWriter.WriteUnicodeString(party.Leader.Name);
+            pWriter.WriteLong(); // unk
+            pWriter.WriteLong(); // unk
+            pWriter.WriteInt(); // dungeonId
+            pWriter.WriteByte((byte) party.Members.Count);
+            return pWriter;
+        }
+    }
+}

--- a/MapleServer2/Packets/DungeonPacket.cs
+++ b/MapleServer2/Packets/DungeonPacket.cs
@@ -1,0 +1,44 @@
+﻿using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+
+namespace MapleServer2.Packets
+{
+
+    public static class DungeonPacket
+    {
+        private enum DungeonPacketMode : byte
+        {
+            DungeonInfo = 0x6,
+            UpdateDungeonInfo = 0x7,
+        }
+
+        public static Packet DungeonInfo(int dungeonId, byte weeklyClearCountMax, byte addRewards, int clearCount, short lifetimeRecord, byte toggle)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.ROOM_DUNGEON);
+            pWriter.WriteEnum(DungeonPacketMode.DungeonInfo);
+            pWriter.WriteInt(dungeonId);
+            pWriter.WriteLong(0); //timestamp
+            pWriter.WriteByte(weeklyClearCountMax);
+            pWriter.WriteByte();
+            pWriter.WriteLong(0); //timestamp
+            pWriter.WriteByte(addRewards);
+            pWriter.WriteByte();
+            pWriter.WriteLong(0); //timestamp
+            pWriter.WriteInt(clearCount);
+            pWriter.WriteShort(lifetimeRecord);
+            pWriter.WriteLong(0); //timestamp
+            pWriter.WriteShort(lifetimeRecord);
+            pWriter.WriteByte(toggle); // tbd
+            return pWriter;
+        }
+
+        public static Packet UpdateDungeonInfo(byte mode, int dungeonId)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.ROOM_DUNGEON);
+            pWriter.WriteEnum(DungeonPacketMode.UpdateDungeonInfo);
+            pWriter.WriteByte(mode); //05 = favorite, 04 = become veteran
+            pWriter.WriteInt(dungeonId);
+            return pWriter;
+        }
+    }
+}

--- a/MapleServer2/Packets/MatchPartyPacket.cs
+++ b/MapleServer2/Packets/MatchPartyPacket.cs
@@ -58,7 +58,7 @@ namespace MapleServer2.Packets
             pWriter.WriteUnicodeString(party.Name);
             pWriter.WriteBool(party.Approval);
             pWriter.WriteInt(party.Members.Count);
-            pWriter.WriteInt(party.MaxMembers);
+            pWriter.WriteInt(party.RecruitMemberCount);
             pWriter.WriteLong(party.Leader.AccountId);
             pWriter.WriteLong(party.Leader.CharacterId);
             pWriter.WriteUnicodeString(party.Leader.Name);

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Enums;
 using MapleServer2.Types;
 
 namespace MapleServer2.Packets
@@ -10,19 +11,34 @@ namespace MapleServer2.Packets
     {
         private enum PartyPacketMode : byte
         {
+            Notice = 0x0,
             Join = 0x2,
             Leave = 0x3,
             Kick = 0x4,
+            LoginNotice = 0x5,
+            LogoutNotice = 0x6,
             Disband = 0x7,
             SetLeader = 0x8,
             Create = 0x9,
             Invite = 0xB,
             UpdatePlayer = 0xD,
             UpdateHitpoints = 0x13,
+            PartyHelp = 0x19,
             MatchParty = 0x1A,
+            DungeonFindParty = 0x1E,
+            JoinRequest = 0x2C,
             StartReadyCheck = 0x2F,
             ReadyCheck = 0x30,
             EndReadyCheck = 0x31
+        }
+
+        public static Packet Notice(Player player, PartyNotice notice)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
+            pWriter.WriteEnum(PartyPacketMode.Notice);
+            pWriter.WriteEnum(notice);
+            pWriter.WriteUnicodeString(player.Name);
+            return pWriter;
         }
 
         public static Packet Join(Player player)
@@ -56,50 +72,49 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        //Generates the header code for Create
-        public static void CreatePartyHeader(Player player, PacketWriter pWriter, short members)
-        {
-            pWriter.WriteEnum(PartyPacketMode.Create);
-            pWriter.WriteByte();
-            pWriter.WriteInt();
-            pWriter.WriteLong(player.CharacterId);
-            pWriter.WriteShort(members); //# of Party member. but it's scuffed atm
-        }
-
-        public static Packet Create(Player leader)
+        public static Packet Create(Party party)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
+            pWriter.WriteEnum(PartyPacketMode.Create);
+            pWriter.WriteByte(1);
+            pWriter.WriteInt(party.Id);
+            pWriter.WriteLong(party.Leader.CharacterId);
+            pWriter.WriteByte((byte) party.Members.Count);
 
-            CreatePartyHeader(leader, pWriter, 1);
+            foreach (Player member in party.Members)
+            {
+                pWriter.WriteByte(0);
+                CharacterListPacket.WriteCharacter(member, pWriter);
+                pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
+                pWriter.WriteInt(); // dungeonID
+                pWriter.WriteByte(); // dungeon clear count
+            }
 
-            CharacterListPacket.WriteCharacter(leader, pWriter);
+            pWriter.WriteByte();
+            pWriter.WriteInt();
+            pWriter.WriteByte();
+            pWriter.WriteByte();
+            pWriter.WriteByte();
+            return pWriter;
+        }
+
+        public static Packet LoginNotice(Player player)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
+            pWriter.WriteEnum(PartyPacketMode.LoginNotice);
+            CharacterListPacket.WriteCharacter(player, pWriter);
             pWriter.WriteLong();
             pWriter.WriteInt();
             pWriter.WriteShort();
             pWriter.WriteByte();
-            JobPacket.WriteSkills(pWriter, leader);
-            pWriter.WriteLong();
-
             return pWriter;
         }
 
-        public static Packet CreateExisting(Player leader, List<Player> members)
+        public static Packet LogoutNotice(Player player)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
-
-            CreatePartyHeader(leader, pWriter, (short) members.Count);
-
-            foreach (Player member in members)
-            {
-                CharacterListPacket.WriteCharacter(member, pWriter);
-                pWriter.WriteLong();
-                pWriter.WriteInt();
-                pWriter.WriteShort();
-                pWriter.WriteByte();
-                JobPacket.WriteSkills(pWriter, member);
-            }
-            pWriter.WriteLong();
-
+            pWriter.WriteEnum(PartyPacketMode.LogoutNotice);
+            pWriter.WriteLong(player.CharacterId);
             return pWriter;
         }
 
@@ -107,7 +122,6 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.Disband);
-
             return pWriter;
         }
 
@@ -120,15 +134,12 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet SendInvite(Player sender)
+        public static Packet SendInvite(Player sender, Party party)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.Invite);
             pWriter.WriteUnicodeString(sender.Name);
-            pWriter.WriteShort(); //Unk
-            pWriter.WriteByte(); //Unk
-            pWriter.WriteByte(); //Unk
-
+            pWriter.WriteInt(party.Id);
             return pWriter;
         }
 
@@ -139,9 +150,9 @@ namespace MapleServer2.Packets
             pWriter.WriteLong(player.CharacterId);
 
             CharacterListPacket.WriteCharacter(player, pWriter);
-            pWriter.WriteInt();
-            JobPacket.WriteSkills(pWriter, player);
-            pWriter.WriteLong();
+            pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
+            pWriter.WriteInt(); // dungeonID
+            pWriter.WriteByte(); // dungeon clear count
 
             return pWriter;
         }
@@ -153,27 +164,65 @@ namespace MapleServer2.Packets
             pWriter.WriteLong(player.CharacterId);
             pWriter.WriteLong(player.AccountId);
             pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Max);
-            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Min);
+            pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Current);
             pWriter.WriteShort();
 
             return pWriter;
         }
 
-        public static Packet MatchParty(Party party)
+        public static Packet PartyHelp(int dungeonId)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
+            pWriter.WriteEnum(PartyPacketMode.PartyHelp);
+            pWriter.WriteByte(0);
+            pWriter.WriteInt(dungeonId);
+            return pWriter;
+        }
+
+        public static Packet MatchParty(Party party, bool createListing)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.MatchParty);
-            if (party == null)
+            pWriter.WriteBool(createListing);
+            if (createListing)
             {
-                pWriter.WriteByte();
+                pWriter.WriteLong(party.PartyFinderId);
+                pWriter.WriteInt(party.Id);
+                pWriter.WriteInt();
+                pWriter.WriteInt();
+                pWriter.WriteUnicodeString(party.Name);
+                pWriter.WriteBool(party.Approval);
+                pWriter.WriteInt(party.Members.Count);
+                pWriter.WriteInt(party.RecruitMemberCount);
+                pWriter.WriteLong(party.Leader.AccountId);
+                pWriter.WriteLong(party.Leader.CharacterId);
+                pWriter.WriteUnicodeString(party.Leader.Name);
+                pWriter.WriteLong(party.CreationTimestamp);
             }
             else
             {
-                MatchPartyPacket.WritePartyInformation(pWriter, party);
+                pWriter.WriteByte(0);
             }
 
             return pWriter;
         }
+
+        public static Packet DungeonFindParty()
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
+            pWriter.WriteEnum(PartyPacketMode.DungeonFindParty);
+            pWriter.WriteInt(); // dungeon queue Id
+            return pWriter;
+        }
+
+        public static Packet JoinRequest(Player player)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
+            pWriter.WriteEnum(PartyPacketMode.JoinRequest);
+            pWriter.WriteUnicodeString(player.Name);
+            return pWriter;
+        }
+
 
         public static Packet StartReadyCheck(Player leader, List<Player> members, int count)
         {

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -49,7 +49,6 @@ namespace MapleServer2.Packets
             pWriter.WriteInt();
             JobPacket.WriteSkills(pWriter, player);
             pWriter.WriteLong();
-
             return pWriter;
         }
 
@@ -59,7 +58,6 @@ namespace MapleServer2.Packets
             pWriter.WriteEnum(PartyPacketMode.Leave);
             pWriter.WriteLong(player.CharacterId);
             pWriter.WriteByte(self); //0 = Other leaving, 1 = Self leaving
-
             return pWriter;
         }
 
@@ -68,7 +66,6 @@ namespace MapleServer2.Packets
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.Kick);
             pWriter.WriteLong(player.CharacterId);
-
             return pWriter;
         }
 
@@ -130,7 +127,6 @@ namespace MapleServer2.Packets
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.SetLeader);
             pWriter.WriteLong(player.CharacterId);
-
             return pWriter;
         }
 
@@ -153,7 +149,6 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
             pWriter.WriteInt(); // dungeonID
             pWriter.WriteByte(); // dungeon clear count
-
             return pWriter;
         }
 
@@ -166,7 +161,6 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Max);
             pWriter.WriteInt(player.Stats[PlayerStatId.Hp].Current);
             pWriter.WriteShort();
-
             return pWriter;
         }
 
@@ -223,7 +217,6 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-
         public static Packet StartReadyCheck(Player leader, List<Player> members, int count)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
@@ -240,7 +233,6 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(1); //unk
             pWriter.WriteLong(leader.CharacterId);
             pWriter.WriteInt(); //unk
-
             return pWriter;
         }
 
@@ -250,7 +242,6 @@ namespace MapleServer2.Packets
             pWriter.WriteEnum(PartyPacketMode.ReadyCheck);
             pWriter.WriteLong(player.CharacterId);
             pWriter.WriteByte(accept);
-
             return pWriter;
         }
 
@@ -258,7 +249,6 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.EndReadyCheck);
-
             return pWriter;
         }
     }

--- a/MapleServer2/Tools/PartyManager.cs
+++ b/MapleServer2/Tools/PartyManager.cs
@@ -25,7 +25,7 @@ namespace MapleServer2.Tools
 
         public List<Party> GetPartyFinderList()
         {
-            return PartyList.Cast<Party>().Where(party => party.PartyFinderId != 0).ToList();
+            return PartyList.Values.Where(party => party.PartyFinderId != 0).ToList();
         }
 
         public Party GetPartyById(long id)


### PR DESCRIPTION
The biggest changes to parties are the following four points:
1. Writing HP of the player in the WriteCharacter packet. This solves needing to send unnecessary packets to the player upon first joining a party.
2. Implement the ability to request to join a party if a party exists.
3. Above all else, when you invite players to a new party or by making a recruitment listing, the server makes a party in order for the other player(s) to join. We're treating a party of 1 as if the player is _not_ in a party. This allows players to invite others to a party if they've already established a 1 player party (i.e. if player a invites player b to a new party, but player c invites player a).
4. Implemented `PartyNotice` for the various different errors parties come across.

Party kicking and party matching (for dungeons) is not yet implemented.
Initial dungeon handler and packets added. Still very much a WIP. Main focus of these were party handling.

#85 