### PR TITLE
Safe Return Teleporting

### DIFF
--- a/MapleServer2/Data/Static/MapEntityStorage.cs
+++ b/MapleServer2/Data/Static/MapEntityStorage.cs
@@ -89,6 +89,12 @@ namespace MapleServer2.Data.Static
             return boundingBox.GetValueOrDefault(mapId);
         }
 
+        public static bool HasSafePortal(int mapId)
+        {
+            List<MapPortal> items = portals.GetValueOrDefault(mapId).Where(x => x.TargetPortalId != 0).ToList();
+            return items.Count != 0;
+        }
+
         public static bool HasHealingSpot(int mapId)
         {
             return healthSpot.GetValueOrDefault(mapId).Count != 0;

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -30,6 +30,7 @@ namespace MapleServer2.PacketHandlers.Game
             ModifyExistingBeauty = 0x5,
             ModifySkin = 0x6,
             RandomHair = 0x7,
+            Teleport = 0xA,
             ChooseRandomHair = 0xC,
             SaveHair = 0x10,
             DeleteSavedHair = 0x12,
@@ -63,6 +64,9 @@ namespace MapleServer2.PacketHandlers.Game
                     break;
                 case BeautyMode.SaveHair:
                     HandleSaveHair(session, packet);
+                    break;
+                case BeautyMode.Teleport:
+                    HandleTeleport(session, packet);
                     break;
                 case BeautyMode.DeleteSavedHair:
                     HandleDeleteSavedHair(session, packet);
@@ -316,6 +320,30 @@ namespace MapleServer2.PacketHandlers.Game
             session.Player.HairInventory.SavedHair.Add(hairCopy);
 
             session.Send(BeautyPacket.SaveHair(hair, hairCopy));
+        }
+
+        private static void HandleTeleport(GameSession session, PacketReader packet)
+        {
+            byte teleportId = packet.ReadByte();
+
+            Map mapId;
+            switch (teleportId)
+            {
+                case 1:
+                    mapId = Map.RosettaBeautySalon;
+                    break;
+                case 3:
+                    mapId = Map.TriaPlasticSurgery;
+                    break;
+                case 5:
+                    mapId = Map.DouglasDyeWorkshop;
+                    break;
+                default:
+                    Console.WriteLine($"teleportId: {teleportId} not found");
+                    return;
+            }
+
+            MoveFieldHandler.HandleInstanceMove(session, (int) mapId);
         }
 
         private static void HandleDeleteSavedHair(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -37,11 +37,22 @@ namespace MapleServer2.PacketHandlers.Game
                     return;
                 }
 
+                if (!MapEntityStorage.HasSafePortal(srcMapId)) // map is instance only
+                {
+                    session.Player.MapId = session.Player.ReturnMapId;
+                    session.Player.Rotation = session.FieldPlayer.Rotation;
+                    session.Player.Coord = session.Player.ReturnCoord;
+                    session.Player.ReturnCoord.Z += Block.BLOCK_SIZE;
+                    session.Send(FieldPacket.RequestEnter(session.FieldPlayer));
+                    return;
+                }
+
                 MapPortal dstPortal = MapEntityStorage.GetPortals(srcPortal.Target)
                     .FirstOrDefault(portal => portal.Target == srcMapId);
                 if (dstPortal == default)
                 {
-                    Logger.Warning($"Unable to find return portal to map:{srcMapId} in map:{srcPortal.Target}");
+                    session.Player.ReturnCoord = session.FieldPlayer.Coord;
+                    session.Player.ReturnMapId = session.Player.MapId;
                 }
 
                 dstPortal = MapEntityStorage.GetPortals(srcPortal.Target)
@@ -59,19 +70,19 @@ namespace MapleServer2.PacketHandlers.Game
 
                 if (dstPortal.Name == "Portal_cube") // spawn on the next block if portal is a cube
                 {
-                    if (dstPortal.Rotation.Z == 0) // Facing SE
+                    if (dstPortal.Rotation.Z == Direction.SOUTH_EAST)
                     {
                         session.Player.Coord.Y -= Block.BLOCK_SIZE;
                     }
-                    else if (dstPortal.Rotation.Z == 90) // Facing NE
+                    else if (dstPortal.Rotation.Z == Direction.NORTH_EAST)
                     {
                         session.Player.Coord.X += Block.BLOCK_SIZE;
                     }
-                    else if (dstPortal.Rotation.Z == 180) // Facing NW
+                    else if (dstPortal.Rotation.Z == Direction.NORTH_WEST)
                     {
                         session.Player.Coord.Y += Block.BLOCK_SIZE;
                     }
-                    else if (dstPortal.Rotation.Z == 270) // Facing SW
+                    else if (dstPortal.Rotation.Z == Direction.SOUTH_WEST)
                     {
                         session.Player.Coord.X -= Block.BLOCK_SIZE;
                     }
@@ -80,6 +91,28 @@ namespace MapleServer2.PacketHandlers.Game
                 session.Player.SafeBlock = session.Player.Coord;
                 session.Send(FieldPacket.RequestEnter(session.FieldPlayer));
             }
+        }
+
+        public static void HandleInstanceMove(GameSession session, int mapId)
+        {
+            // TODO: Revise to include instancing
+
+            if (MapEntityStorage.HasSafePortal(session.Player.MapId))
+            {
+                session.Player.ReturnCoord = session.FieldPlayer.Coord;
+                session.Player.ReturnMapId = session.Player.MapId;
+            }
+
+            MapPortal dstPortal = MapEntityStorage.GetPortals(mapId).First(x => x.Id == 1);
+            if (dstPortal == null)
+            {
+                return;
+            }
+
+            session.Player.MapId = mapId;
+            session.Player.Rotation = dstPortal.Rotation.ToFloat();
+            session.Player.Coord = dstPortal.Coord.ToFloat();
+            session.Send(FieldPacket.RequestEnter(session.FieldPlayer));
         }
     }
 }

--- a/MapleServer2/Packets/CharacterListPacket.cs
+++ b/MapleServer2/Packets/CharacterListPacket.cs
@@ -97,7 +97,7 @@ namespace MapleServer2.Packets
             pWriter.WriteByte(player.Gender);
             pWriter.WriteByte(1);
 
-            pWriter.WriteLong();
+            pWriter.WriteLong(player.AccountId);
             pWriter.WriteInt();
             pWriter.WriteInt(player.MapId);
             pWriter.WriteInt(player.MapId); // Sometimes 0
@@ -112,8 +112,8 @@ namespace MapleServer2.Packets
             pWriter.WriteLong();
             pWriter.WriteLong(); // Some timestamp
             pWriter.WriteLong();
-            pWriter.WriteInt();
-            pWriter.Write(player.Rotation); // NOT char Coord/UnknownCoord
+            pWriter.WriteInt(player.ReturnMapId);
+            pWriter.Write(player.ReturnCoord);
             pWriter.WriteInt(); // gearscore
             pWriter.Write(player.SkinColor);
             pWriter.WriteLong(player.CreationTime);

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -77,7 +77,8 @@ namespace MapleServer2.Types
         public long HomeExpiration; // if player does not have a purchased plot, home expiration needs to be set to a far away date
         public string HomeName = "";
 
-        public Vector3 ReturnPosition;
+        public int ReturnMapId = (int) Map.Tria;
+        public CoordF ReturnCoord = CoordF.From(-900, -900, 3000);
 
         public int MaxSkillTabs;
         public long ActiveSkillTabId;


### PR DESCRIPTION
Allows for safe returning in maps that do not have return exit portals
In most, if not all, cases, this is used for instance map teleporting - Beauty shops, housing, dungeon lobbies, etc.