### PR TITLE
Changed Field Packet Updates

### DIFF
--- a/MapleServer2/Constants/SendOp.cs
+++ b/MapleServer2/Constants/SendOp.cs
@@ -90,6 +90,7 @@
         SYNC_PET_TAMING_POINT = 0x005D,
         TOMBSTONE = 0x005E,
         TROPHY = 0x005F,
+        DUNGEON_WAIT = 0x00F2,
         USER_MOVE_BY_PORTAL = 0x0060,
         ITEM_TITLE = 0x0061,
         MASSIVE_EVENT = 0x0062,

--- a/MapleServer2/MapleServer.cs
+++ b/MapleServer2/MapleServer.cs
@@ -61,6 +61,10 @@ namespace MapleServer2
                         loginServer.Stop();
                         return;
                     case "send":
+                        if (input.Length <= 1)
+                        {
+                            break;
+                        }
                         string packet = input[1];
                         PacketWriter pWriter = new PacketWriter();
                         pWriter.Write(packet.ToByteArray());

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -15,6 +15,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         private enum DungeonMode : byte
         {
+            EnterDungeonRoom = 0x02,
             AddRewards = 0x8,
             GetHelp = 0x10,
             Veteran = 0x11,
@@ -27,6 +28,9 @@ namespace MapleServer2.PacketHandlers.Game
 
             switch (mode)
             {
+                case DungeonMode.EnterDungeonRoom:
+                    HandleEnterDungeonRoom(session, packet);
+                    break;
                 case DungeonMode.AddRewards:
                     HandleAddRewards(session, packet);
                     break;
@@ -43,6 +47,10 @@ namespace MapleServer2.PacketHandlers.Game
                     IPacketHandler<GameSession>.LogUnknownMode(mode);
                     break;
             }
+        }
+        public static void HandleEnterDungeonRoom(GameSession session, PacketReader packet)
+        {
+            int dungeonId = packet.ReadInt();
         }
 
         private static void HandleAddRewards(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -48,6 +48,7 @@ namespace MapleServer2.PacketHandlers.Game
                     break;
             }
         }
+
         public static void HandleEnterDungeonRoom(GameSession session, PacketReader packet)
         {
             int dungeonId = packet.ReadInt();

--- a/MapleServer2/Packets/DungeonWaitPacket.cs
+++ b/MapleServer2/Packets/DungeonWaitPacket.cs
@@ -1,0 +1,16 @@
+using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+
+namespace MapleServer2.Packets
+{
+    public static class DungeonWaitPacket
+    {
+        public static Packet Show(int dungeonId, int playerCountDisplay)
+        {
+            PacketWriter pWriter = PacketWriter.Of(SendOp.DUNGEON_WAIT);
+            pWriter.WriteInt(dungeonId);
+            pWriter.WriteInt(playerCountDisplay);
+            return pWriter;
+        }
+    }
+}

--- a/MapleServer2/Packets/TriggerPacket.cs
+++ b/MapleServer2/Packets/TriggerPacket.cs
@@ -23,14 +23,14 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet Banner(byte state, int stringGuideId)
+        public static Packet Banner(byte state, int stringGuideId, int time)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.TRIGGER);
             pWriter.WriteEnum(TriggerPacketMode.Banner);
             pWriter.WriteByte(state); // 02 = on, 03 = off
             pWriter.WriteInt(stringGuideId);
             pWriter.WriteInt(stringGuideId);
-            pWriter.WriteInt();
+            pWriter.WriteInt(time); //display duration in ms
             return pWriter;
         }
 

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -106,8 +106,8 @@ namespace MapleServer2.Servers.Game
             }
             AddInteractObject(actors);
 
-            string mapName = MapMetadataStorage.GetMetadata(mapId).Name;
-            Triggers = TriggerLoader.GetTriggers(mapName).Select(initializer =>
+            string xBlockName = MapMetadataStorage.GetMetadata(mapId).XBlockName;
+            Triggers = TriggerLoader.GetTriggers(xBlockName).Select(initializer =>
             {
                 TriggerContext context = new TriggerContext(this, Logger);
                 TriggerState startState = initializer.Invoke(context);

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -436,8 +436,7 @@ namespace MapleServer2.Servers.Game
 
         public bool RemoveItem(int objectId, out Item item)
         {
-            Item itemResult;
-            if (!State.RemoveItem(objectId, out itemResult))
+            if (!State.RemoveItem(objectId, out Item itemResult))
             {
                 item = itemResult;
                 return false;

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -156,6 +156,7 @@ namespace MapleServer2.Servers.Game
             }
             return updates;
         }
+
         private void SendUpdates()
         {
             foreach (Packet update in GetUpdates())

--- a/MapleServer2/Servers/Game/GameSession.cs
+++ b/MapleServer2/Servers/Game/GameSession.cs
@@ -31,23 +31,6 @@ namespace MapleServer2.Servers.Game
         public GameSession(ManagerFactory<FieldManager> fieldManagerFactory, ILogger<GameSession> logger) : base(logger)
         {
             FieldManagerFactory = fieldManagerFactory;
-            CancellationToken = new CancellationTokenSource();
-
-            // Continuously sends field updates to client
-            new Thread(() =>
-            {
-                while (!CancellationToken.IsCancellationRequested)
-                {
-                    if (FieldManager != null)
-                    {
-                        foreach (Packet update in FieldManager.GetUpdates())
-                        {
-                            Send(update);
-                        }
-                    }
-                    Thread.Sleep(1000);
-                }
-            }).Start();
         }
 
         public void SendNotice(string message)
@@ -90,7 +73,6 @@ namespace MapleServer2.Servers.Game
         {
             FieldManager.RemovePlayer(this, FieldPlayer);
             GameServer.Storage.RemovePlayer(FieldPlayer.Value);
-            CancellationToken.Cancel();
             // Should we Join the thread to wait for it to complete?
         }
     }

--- a/MapleServer2/Servers/Game/GameSession.cs
+++ b/MapleServer2/Servers/Game/GameSession.cs
@@ -25,9 +25,6 @@ namespace MapleServer2.Servers.Game
 
         private readonly ManagerFactory<FieldManager> FieldManagerFactory;
 
-        // TODO: Replace this with a scheduler.
-        private readonly CancellationTokenSource CancellationToken;
-
         public GameSession(ManagerFactory<FieldManager> fieldManagerFactory, ILogger<GameSession> logger) : base(logger)
         {
             FieldManagerFactory = fieldManagerFactory;


### PR DESCRIPTION
### Field Packet Updates

Broadcast all packets to players on Field once

### Added DungeonWait Packet.
It creates the display in the dungeon which says what kind of dungeon it is and for how many players it was created

### Misc

Added DungeonHandler Enum Type for entering dungeon lobby. This packet can / will probably be used to initiate trigger scripts
Added Check for send manual packet function, to prevent crashes on the server.