### PR TITLE
Instrument Ensemble & Tick Changes

### DIFF
--- a/MapleServer2/PacketHandlers/Common/RequestTimeSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/RequestTimeSyncHandler.cs
@@ -16,7 +16,7 @@ namespace MapleServer2.PacketHandlers.Common
         {
             int key = packet.ReadInt();
 
-            session.Send(TimeSyncPacket.Response(key));
+            session.Send(TimeSyncPacket.SetSessionServerTick(key));
         }
     }
 }

--- a/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
@@ -44,7 +44,6 @@ namespace MapleServer2.PacketHandlers.Common
             session.InitPlayer(player);
 
             //session.Send(0x27, 0x01); // Meret market related...?
-            session.Send(BuddyPacket.Initialize());
 
             session.Send(LoginPacket.LoginRequired(accountId));
 
@@ -54,6 +53,7 @@ namespace MapleServer2.PacketHandlers.Common
                 session.Send(GuildPacket.UpdateGuild(guild));
                 session.Send(GuildPacket.MemberJoin(player));
             }
+            session.Send(BuddyPacket.Initialize());
             session.Send(BuddyPacket.LoadList(player));
             session.Send(BuddyPacket.EndList(player.BuddyList.Count));
 
@@ -152,8 +152,11 @@ namespace MapleServer2.PacketHandlers.Common
             // SendUgc: 15 01 00 00 00 00 00 00 00 00 00 00 00 4B 00 00 00
             // SendHomeCommand: 00 E1 0F 26 89 7F 98 3C 26 00 00 00 00 00 00 00 00
 
+            // Server is supposed to request SetSessionServerTick packet but it is not.
+            // As a temporary fix, we're sending the packet to set it
+            session.Send(TimeSyncPacket.SetSessionServerTick(0));
             //session.Send("B9 00 00 E1 0F 26 89 7F 98 3C 26 00 00 00 00 00 00 00 00".ToByteArray());
-            //session.Send(ServerEnterPacket.Confirm());
+            session.Send(ServerEnterPacket.Confirm());
 
             //session.Send(0xF0, 0x00, 0x1F, 0x78, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x00, 0x00);
             //session.Send(0x28, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00);

--- a/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
@@ -152,7 +152,7 @@ namespace MapleServer2.PacketHandlers.Common
             // SendUgc: 15 01 00 00 00 00 00 00 00 00 00 00 00 4B 00 00 00
             // SendHomeCommand: 00 E1 0F 26 89 7F 98 3C 26 00 00 00 00 00 00 00 00
 
-            // Server is supposed to request SetSessionServerTick packet but it is not.
+            // Client is supposed to request SetSessionServerTick packet but it is not.
             // As a temporary fix, we're sending the packet to set it
             session.Send(TimeSyncPacket.SetSessionServerTick(0));
             //session.Send("B9 00 00 E1 0F 26 89 7F 98 3C 26 00 00 00 00 00 00 00 00".ToByteArray());

--- a/MapleServer2/PacketHandlers/Common/ResponseVersionHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseVersionHandler.cs
@@ -29,7 +29,7 @@ namespace MapleServer2.PacketHandlers.Common
             // No idea what this is, but server sends it when logging into game server
             PacketWriter pWriter = PacketWriter.Of(SendOp.UNKNOWN_SYNC);
             pWriter.WriteByte();
-            pWriter.WriteInt(Environment.TickCount);
+            pWriter.WriteInt(session.ClientTick);
 
             session.Send(pWriter);
             session.Send(RequestPacket.Key());

--- a/MapleServer2/PacketHandlers/Common/ResponseVersionHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseVersionHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using MaplePacketLib2.Tools;
+﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Network;
 using MapleServer2.Packets;

--- a/MapleServer2/PacketHandlers/Game/ClientTickSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ClientTickSyncHandler.cs
@@ -13,11 +13,8 @@ namespace MapleServer2.PacketHandlers.Game
 
         public override void Handle(GameSession session, PacketReader packet)
         {
-            int serverTicks = packet.ReadInt();
-            if (serverTicks == session.ServerTick)
-            {
-                session.ClientTick = packet.ReadInt();
-            }
+            session.ClientTick = packet.ReadInt();
+            session.ServerTick = packet.ReadInt();
         }
     }
 }

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -105,6 +105,11 @@ namespace MapleServer2.PacketHandlers.Game
 
         private static void HandleStopImprovise(GameSession session)
         {
+            if (session.Player.Instrument == null)
+            {
+                return;
+            }
+
             session.FieldManager.BroadcastPacket(InstrumentPacket.StopImprovise(session.FieldPlayer));
             session.FieldManager.RemoveInstrument(session.Player.Instrument);
             session.Player.Instrument = null;

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -131,7 +131,6 @@ namespace MapleServer2.PacketHandlers.Game
             session.Player.Instrument = session.FieldManager.RequestFieldObject(instrument);
             session.Player.Instrument.Coord = session.FieldPlayer.Coord;
             session.FieldManager.Addinstrument(session.Player.Instrument, session);
-            session.FieldManager.BroadcastPacket(InstrumentPacket.PlayScore(session.Player.Instrument));
             session.Send(InstrumentPacket.UpdateScoreUses(scoreItemUid, score.PlayCount));
         }
 
@@ -214,7 +213,6 @@ namespace MapleServer2.PacketHandlers.Game
                         {
                             member.Instrument.Value.InstrumentTick = instrumentTick; // set the tick to be all the same
                             member.Session.FieldManager.Addinstrument(member.Session.Player.Instrument, member.Session);
-                            member.Session.FieldManager.BroadcastPacket(InstrumentPacket.PlayScore(member.Session.Player.Instrument));
                             member.Instrument.Value.Score.PlayCount -= 1;
                             member.Session.Send(InstrumentPacket.UpdateScoreUses(member.Instrument.Value.Score.Uid, member.Instrument.Value.Score.PlayCount));
                             member.Instrument.Value.Ensemble = false;

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -84,7 +84,7 @@ namespace MapleServer2.PacketHandlers.Game
 
             InsturmentInfoMetadata instrument = InstrumentInfoMetadataStorage.GetMetadata(item.Function.Id);
             InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrument.Category);
-            session.FieldManager.BroadcastPacket(InstrumentPacket.StartImprovise(session.FieldPlayer, instrumentCategory.GMId));
+            session.FieldManager.BroadcastPacket(InstrumentPacket.StartImprovise(session.FieldPlayer, instrumentCategory.GMId, instrumentCategory.PercussionId));
         }
 
         private static void HandlePlayNote(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -92,7 +92,7 @@ namespace MapleServer2.PacketHandlers.Game
 
             session.Player.Instrument = session.FieldManager.RequestFieldObject(instrument);
             session.Player.Instrument.Coord = session.FieldPlayer.Coord;
-            session.FieldManager.Addinstrument(session.Player.Instrument);
+            session.FieldManager.AddInstrument(session.Player.Instrument);
             session.FieldManager.BroadcastPacket(InstrumentPacket.StartImprovise(session.Player.Instrument));
         }
 
@@ -147,7 +147,7 @@ namespace MapleServer2.PacketHandlers.Game
             score.PlayCount -= 1;
             session.Player.Instrument = session.FieldManager.RequestFieldObject(instrument);
             session.Player.Instrument.Coord = session.FieldPlayer.Coord;
-            session.FieldManager.Addinstrument(session.Player.Instrument);
+            session.FieldManager.AddInstrument(session.Player.Instrument);
             session.FieldManager.BroadcastPacket(InstrumentPacket.PlayScore(session.Player.Instrument));
             session.Send(InstrumentPacket.UpdateScoreUses(scoreItemUid, score.PlayCount));
         }
@@ -240,7 +240,7 @@ namespace MapleServer2.PacketHandlers.Game
                 }
 
                 member.Instrument.Value.InstrumentTick = instrumentTick; // set the tick to be all the same
-                member.Session.FieldManager.Addinstrument(member.Session.Player.Instrument);
+                member.Session.FieldManager.AddInstrument(member.Session.Player.Instrument);
                 session.FieldManager.BroadcastPacket(InstrumentPacket.PlayScore(session.Player.Instrument));
                 member.Instrument.Value.Score.PlayCount -= 1;
                 member.Session.Send(InstrumentPacket.UpdateScoreUses(member.Instrument.Value.Score.Uid, member.Instrument.Value.Score.PlayCount));

--- a/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
@@ -22,8 +22,10 @@ namespace MapleServer2.PacketHandlers.Game
         public override void Handle(GameSession session, PacketReader packet)
         {
             byte function = packet.ReadByte(); // Unknown what this is for
-            session.ClientTick = packet.ReadInt(); //ClientTicks
-            packet.ReadInt(); // ServerTicks
+            int serverTick = packet.ReadInt(); // ServerTicks
+            int clientTick = packet.ReadInt(); // ClientTicks
+            session.ServerTick = serverTick;
+            session.ClientTick = clientTick;
 
             byte segments = packet.ReadByte();
             if (segments < 1)

--- a/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
@@ -22,10 +22,8 @@ namespace MapleServer2.PacketHandlers.Game
         public override void Handle(GameSession session, PacketReader packet)
         {
             byte function = packet.ReadByte(); // Unknown what this is for
-            int serverTick = packet.ReadInt(); // ServerTicks
-            int clientTick = packet.ReadInt(); // ClientTicks
-            session.ServerTick = serverTick;
-            session.ClientTick = clientTick;
+            session.ServerTick = packet.ReadInt();
+            session.ClientTick = packet.ReadInt();
 
             byte segments = packet.ReadByte();
             if (segments < 1)

--- a/MapleServer2/Packets/InstrumentPacket.cs
+++ b/MapleServer2/Packets/InstrumentPacket.cs
@@ -17,6 +17,7 @@ namespace MapleServer2.Packets
             StopImprovise = 0x2,
             PlayScore = 0x3,
             StopScore = 0x4,
+            LeaveEnsemble = 0x6,
             Compose = 0x8,
             UpdateScoreUses = 0x9,
             Fireworks = 0xE,
@@ -53,36 +54,43 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet PlayScore(GameSession session, Item score, byte gmId, byte percussionId)
+        public static Packet PlayScore(IFieldObject<Instrument> instrument)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
             pWriter.WriteEnum(InstrumentPacketMode.PlayScore);
-            pWriter.WriteBool(score.IsCustomScore);
-            pWriter.WriteInt(session.FieldPlayer.ObjectId + (session.ClientTick - Environment.TickCount)); // This needs to be objectid + player tick count on map?
-            pWriter.WriteInt(session.FieldPlayer.ObjectId);
-            pWriter.Write(session.Player.Coord);
-            pWriter.WriteInt(session.ClientTick);
-            pWriter.WriteInt(gmId);
-            pWriter.WriteInt(percussionId);
-            pWriter.WriteByte();
+            pWriter.WriteBool(instrument.Value.IsCustomScore);
+            pWriter.WriteInt(instrument.ObjectId);
+            pWriter.WriteInt(instrument.Value.PlayerObjectId);
+            pWriter.Write(instrument.Coord);
+            pWriter.WriteInt(instrument.Value.InstrumentTick);
+            pWriter.WriteInt(instrument.Value.GmId);
+            pWriter.WriteInt(instrument.Value.PercussionId);
+            pWriter.WriteByte(1);
 
-            if (score.IsCustomScore)
+            if (instrument.Value.IsCustomScore)
             {
-                pWriter.WriteMapleString(score.Score.Notes);
+                pWriter.WriteMapleString(instrument.Value.Score.Score.Notes);
             }
             else
             {
-                pWriter.WriteUnicodeString(score.FileName);
+                pWriter.WriteUnicodeString(instrument.Value.Score.FileName);
             }
             return pWriter;
         }
 
-        public static Packet StopScore(IFieldObject<Player> player)
+        public static Packet StopScore(IFieldObject<Instrument> instrument)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
             pWriter.WriteEnum(InstrumentPacketMode.StopScore);
-            pWriter.WriteInt(player.ObjectId + 0x10); // playId ?
-            pWriter.WriteInt(player.ObjectId);
+            pWriter.WriteInt(instrument.ObjectId);
+            pWriter.WriteInt(instrument.Value.PlayerObjectId);
+            return pWriter;
+        }
+
+        public static Packet LeaveEnsemble()
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
+            pWriter.WriteEnum(InstrumentPacketMode.LeaveEnsemble);
             return pWriter;
         }
 

--- a/MapleServer2/Packets/InstrumentPacket.cs
+++ b/MapleServer2/Packets/InstrumentPacket.cs
@@ -21,15 +21,15 @@ namespace MapleServer2.Packets
             Fireworks = 0xE,
         }
 
-        public static Packet StartImprovise(IFieldObject<Player> player, int gmId, int percussionId)
+        public static Packet StartImprovise(IFieldObject<Instrument> instrument)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
             pWriter.WriteEnum(InstrumentPacketMode.StartImprovise);
-            pWriter.WriteInt(); // playId?
-            pWriter.WriteInt(player.ObjectId);
-            pWriter.Write(player.Coord);
-            pWriter.WriteInt(gmId);
-            pWriter.WriteInt(percussionId);
+            pWriter.WriteInt(instrument.ObjectId);
+            pWriter.WriteInt(instrument.Value.PlayerObjectId);
+            pWriter.Write(instrument.Coord);
+            pWriter.WriteInt(instrument.Value.GmId);
+            pWriter.WriteInt(instrument.Value.PercussionId);
             return pWriter;
         }
 
@@ -37,7 +37,7 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
             pWriter.WriteEnum(InstrumentPacketMode.PlayNote);
-            pWriter.WriteInt(); // playId?
+            pWriter.WriteInt(player.Value.Instrument.ObjectId);
             pWriter.WriteInt(player.ObjectId);
             pWriter.WriteInt(note);
             return pWriter;
@@ -47,7 +47,7 @@ namespace MapleServer2.Packets
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
             pWriter.WriteEnum(InstrumentPacketMode.StopImprovise);
-            pWriter.WriteInt(); // playId?
+            pWriter.WriteInt(player.Value.Instrument.ObjectId);
             pWriter.WriteInt(player.ObjectId);
             return pWriter;
         }

--- a/MapleServer2/Packets/InstrumentPacket.cs
+++ b/MapleServer2/Packets/InstrumentPacket.cs
@@ -21,7 +21,7 @@ namespace MapleServer2.Packets
             Fireworks = 0xE,
         }
 
-        public static Packet StartImprovise(IFieldObject<Player> player, byte gmId)
+        public static Packet StartImprovise(IFieldObject<Player> player, int gmId, int percussionId)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PLAY_INSTRUMENT);
             pWriter.WriteEnum(InstrumentPacketMode.StartImprovise);
@@ -29,7 +29,7 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(player.ObjectId);
             pWriter.Write(player.Coord);
             pWriter.WriteInt(gmId);
-            pWriter.WriteInt(0);
+            pWriter.WriteInt(percussionId);
             return pWriter;
         }
 

--- a/MapleServer2/Packets/InstrumentPacket.cs
+++ b/MapleServer2/Packets/InstrumentPacket.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using MaplePacketLib2.Tools;
+﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Packets.Helpers;
-using MapleServer2.Servers.Game;
 using MapleServer2.Types;
 
 namespace MapleServer2.Packets

--- a/MapleServer2/Packets/TimeSyncPacket.cs
+++ b/MapleServer2/Packets/TimeSyncPacket.cs
@@ -10,7 +10,7 @@ namespace MapleServer2.Packets
     // perhaps setting some initial state?
     public static class TimeSyncPacket
     {
-        public static Packet Response(int key)
+        public static Packet SetSessionServerTick(int key)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.RESPONSE_TIME_SYNC);
             pWriter.WriteByte(0x00); // Response

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -228,7 +228,14 @@ namespace MapleServer2.Servers.Game
 
             foreach (IFieldObject<Instrument> instrument in State.Instruments.Values)
             {
-                sender.Send(InstrumentPacket.PlayScore(instrument));
+                if (instrument.Value.Improvise)
+                {
+                    sender.Send(InstrumentPacket.StartImprovise(instrument));
+                }
+                else
+                {
+                    sender.Send(InstrumentPacket.PlayScore(instrument));
+                }
             }
 
             State.AddPlayer(player);
@@ -314,15 +321,13 @@ namespace MapleServer2.Servers.Game
             return State.RemoveCube(cube.ObjectId);
         }
 
-        public void Addinstrument(IFieldObject<Instrument> instrument, GameSession session)
+        public void Addinstrument(IFieldObject<Instrument> instrument)
         {
             State.AddInstrument(instrument);
-            BroadcastPacket(InstrumentPacket.PlayScore(session.Player.Instrument));
         }
 
         public bool RemoveInstrument(IFieldObject<Instrument> instrument)
         {
-            BroadcastPacket(InstrumentPacket.StopScore(instrument));
             return State.RemoveInstrument(instrument.ObjectId);
         }
 

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -321,7 +321,7 @@ namespace MapleServer2.Servers.Game
             return State.RemoveCube(cube.ObjectId);
         }
 
-        public void Addinstrument(IFieldObject<Instrument> instrument)
+        public void AddInstrument(IFieldObject<Instrument> instrument)
         {
             State.AddInstrument(instrument);
         }

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -226,6 +226,11 @@ namespace MapleServer2.Servers.Game
                 sender.Send(RegionSkillPacket.Send(healingSpot.ObjectId, healingSpot.Value.Coord, new SkillCast(70000018, 1, 0, 1)));
             }
 
+            foreach (IFieldObject<Instrument> instrument in State.Instruments.Values)
+            {
+                sender.Send(InstrumentPacket.PlayScore(instrument));
+            }
+
             State.AddPlayer(player);
 
             if (!State.HealingSpots.IsEmpty)
@@ -307,6 +312,17 @@ namespace MapleServer2.Servers.Game
         public bool RemoveCube(IFieldObject<Cube> cube)
         {
             return State.RemoveCube(cube.ObjectId);
+        }
+
+        public void Addinstrument(IFieldObject<Instrument> instrument, GameSession session)
+        {
+            State.AddInstrument(instrument);
+        }
+
+        public bool RemoveInstrument(IFieldObject<Instrument> instrument)
+        {
+            BroadcastPacket(InstrumentPacket.StopScore(instrument));
+            return State.RemoveInstrument(instrument.ObjectId);
         }
 
         public void AddPortal(IFieldObject<Portal> portal)

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -317,6 +317,7 @@ namespace MapleServer2.Servers.Game
         public void Addinstrument(IFieldObject<Instrument> instrument, GameSession session)
         {
             State.AddInstrument(instrument);
+            BroadcastPacket(InstrumentPacket.PlayScore(session.Player.Instrument));
         }
 
         public bool RemoveInstrument(IFieldObject<Instrument> instrument)

--- a/MapleServer2/Servers/Game/GameServer.cs
+++ b/MapleServer2/Servers/Game/GameServer.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Autofac;
 using MapleServer2.Database;
 using MapleServer2.Network;
 using MapleServer2.Tools;
 using MapleServer2.Types;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace MapleServer2.Servers.Game

--- a/MapleServer2/Servers/Game/GameSession.cs
+++ b/MapleServer2/Servers/Game/GameSession.cs
@@ -15,7 +15,7 @@ namespace MapleServer2.Servers.Game
     {
         protected override SessionType Type => SessionType.Game;
 
-        public int ServerTick { get; private set; }
+        public int ServerTick;
         public int ClientTick;
 
         public IFieldObject<Player> FieldPlayer { get; private set; }

--- a/MapleServer2/Types/FieldState.cs
+++ b/MapleServer2/Types/FieldState.cs
@@ -16,6 +16,8 @@ namespace MapleServer2.Types
         public readonly ConcurrentDictionary<int, IFieldObject<GuideObject>> Guide;
         public readonly ConcurrentDictionary<int, IFieldObject<Cube>> Cubes;
         public readonly ConcurrentDictionary<int, IFieldObject<HealingSpot>> HealingSpots;
+        public readonly ConcurrentDictionary<int, IFieldObject<Instrument>> Instruments;
+
 
         public FieldState()
         {
@@ -29,6 +31,7 @@ namespace MapleServer2.Types
             Guide = new ConcurrentDictionary<int, IFieldObject<GuideObject>>();
             Cubes = new ConcurrentDictionary<int, IFieldObject<Cube>>();
             HealingSpots = new ConcurrentDictionary<int, IFieldObject<HealingSpot>>();
+            Instruments = new ConcurrentDictionary<int, IFieldObject<Instrument>>();
         }
 
         public bool TryGetItem(int objectId, out IFieldObject<Item> item)
@@ -112,6 +115,16 @@ namespace MapleServer2.Types
         public bool RemoveCube(int objectId)
         {
             return Cubes.Remove(objectId, out _);
+        }
+
+        public void AddInstrument(IFieldObject<Instrument> instrument)
+        {
+            Instruments[instrument.ObjectId] = instrument;
+        }
+
+        public bool RemoveInstrument(int objectId)
+        {
+            return Instruments.Remove(objectId, out _);
         }
 
         public void AddMobSpawn(IFieldObject<MobSpawn> spawn)

--- a/MapleServer2/Types/FieldState.cs
+++ b/MapleServer2/Types/FieldState.cs
@@ -18,7 +18,6 @@ namespace MapleServer2.Types
         public readonly ConcurrentDictionary<int, IFieldObject<HealingSpot>> HealingSpots;
         public readonly ConcurrentDictionary<int, IFieldObject<Instrument>> Instruments;
 
-
         public FieldState()
         {
             Items = new ConcurrentDictionary<int, IFieldObject<Item>>();

--- a/MapleServer2/Types/Instrument.cs
+++ b/MapleServer2/Types/Instrument.cs
@@ -8,6 +8,7 @@
         public Item Score;
         public int InstrumentTick;
         public int PlayerObjectId;
+        public bool Improvise;
         public bool Ensemble;
 
         public Instrument(int gmId, int percussionId, bool isCustomScore, int playerObjectId)

--- a/MapleServer2/Types/Instrument.cs
+++ b/MapleServer2/Types/Instrument.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using Maple2Storage.Types.Metadata;
+using MapleServer2.Data.Static;
+using MapleServer2.Enums;
+using MapleServer2.Packets;
+using MapleServer2.Servers.Game;
+
+namespace MapleServer2.Types
+{
+    public class Instrument
+    {
+        public int GmId;
+        public int PercussionId;
+        public bool IsCustomScore;
+        public Item Score;
+        public int InstrumentTick;
+        public int PlayerObjectId;
+        public bool Ensemble;
+
+        public Instrument(int gmId, int percussionId, bool isCustomScore, int playerObjectId)
+        {
+            GmId = gmId;
+            PercussionId = percussionId;
+            IsCustomScore = isCustomScore;
+            PlayerObjectId = playerObjectId;
+        }
+    }
+}

--- a/MapleServer2/Types/Instrument.cs
+++ b/MapleServer2/Types/Instrument.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Linq;
-using Maple2Storage.Types.Metadata;
-using MapleServer2.Data.Static;
-using MapleServer2.Enums;
-using MapleServer2.Packets;
-using MapleServer2.Servers.Game;
-
-namespace MapleServer2.Types
+﻿namespace MapleServer2.Types
 {
     public class Instrument
     {

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -46,6 +46,7 @@ namespace MapleServer2.Types
         public IFieldObject<Mount> Mount;
         public IFieldObject<Pet> Pet;
         public IFieldObject<GuideObject> Guide;
+        public IFieldObject<Instrument> Instrument;
 
         public long VIPExpiration { get; set; }
         public int SuperChat;

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -168,7 +168,7 @@ namespace MapleServer2.Types
             Titles = new List<int>();
             ChatSticker = new List<ChatSticker>();
             FavoriteStickers = new List<int>();
-            Emotes = new List<int>();
+            Emotes = new List<int>() { 90200011, 90200004, 90200024, 90200041, 90200042, 90200057, 90200043, 90200022, 90200031, 90200005, 90200006, 90200003, 90200092, 90200077, 90200073, 90200023, 90200001, 90200019, 90200020, 90200021 };
             SkillTabs = new List<SkillTab> { new SkillTab(job) };
             StatPointDistribution = new StatDistribution(20);
             Inventory = new Inventory();


### PR DESCRIPTION
## Instruments
- Created an `Instrument` class for handling instruments in a given field.
- Added `Instrument` to `FieldState` in order to have instruments be playing if a player enters a map mid-play.
- Ensembles now work because session server tick changes were made:

## Tick Changes
- a Player session is now properly having their ServerTick be set. Before, we were setting it with client tick.
- Normally, the client is supposed to request the ServerTick every 1 second from the server. It's not doing it (we're probably missing some packet or something). As a current workaround, I'm updating a session's ServerTick via `UserSyncHandler`

### Etc
- Added the default Emotes to the Player constructor