### PR TITLE
Fix: better variables naming

### DIFF
--- a/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
@@ -224,7 +224,7 @@ namespace MapleServer2.PacketHandlers.Game
                     session.Send(NpcTalkPacket.Action(ActionType.OpenWindow, "BeautyShopDialog", "hair,styleSave"));
                     break;
             }
-            session.Send(UserMoveByPortalPacket.Move(session.FieldPlayer.ObjectId, portal.Coord.ToFloat(), portal.Rotation.ToFloat()));
+            session.Send(UserMoveByPortalPacket.Move(session.FieldPlayer, portal.Coord.ToFloat(), portal.Rotation.ToFloat()));
         }
 
         private static DialogType GetDialogType(ScriptMetadata scriptMetadata, NpcTalk npcTalk, bool hasNextScript)

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -137,7 +137,7 @@ namespace MapleServer2.PacketHandlers.Game
             }
 
             session.FieldManager.BroadcastPacket(MountPacket.StopTwoPersonRide(otherPlayer.ObjectId, session.FieldPlayer.ObjectId));
-            session.Send(UserMoveByPortalPacket.Move(session.FieldPlayer.ObjectId, otherPlayer.Coord, otherPlayer.Rotation));
+            session.Send(UserMoveByPortalPacket.Move(session.FieldPlayer, otherPlayer.Coord, otherPlayer.Rotation));
 
             if (otherPlayer.Value.Mount != null)
             {

--- a/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
@@ -69,7 +69,7 @@ namespace MapleServer2.PacketHandlers.Game
                 safeBlock.Z += Block.BLOCK_SIZE + 1; // Without this player will spawn inside the block
                 session.Player.ConsumeHp(fallDamage);
 
-                session.Send(UserMoveByPortalPacket.Move(session.FieldPlayer.ObjectId, safeBlock, session.Player.Rotation));
+                session.Send(UserMoveByPortalPacket.Move(session.FieldPlayer, safeBlock, session.Player.Rotation));
                 session.Send(StatPacket.UpdateStats(session.FieldPlayer, PlayerStatId.Hp));
                 session.Send(FallDamagePacket.FallDamage(session, fallDamage));
             }

--- a/MapleServer2/Packets/UserMoveByPortalPacket.cs
+++ b/MapleServer2/Packets/UserMoveByPortalPacket.cs
@@ -1,15 +1,16 @@
 ﻿using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Types;
 
 namespace MapleServer2.Packets
 {
     public static class UserMoveByPortalPacket
     {
-        public static Packet Move(int objectId, CoordF coords, CoordF rotation)
+        public static Packet Move(IFieldObject<Player> fieldPlayer, CoordF coords, CoordF rotation)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.USER_MOVE_BY_PORTAL);
-            pWriter.WriteInt(objectId);
+            pWriter.WriteInt(fieldPlayer.ObjectId);
             pWriter.Write(coords);
             pWriter.Write(rotation);
             pWriter.WriteByte(); // Unknown

--- a/MapleServer2/Servers/Game/FieldManager.cs
+++ b/MapleServer2/Servers/Game/FieldManager.cs
@@ -108,10 +108,10 @@ namespace MapleServer2.Servers.Game
             }
             AddInteractObject(actors);
 
-            MapMetadata metadata = MapMetadataStorage.GetMetadata(mapId);
-            if (metadata != null)
+            MapMetadata mapMetadata = MapMetadataStorage.GetMetadata(mapId);
+            if (mapMetadata != null)
             {
-                string xBlockName = metadata.XBlockName;
+                string xBlockName = mapMetadata.XBlockName;
                 Triggers = TriggerLoader.GetTriggers(xBlockName).Select(initializer =>
                 {
                     TriggerContext context = new TriggerContext(this, Logger);


### PR DESCRIPTION
Suggestions from @Clockworkx 

- Better variables naming;
- Using similar style from **TryParse** in `GameCommandActions`: **ParseShort**, **ParseInt**, **ParseLong**.