### PR TITLE
Fix: tutorial barrier portal

### DIFF
--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
@@ -163,6 +164,10 @@ namespace MapleServer2.PacketHandlers.Game
                         session.Send("4F 00 03 E8 03 00 00 00 00 00 00 00 00 00 00 00 00 80 3F".ToByteArray());
                         session.Send("4F 00 03 D0 07 00 00 00 00 00 00 00 00 00 00 00 00 80 3F".ToByteArray());
                         session.Send("4F 00 08 01 04 01 00 00".ToByteArray());
+
+                        IFieldObject<Portal> portal = session.FieldManager.State.Portals.Values.First(p => p.Value.Id == 1);
+                        portal.Value.Update(true, true, true);
+                        session.FieldManager.BroadcastPacket(FieldPacket.UpdatePortal(portal));
                     }
 
                     mobs.Add((mob, damage));


### PR DESCRIPTION
With the recent PR #292 it was implemented an trigger function **SetPortal** which is called when entering the tutorial map that sets all portals to invisible and disabled. 

This is an temporary fix so the portal appears after breaking the barrier.