### PR TITLE
Fix: Attack on npcStats should be Accuracy.

### DIFF
--- a/GameDataParser/Parsers/NpcParser.cs
+++ b/GameDataParser/Parsers/NpcParser.cs
@@ -118,7 +118,7 @@ namespace GameDataParser.Parsers
             npcStats.EpInv = new NpcStat<int>(int.Parse(collection["ep_inv"].Value));
             npcStats.AtkSpd = new NpcStat<int>(int.Parse(collection["asp"].Value));
             npcStats.MoveSpd = new NpcStat<int>(int.Parse(collection["msp"].Value));
-            npcStats.Attack = new NpcStat<int>(int.Parse(collection["atp"].Value));
+            npcStats.Accuracy = new NpcStat<int>(int.Parse(collection["atp"].Value));
             npcStats.Evasion = new NpcStat<int>(int.Parse(collection["evp"].Value));
             npcStats.Cap = new NpcStat<int>(int.Parse(collection["cap"].Value));
             npcStats.Cad = new NpcStat<int>(int.Parse(collection["cad"].Value));

--- a/Maple2Storage/Types/NpcStats.cs
+++ b/Maple2Storage/Types/NpcStats.cs
@@ -37,7 +37,7 @@ namespace Maple2Storage.Types
         [XmlElement(Order = 15)]
         public NpcStat<int> MoveSpd;
         [XmlElement(Order = 16)]
-        public NpcStat<int> Attack;
+        public NpcStat<int> Accuracy;
         [XmlElement(Order = 17)]
         public NpcStat<int> Evasion;
         [XmlElement(Order = 18)]


### PR DESCRIPTION
This PR proposes just a minor change that I almost overlooked when understanding the parsers. An `atp` tag indicates `Accuracy` instead of `Attack`, in the same way it is proposed by `ItemOptionRangeParser`.

Additionally, I have checked some of the values in the parsed output and they indeed correspond to the accuracy attribute, e.g., [slime](https://maplestory2.fandom.com/wiki/Slime) has 80 acc instead of 80 atk.