### PR TITLE
Fix: Add IP and ports to .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
-[Database Info]
-DB_IP = localhost
-DB_Port = 3306
-DB_Database = Maple2DB
-DB_User = root
-DB_Password = root
+# Database Info
+DB_IP=localhost
+DB_PORT=3306
+DB_NAME=Maple2DB
+DB_USER=root
+DB_PASSWORD=root
 
-[Server Info]
-IP = 127.0.0.1
-GamePort = 21001
-LoginPort = 20001
-Name = Paperwood
+# Server Info
+IP=127.0.0.1
+GAME_PORT=21001
+LOGIN_PORT=20001
+NAME=Paperwood

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,12 @@
-DATABASE_URL:server=localhost;database=Maple2DB;user=root;password=root
+[Database Info]
+DB_IP = localhost
+DB_Port = 3306
+DB_Database = Maple2DB
+DB_User = root
+DB_Password = root
+
+[Server Info]
+IP = 127.0.0.1
+GamePort = 21001
+LoginPort = 20001
+Name = Paperwood

--- a/MapleServer2.sln
+++ b/MapleServer2.sln
@@ -16,8 +16,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ms2Database", "Ms2Database\Ms2Database.csproj", "{F021381E-8A42-4A9F-8183-47783ED4BB4C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,10 +37,6 @@ Global
 		{977E8028-3EB4-4DBA-9AC4-81961AAEEB9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{977E8028-3EB4-4DBA-9AC4-81961AAEEB9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{977E8028-3EB4-4DBA-9AC4-81961AAEEB9A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F021381E-8A42-4A9F-8183-47783ED4BB4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F021381E-8A42-4A9F-8183-47783ED4BB4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F021381E-8A42-4A9F-8183-47783ED4BB4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F021381E-8A42-4A9F-8183-47783ED4BB4C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MapleServer2/Database/DatabaseContext.cs
+++ b/MapleServer2/Database/DatabaseContext.cs
@@ -42,7 +42,13 @@ namespace MapleServer2.Database
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseMySQL(Environment.GetEnvironmentVariable("DATABASE_URL"));
+            string server = Environment.GetEnvironmentVariable("DB_IP");
+            string port = Environment.GetEnvironmentVariable("DB_Port");
+            string database = Environment.GetEnvironmentVariable("DB_Database");
+            string user = Environment.GetEnvironmentVariable("DB_User");
+            string password = Environment.GetEnvironmentVariable("DB_Password");
+
+            optionsBuilder.UseMySQL($"server={server};port={port};database={database};user={user};password={password}");
             // optionsBuilder.LogTo(Console.WriteLine);
         }
 

--- a/MapleServer2/Database/DatabaseContext.cs
+++ b/MapleServer2/Database/DatabaseContext.cs
@@ -43,12 +43,12 @@ namespace MapleServer2.Database
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             string server = Environment.GetEnvironmentVariable("DB_IP");
-            string port = Environment.GetEnvironmentVariable("DB_Port");
-            string database = Environment.GetEnvironmentVariable("DB_Database");
-            string user = Environment.GetEnvironmentVariable("DB_User");
-            string password = Environment.GetEnvironmentVariable("DB_Password");
+            string port = Environment.GetEnvironmentVariable("DB_PORT");
+            string name = Environment.GetEnvironmentVariable("DB_NAME");
+            string user = Environment.GetEnvironmentVariable("DB_USER");
+            string password = Environment.GetEnvironmentVariable("DB_PASSWORD");
 
-            optionsBuilder.UseMySQL($"server={server};port={port};database={database};user={user};password={password}");
+            optionsBuilder.UseMySQL($"server={server};port={port};database={name};user={user};password={password}");
             // optionsBuilder.LogTo(Console.WriteLine);
         }
 

--- a/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
@@ -97,6 +97,10 @@ namespace MapleServer2.PacketHandlers.Game
             else
             {
                 ScriptMetadata scriptMetadata = ScriptMetadataStorage.GetNpcScriptMetadata(npc.Value.Id);
+                if (!scriptMetadata.Options.Exists(x => x.Type == ScriptType.Script))
+                {
+                    return;
+                }
                 int firstScript = scriptMetadata.Options.First(x => x.Type == ScriptType.Script).Id;
                 session.Player.NpcTalk.ScriptId = firstScript;
 

--- a/MapleServer2/PacketHandlers/Game/QuitHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/QuitHandler.cs
@@ -1,11 +1,11 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Data;
 using MapleServer2.Database;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
-using MapleServer2.Servers.Login;
 using Microsoft.Extensions.Logging;
 
 namespace MapleServer2.PacketHandlers.Game
@@ -17,7 +17,9 @@ namespace MapleServer2.PacketHandlers.Game
 
         public QuitHandler(ILogger<GamePacketHandler> logger) : base(logger)
         {
-            LoginEndpoint = new IPEndPoint(IPAddress.Loopback, LoginServer.PORT);
+            string ipAddress = Environment.GetEnvironmentVariable("IP");
+            int port = int.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            LoginEndpoint = new IPEndPoint(IPAddress.Parse(ipAddress), port);
         }
 
         private enum QuitMode : byte

--- a/MapleServer2/PacketHandlers/Game/QuitHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/QuitHandler.cs
@@ -18,7 +18,7 @@ namespace MapleServer2.PacketHandlers.Game
         public QuitHandler(ILogger<GamePacketHandler> logger) : base(logger)
         {
             string ipAddress = Environment.GetEnvironmentVariable("IP");
-            int port = int.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            int port = int.Parse(Environment.GetEnvironmentVariable("LOGIN_PORT"));
             LoginEndpoint = new IPEndPoint(IPAddress.Parse(ipAddress), port);
         }
 

--- a/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
@@ -58,7 +58,7 @@ namespace MapleServer2.PacketHandlers.Login
             Logger.Info($"Logging in to game with char id: {charId}");
 
             string ipAddress = Environment.GetEnvironmentVariable("IP");
-            int port = int.Parse(Environment.GetEnvironmentVariable("GamePort"));
+            int port = int.Parse(Environment.GetEnvironmentVariable("GAME_PORT"));
             IPEndPoint endpoint = new IPEndPoint(IPAddress.Parse(ipAddress), port);
             AuthData authData = new AuthData
             {

--- a/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
@@ -9,7 +9,6 @@ using MapleServer2.Database;
 using MapleServer2.Enums;
 using MapleServer2.Extensions;
 using MapleServer2.Packets;
-using MapleServer2.Servers.Game;
 using MapleServer2.Servers.Login;
 using MapleServer2.Types;
 using Microsoft.Extensions.Logging;
@@ -58,7 +57,9 @@ namespace MapleServer2.PacketHandlers.Login
             packet.ReadShort(); // 01 00
             Logger.Info($"Logging in to game with char id: {charId}");
 
-            IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, GameServer.PORT);
+            string ipAddress = Environment.GetEnvironmentVariable("IP");
+            int port = int.Parse(Environment.GetEnvironmentVariable("GamePort"));
+            IPEndPoint endpoint = new IPEndPoint(IPAddress.Parse(ipAddress), port);
             AuthData authData = new AuthData
             {
                 TokenA = session.GetToken(),

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -26,11 +26,11 @@ namespace MapleServer2.PacketHandlers.Login
         {
             ImmutableList<IPEndPoint>.Builder builder = ImmutableList.CreateBuilder<IPEndPoint>();
             string ipAddress = Environment.GetEnvironmentVariable("IP");
-            int port = int.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            int port = int.Parse(Environment.GetEnvironmentVariable("LOGIN_PORT"));
             builder.Add(new IPEndPoint(IPAddress.Parse(ipAddress), port));
 
             ServerIPs = builder.ToImmutable();
-            ServerName = Environment.GetEnvironmentVariable("Name");
+            ServerName = Environment.GetEnvironmentVariable("NAME");
         }
 
         public override void Handle(LoginSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
 using MaplePacketLib2.Tools;
@@ -24,10 +25,12 @@ namespace MapleServer2.PacketHandlers.Login
         public LoginHandler(ILogger<LoginHandler> logger) : base(logger)
         {
             ImmutableList<IPEndPoint>.Builder builder = ImmutableList.CreateBuilder<IPEndPoint>();
-            builder.Add(new IPEndPoint(IPAddress.Loopback, LoginServer.PORT));
+            string ipAddress = Environment.GetEnvironmentVariable("IP");
+            int port = int.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            builder.Add(new IPEndPoint(IPAddress.Parse(ipAddress), port));
 
             ServerIPs = builder.ToImmutable();
-            ServerName = "Paperwood";
+            ServerName = Environment.GetEnvironmentVariable("Name");
         }
 
         public override void Handle(LoginSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
 using MaplePacketLib2.Tools;
@@ -22,10 +23,12 @@ namespace MapleServer2.PacketHandlers.Login
         public ServerEnterPacketHandler(ILogger<ServerEnterPacketHandler> logger) : base(logger)
         {
             ImmutableList<IPEndPoint>.Builder builder = ImmutableList.CreateBuilder<IPEndPoint>();
-            builder.Add(new IPEndPoint(IPAddress.Any, LoginServer.PORT));
+            string ipAddress = Environment.GetEnvironmentVariable("IP");
+            int port = int.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            builder.Add(new IPEndPoint(IPAddress.Parse(ipAddress), port));
 
             ServerIPs = builder.ToImmutable();
-            ServerName = "Paperwood";
+            ServerName = Environment.GetEnvironmentVariable("Name");
         }
 
         public override void Handle(LoginSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
@@ -24,11 +24,11 @@ namespace MapleServer2.PacketHandlers.Login
         {
             ImmutableList<IPEndPoint>.Builder builder = ImmutableList.CreateBuilder<IPEndPoint>();
             string ipAddress = Environment.GetEnvironmentVariable("IP");
-            int port = int.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            int port = int.Parse(Environment.GetEnvironmentVariable("LOGIN_PORT"));
             builder.Add(new IPEndPoint(IPAddress.Parse(ipAddress), port));
 
             ServerIPs = builder.ToImmutable();
-            ServerName = Environment.GetEnvironmentVariable("Name");
+            ServerName = Environment.GetEnvironmentVariable("NAME");
         }
 
         public override void Handle(LoginSession session, PacketReader packet)

--- a/MapleServer2/Servers/Game/GameServer.cs
+++ b/MapleServer2/Servers/Game/GameServer.cs
@@ -31,7 +31,7 @@ namespace MapleServer2.Servers.Game
                 GuildManager.AddGuild(guild);
             }
 
-            ushort port = ushort.Parse(Environment.GetEnvironmentVariable("GamePort"));
+            ushort port = ushort.Parse(Environment.GetEnvironmentVariable("GAME_PORT"));
             Start(port);
         }
     }

--- a/MapleServer2/Servers/Game/GameServer.cs
+++ b/MapleServer2/Servers/Game/GameServer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Autofac;
 using MapleServer2.Database;
 using MapleServer2.Network;
@@ -10,7 +11,6 @@ namespace MapleServer2.Servers.Game
 {
     public class GameServer : Server<GameSession>
     {
-        public const int PORT = 21001;
         public static readonly PlayerStorage Storage = new();
         public static readonly PartyManager PartyManager = new();
         public static readonly ClubManager ClubManager = new();
@@ -30,7 +30,9 @@ namespace MapleServer2.Servers.Game
             {
                 GuildManager.AddGuild(guild);
             }
-            Start(PORT);
+
+            ushort port = ushort.Parse(Environment.GetEnvironmentVariable("GamePort"));
+            Start(port);
         }
     }
 }

--- a/MapleServer2/Servers/Login/LoginServer.cs
+++ b/MapleServer2/Servers/Login/LoginServer.cs
@@ -14,7 +14,7 @@ namespace MapleServer2.Servers.Login
 
         public void Start()
         {
-            ushort port = ushort.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            ushort port = ushort.Parse(Environment.GetEnvironmentVariable("LOGIN_PORT"));
             Start(port);
         }
     }

--- a/MapleServer2/Servers/Login/LoginServer.cs
+++ b/MapleServer2/Servers/Login/LoginServer.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using System;
+using Autofac;
 using MapleServer2.Network;
 using Microsoft.Extensions.Logging;
 
@@ -6,8 +7,6 @@ namespace MapleServer2.Servers.Login
 {
     public class LoginServer : Server<LoginSession>
     {
-        public const int PORT = 20001;
-
         public LoginServer(PacketRouter<LoginSession> router, ILogger<LoginServer> logger, IComponentContext context)
             : base(router, logger, context)
         {
@@ -15,7 +14,8 @@ namespace MapleServer2.Servers.Login
 
         public void Start()
         {
-            base.Start(PORT);
+            ushort port = ushort.Parse(Environment.GetEnvironmentVariable("LoginPort"));
+            Start(port);
         }
     }
 }

--- a/MapleServer2/Tools/Dotenv.cs
+++ b/MapleServer2/Tools/Dotenv.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Tools
         {
             foreach (string line in File.ReadAllLines(filePath))
             {
-                string[] parts = line.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                string[] parts = line.Split('=', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
                 if (parts.Length != 2)
                 {


### PR DESCRIPTION
### .env
- Split database info and added port;
- Added server IP, game and login port and server name to .env.

### Others
- Fixed `NpcTalkHandler` to not crash if NPC doesn't have script;
- Removed references of `Ms2Database` from `MapleServer2.sln`