### PR TITLE
Party In Memory Only & Ensemble Performances Fix

### DIFF
--- a/MapleServer2/Database/DatabaseContext.cs
+++ b/MapleServer2/Database/DatabaseContext.cs
@@ -80,7 +80,6 @@ namespace MapleServer2.Database
                 entity.Property(e => e.ProfileUrl).HasDefaultValue("").HasMaxLength(50);
                 entity.Property(e => e.Motto).HasDefaultValue("").HasMaxLength(25);
                 entity.Property(e => e.HomeName).HasDefaultValue("").HasMaxLength(25);
-                entity.Property(e => e.PartyId);
                 entity.Property(e => e.ClubId);
                 entity.HasOne(e => e.Guild);
                 entity.HasOne(e => e.GuildMember);
@@ -172,7 +171,7 @@ namespace MapleServer2.Database
                 entity.Ignore(e => e.GatheringCount);
                 entity.Ignore(e => e.Mailbox);
                 entity.Ignore(e => e.InstanceId);
-                entity.Ignore(e => e.PartyId);
+                entity.Ignore(e => e.Party);
             });
 
             modelBuilder.Entity<Levels>(entity =>

--- a/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
@@ -144,6 +144,14 @@ namespace MapleServer2.PacketHandlers.Common
             // RequestFieldEnter
             //session.Send("16 00 00 41 75 19 03 00 01 8A 42 0F 00 00 00 00 00 00 C0 28 C4 00 40 03 44 00 00 16 44 00 00 00 00 00 00 00 00 55 FF 33 42 E8 49 01 00".ToByteArray());
             session.Send(FieldPacket.RequestEnter(session.FieldPlayer));
+
+            Party party = GameServer.PartyManager.GetPartyByMember(session.Player.CharacterId);
+            if (party != null)
+            {
+                session.Player.Party = party;
+                session.Send(PartyPacket.Create(party, false));
+            }
+
             // SendUgc: 15 01 00 00 00 00 00 00 00 00 00 00 00 4B 00 00 00
             // SendHomeCommand: 00 E1 0F 26 89 7F 98 3C 26 00 00 00 00 00 00 00 00
 

--- a/MapleServer2/PacketHandlers/Game/ClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ClubHandler.cs
@@ -77,7 +77,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         private static void HandleJoin(GameSession session, PacketReader packet)
         {
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             if (party == null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -94,7 +94,7 @@ namespace MapleServer2.PacketHandlers.Game
             //the session belongs to the party leader
             if (groupEnter)
             {
-                Party party = GameServer.PartyManager.GetPartyById(player.PartyId);
+                Party party = player.Party;
                 if (party.DungeonSessionId != -1)
                 {
                     session.SendNotice("Need to reset dungeon before entering another instance");
@@ -124,7 +124,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         public static void HandleEnterDungeonButton(GameSession session)
         {
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             DungeonSession dungeonSession = GameServer.DungeonManager.GetDungeonSessionBySessionId(party.DungeonSessionId);
             if (dungeonSession == null) //Can be removed when enter dungeon button is removed on dungeonsession deletion.
             {
@@ -150,19 +150,19 @@ namespace MapleServer2.PacketHandlers.Game
         {
             int dungeonId = packet.ReadInt();
 
-            if (session.Player.PartyId == 0)
+            if (session.Player.Party == null)
             {
                 Party newParty = new(session.Player);
                 GameServer.PartyManager.AddParty(newParty);
 
-                session.Send(PartyPacket.Create(newParty));
+                session.Send(PartyPacket.Create(newParty, false));
                 session.Send(PartyPacket.PartyHelp(dungeonId));
                 MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(newParty, dungeonId));
 
                 return;
             }
 
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
 
             party.BroadcastPacketParty(PartyPacket.PartyHelp(dungeonId));
             MapleServer.BroadcastPacketAll(DungeonHelperPacket.BroadcastAssist(party, dungeonId));

--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -34,6 +34,10 @@ namespace MapleServer2.PacketHandlers.Game
             session.Send(ChatStickerPacket.LoadChatSticker(session.Player));
             session.Send(ResponseCubePacket.LoadHome(session.FieldPlayer));
 
+            if (session.Player.Party != null)
+            {
+                session.Send(PartyPacket.UpdatePlayer(session.Player));
+            }
             // Normally skill layout would be loaded from a database
             QuickSlot arrowStream = QuickSlot.From(10500001);
             QuickSlot arrowBarrage = QuickSlot.From(10500011);

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -5,6 +5,7 @@ using MapleServer2.Data.Static;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
 using MapleServer2.Types;
+using Instrument = MapleServer2.Types.Instrument;
 using Microsoft.Extensions.Logging;
 
 namespace MapleServer2.PacketHandlers.Game
@@ -85,7 +86,7 @@ namespace MapleServer2.PacketHandlers.Game
             InsturmentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(item.Function.Id);
             InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
 
-            Types.Instrument instrument = new Types.Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, false, session.FieldPlayer.ObjectId)
+            Instrument instrument = new Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, false, session.FieldPlayer.ObjectId)
             {
                 Improvise = true
             };
@@ -137,7 +138,7 @@ namespace MapleServer2.PacketHandlers.Game
                 return;
             }
 
-            Types.Instrument instrument = new Types.Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
+            Instrument instrument = new Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
             {
                 InstrumentTick = session.ServerTick,
                 Score = score,
@@ -214,7 +215,7 @@ namespace MapleServer2.PacketHandlers.Game
             Item instrumentItem = session.Player.Inventory.Items[instrumentItemUid];
             InsturmentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(instrumentItem.Function.Id);
             InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
-            Types.Instrument instrument = new Types.Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
+            Instrument instrument = new Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
             {
                 Score = score,
                 Ensemble = true,

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -85,7 +85,7 @@ namespace MapleServer2.PacketHandlers.Game
             InsturmentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(item.Function.Id);
             InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
 
-            Instrument instrument = new Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, false, session.FieldPlayer.ObjectId)
+            Types.Instrument instrument = new Types.Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, false, session.FieldPlayer.ObjectId)
             {
                 Improvise = true
             };
@@ -137,7 +137,7 @@ namespace MapleServer2.PacketHandlers.Game
                 return;
             }
 
-            Instrument instrument = new Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
+            Types.Instrument instrument = new Types.Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
             {
                 InstrumentTick = session.ServerTick,
                 Score = score,
@@ -192,7 +192,7 @@ namespace MapleServer2.PacketHandlers.Game
             long instrumentItemUid = packet.ReadLong();
             long scoreItemUid = packet.ReadLong();
 
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             if (party == null)
             {
                 return;
@@ -214,7 +214,7 @@ namespace MapleServer2.PacketHandlers.Game
             Item instrumentItem = session.Player.Inventory.Items[instrumentItemUid];
             InsturmentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(instrumentItem.Function.Id);
             InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
-            Instrument instrument = new Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
+            Types.Instrument instrument = new Types.Instrument(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.FieldPlayer.ObjectId)
             {
                 Score = score,
                 Ensemble = true,
@@ -241,10 +241,11 @@ namespace MapleServer2.PacketHandlers.Game
                 {
                     continue;
                 }
+                System.Console.WriteLine($"{member.Name} Instrument is not null");
 
                 member.Instrument.Value.InstrumentTick = instrumentTick; // set the tick to be all the same
                 member.Session.FieldManager.AddInstrument(member.Session.Player.Instrument);
-                session.FieldManager.BroadcastPacket(InstrumentPacket.PlayScore(session.Player.Instrument));
+                session.FieldManager.BroadcastPacket(InstrumentPacket.PlayScore(member.Session.Player.Instrument));
                 member.Instrument.Value.Score.PlayCount -= 1;
                 member.Session.Send(InstrumentPacket.UpdateScoreUses(member.Instrument.Value.Score.Uid, member.Instrument.Value.Score.PlayCount));
                 member.Instrument.Value.Ensemble = false;

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -241,7 +241,6 @@ namespace MapleServer2.PacketHandlers.Game
                 {
                     continue;
                 }
-                System.Console.WriteLine($"{member.Name} Instrument is not null");
 
                 member.Instrument.Value.InstrumentTick = instrumentTick; // set the tick to be all the same
                 member.Session.FieldManager.AddInstrument(member.Session.Player.Instrument);

--- a/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
@@ -63,10 +63,10 @@ namespace MapleServer2.PacketHandlers.Game
                 Party newParty = new(partyName, approval, session.Player, memberCountRecruit);
                 GameServer.PartyManager.AddParty(newParty);
 
-                session.Send(PartyPacket.Create(newParty));
+                session.Send(PartyPacket.Create(newParty, false));
                 session.Send(PartyPacket.UpdateHitpoints(session.Player));
 
-                session.Player.PartyId = newParty.Id;
+                session.Player.Party = newParty;
                 party = newParty;
             }
             else
@@ -87,7 +87,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         public static void HandleRemoveListing(GameSession session)
         {
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             if (party == null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -84,9 +84,9 @@ namespace MapleServer2.PacketHandlers.Game
                 return;
             }
 
-            if (session.Player.PartyId != 0)
+            if (session.Player.Party != null)
             {
-                Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+                Party party = session.Player.Party;
 
                 if (party.Leader != session.Player)
                 {
@@ -100,9 +100,9 @@ namespace MapleServer2.PacketHandlers.Game
                     return;
                 }
 
-                if (other.PartyId != 0)
+                if (other.Party != null)
                 {
-                    Party otherParty = GameServer.PartyManager.GetPartyById(other.PartyId);
+                    Party otherParty = other.Party;
 
                     if (otherParty.Members.Count > 1)
                     {
@@ -115,16 +115,16 @@ namespace MapleServer2.PacketHandlers.Game
             }
             else
             {
-                if (other.PartyId != 0)
+                if (other.Party != null)
                 {
-                    Party otherParty = GameServer.PartyManager.GetPartyById(other.PartyId);
+                    Party otherParty = other.Party;
 
                     if (otherParty.Members.Count == 1)
                     {
                         Party newParty = new(session.Player);
                         GameServer.PartyManager.AddParty(newParty);
 
-                        session.Send(PartyPacket.Create(newParty));
+                        session.Send(PartyPacket.Create(newParty, true));
                         other.Session.Send(PartyPacket.SendInvite(session.Player, newParty));
                         return;
                     }
@@ -139,7 +139,7 @@ namespace MapleServer2.PacketHandlers.Game
                     Party newParty = new(session.Player);
                     GameServer.PartyManager.AddParty(newParty);
                     System.Console.WriteLine(newParty.Id);
-                    session.Send(PartyPacket.Create(newParty));
+                    session.Send(PartyPacket.Create(newParty, true));
                     other.Session.Send(PartyPacket.SendInvite(session.Player, newParty));
                 }
             }
@@ -180,9 +180,9 @@ namespace MapleServer2.PacketHandlers.Game
                 return;
             }
 
-            if (session.Player.PartyId != 0)
+            if (session.Player.Party != null)
             {
-                Party currentParty = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+                Party currentParty = session.Player.Party;
                 if (currentParty.Members.Count == 1)
                 {
                     currentParty.RemoveMember(session.Player);
@@ -194,7 +194,7 @@ namespace MapleServer2.PacketHandlers.Game
                 //establish party.
                 party.BroadcastPacketParty(PartyPacket.Join(session.Player));
                 party.AddMember(session.Player);
-                session.Send(PartyPacket.Create(party));
+                session.Send(PartyPacket.Create(party, true));
                 party.BroadcastPacketParty(PartyPacket.UpdateHitpoints(party.Leader));
                 party.BroadcastPacketParty(PartyPacket.UpdatePlayer(session.Player));
                 return;
@@ -202,7 +202,7 @@ namespace MapleServer2.PacketHandlers.Game
 
             party.BroadcastPacketParty(PartyPacket.Join(session.Player));
             party.AddMember(session.Player);
-            session.Send(PartyPacket.Create(party));
+            session.Send(PartyPacket.Create(party, true));
             party.BroadcastPacketParty(PartyPacket.UpdatePlayer(session.Player));
 
             foreach (Player member in party.Members)
@@ -216,7 +216,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         private static void HandleLeave(GameSession session)
         {
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
 
             session.Send(PartyPacket.Leave(session.Player, 1)); //1 = You're the player leaving
             party?.RemoveMember(session.Player);
@@ -267,7 +267,7 @@ namespace MapleServer2.PacketHandlers.Game
                 return;
             }
 
-            if (session.Player.PartyId != 0)
+            if (session.Player.Party == null)
             {
                 return;
             }
@@ -300,7 +300,7 @@ namespace MapleServer2.PacketHandlers.Game
         {
             long charId = packet.ReadLong();
 
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             if (party == null)
             {
                 return;
@@ -345,14 +345,14 @@ namespace MapleServer2.PacketHandlers.Game
         {
             int dungeonId = packet.ReadInt();
 
-            if (session.Player.PartyId == 0)
+            if (session.Player.Party == null)
             {
                 Party newParty = new(session.Player);
                 GameServer.PartyManager.AddParty(newParty);
-                session.Send(PartyPacket.Create(newParty));
+                session.Send(PartyPacket.Create(newParty, true));
             }
 
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
 
             // TODO: Party pairing system
 
@@ -382,7 +382,7 @@ namespace MapleServer2.PacketHandlers.Game
             int checkNum = packet.ReadInt() + 1; //+ 1 is because the ReadyChecks variable is always 1 ahead
             byte response = packet.ReadByte();
 
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             if (party == null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -138,7 +138,6 @@ namespace MapleServer2.PacketHandlers.Game
                     // create party
                     Party newParty = new(session.Player);
                     GameServer.PartyManager.AddParty(newParty);
-                    System.Console.WriteLine(newParty.Id);
                     session.Send(PartyPacket.Create(newParty, true));
                     other.Session.Send(PartyPacket.SendInvite(session.Player, newParty));
                 }

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -114,7 +114,7 @@ namespace MapleServer2.PacketHandlers.Game
 
             bool isFriend = BuddyManager.IsFriend(session.Player, otherPlayer.Value);
             bool isGuildMember = session.Player != null && otherPlayer.Value.Guild != null && session.Player.Guild.Id == otherPlayer.Value.Guild.Id;
-            bool isPartyMember = session.Player.PartyId == otherPlayer.Value.PartyId;
+            bool isPartyMember = session.Player.Party == otherPlayer.Value.Party;
 
             if (!isFriend &&
                 !isGuildMember &&

--- a/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
@@ -141,7 +141,7 @@ namespace MapleServer2.PacketHandlers.Game
 
         private static void HandlePartyChat(GameSession session, string message, ChatType type)
         {
-            Party party = GameServer.PartyManager.GetPartyById(session.Player.PartyId);
+            Party party = session.Player.Party;
             if (party == null)
             {
                 return;

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -81,7 +81,7 @@ namespace MapleServer2.Packets
 
             foreach (Player member in party.Members)
             {
-                pWriter.WriteBool(member.Session == null);
+                pWriter.WriteBool(!member.Session.Connected());
                 CharacterListPacket.WriteCharacter(member, pWriter);
                 WritePartyDungeonInfo(pWriter);
             }

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -70,22 +70,20 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet Create(Party party)
+        public static Packet Create(Party party, bool joinNotice)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.Create);
-            pWriter.WriteByte(1);
+            pWriter.WriteBool(joinNotice);
             pWriter.WriteInt(party.Id);
             pWriter.WriteLong(party.Leader.CharacterId);
             pWriter.WriteByte((byte) party.Members.Count);
 
             foreach (Player member in party.Members)
             {
-                pWriter.WriteByte(0);
+                pWriter.WriteBool(member.Session == null);
                 CharacterListPacket.WriteCharacter(member, pWriter);
-                pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
-                pWriter.WriteInt(); // dungeonID
-                pWriter.WriteByte(); // dungeon clear count
+                WritePartyDungeonInfo(pWriter);
             }
 
             pWriter.WriteByte(); // is in dungeon? might be a bool.
@@ -108,11 +106,11 @@ namespace MapleServer2.Packets
             return pWriter;
         }
 
-        public static Packet LogoutNotice(Player player)
+        public static Packet LogoutNotice(long characterId)
         {
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.LogoutNotice);
-            pWriter.WriteLong(player.CharacterId);
+            pWriter.WriteLong(characterId);
             return pWriter;
         }
 
@@ -147,9 +145,7 @@ namespace MapleServer2.Packets
             pWriter.WriteLong(player.CharacterId);
 
             CharacterListPacket.WriteCharacter(player, pWriter);
-            pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
-            pWriter.WriteInt(); // dungeonID
-            pWriter.WriteByte(); // dungeon clear count
+            WritePartyDungeonInfo(pWriter);
             return pWriter;
         }
 
@@ -159,9 +155,7 @@ namespace MapleServer2.Packets
             pWriter.WriteEnum(PartyPacketMode.UpdateDungeonInfo);
             pWriter.WriteLong(player.CharacterId);
             pWriter.WriteInt(); //unknown: but value 100 was frequent
-            pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
-            pWriter.WriteInt(); // dungeonID
-            pWriter.WriteByte(); // dungeon clear count
+            WritePartyDungeonInfo(pWriter);
             return pWriter;
         }
 
@@ -263,6 +257,13 @@ namespace MapleServer2.Packets
             PacketWriter pWriter = PacketWriter.Of(SendOp.PARTY);
             pWriter.WriteEnum(PartyPacketMode.EndReadyCheck);
             return pWriter;
+        }
+
+        private static void WritePartyDungeonInfo(PacketWriter pWriter)
+        {
+            pWriter.WriteInt(1); // dungeon info from player. Dungeon count (loop every dungeon)
+            pWriter.WriteInt(); // dungeonID
+            pWriter.WriteByte(); // dungeon clear count
         }
     }
 }

--- a/MapleServer2/Servers/Game/DungeonManager.cs
+++ b/MapleServer2/Servers/Game/DungeonManager.cs
@@ -109,9 +109,9 @@ namespace MapleServer2.Servers.Game
             }
             RemoveDungeonSession(dungeonSession.SessionId);
             //if last player leaves lobby or dungeonmap -> destroy dungeonSession.
-            if (dungeonSession.DungeonType == DungeonType.Group && player.PartyId != 0)
+            if (dungeonSession.DungeonType == DungeonType.Group && player.Party != null)
             {
-                Party party = GameServer.PartyManager.GetPartyById(player.PartyId);
+                Party party = player.Party;
                 party.DungeonSessionId = -1;
             }
             else

--- a/MapleServer2/Servers/Game/DungeonManager.cs
+++ b/MapleServer2/Servers/Game/DungeonManager.cs
@@ -111,8 +111,7 @@ namespace MapleServer2.Servers.Game
             //if last player leaves lobby or dungeonmap -> destroy dungeonSession.
             if (dungeonSession.DungeonType == DungeonType.Group && player.Party != null)
             {
-                Party party = player.Party;
-                party.DungeonSessionId = -1;
+                player.Party.DungeonSessionId = -1;
             }
             else
             {

--- a/MapleServer2/Servers/Game/GameSession.cs
+++ b/MapleServer2/Servers/Game/GameSession.cs
@@ -39,6 +39,12 @@ namespace MapleServer2.Servers.Game
             FieldManager = FieldManagerFactory.GetManager(player.MapId, instanceId: 0);
             FieldPlayer = FieldManager.RequestFieldObject(player);
             GameServer.Storage.AddPlayer(player);
+            Party party = GameServer.PartyManager.GetPartyByMember(player.CharacterId);
+            if (party != null)
+            {
+                party.BroadcastPacketParty(PartyPacket.LoginNotice(player), this);
+            }
+
         }
 
         public void EnterField(Player player)
@@ -76,6 +82,11 @@ namespace MapleServer2.Servers.Game
 
         public override void EndSession()
         {
+            if (Player.Party != null)
+            {
+                Player.Party.CheckOffineParty(Player);
+            }
+
             FieldManager.RemovePlayer(this, FieldPlayer);
             GameServer.Storage.RemovePlayer(FieldPlayer.Value);
             // Should we Join the thread to wait for it to complete?

--- a/MapleServer2/Tools/InventoryController.cs
+++ b/MapleServer2/Tools/InventoryController.cs
@@ -19,7 +19,7 @@ namespace MapleServer2.Tools
                 foreach (Item i in session.Player.Inventory.Items.Values)
                 {
                     // Checks to see if item exists in database (dictionary)
-                    if (i.Id != item.Id || i.Amount >= i.StackLimit)
+                    if (i.Id != item.Id || i.Amount >= i.StackLimit || i.Rarity != item.Rarity)
                     {
                         continue;
                     }

--- a/MapleServer2/Tools/PartyManager.cs
+++ b/MapleServer2/Tools/PartyManager.cs
@@ -33,6 +33,11 @@ namespace MapleServer2.Tools
             return PartyList.TryGetValue(id, out Party foundParty) ? foundParty : null;
         }
 
+        public Party GetPartyByMember(long id)
+        {
+            return PartyList.Values.FirstOrDefault(x => x.Members.Any(z => z.CharacterId == id));
+        }
+
         public Party GetPartyByLeader(Player leader)
         {
             return (from entry in PartyList

--- a/MapleServer2/Tools/PartyManager.cs
+++ b/MapleServer2/Tools/PartyManager.cs
@@ -33,9 +33,9 @@ namespace MapleServer2.Tools
             return PartyList.TryGetValue(id, out Party foundParty) ? foundParty : null;
         }
 
-        public Party GetPartyByMember(long id)
+        public Party GetPartyByMember(long characterId)
         {
-            return PartyList.Values.FirstOrDefault(x => x.Members.Any(z => z.CharacterId == id));
+            return PartyList.Values.FirstOrDefault(x => x.Members.Any(z => z.CharacterId == characterId));
         }
 
         public Party GetPartyByLeader(Player leader)

--- a/MapleServer2/Tools/PartyManager.cs
+++ b/MapleServer2/Tools/PartyManager.cs
@@ -13,30 +13,15 @@ namespace MapleServer2.Tools
             PartyList = new Dictionary<long, Party>();
         }
 
-        public void AddParty(Party party)
-        {
-            PartyList.Add(party.Id, party);
-        }
+        public void AddParty(Party party) => PartyList.Add(party.Id, party);
 
-        public void RemoveParty(Party party)
-        {
-            PartyList.Remove(party.Id);
-        }
+        public void RemoveParty(Party party) => PartyList.Remove(party.Id);
 
-        public List<Party> GetPartyFinderList()
-        {
-            return PartyList.Values.Where(party => party.PartyFinderId != 0).ToList();
-        }
+        public List<Party> GetPartyFinderList() => PartyList.Values.Where(party => party.PartyFinderId != 0).ToList();
 
-        public Party GetPartyById(long id)
-        {
-            return PartyList.TryGetValue(id, out Party foundParty) ? foundParty : null;
-        }
+        public Party GetPartyById(long id) => PartyList.TryGetValue(id, out Party foundParty) ? foundParty : null;
 
-        public Party GetPartyByMember(long characterId)
-        {
-            return PartyList.Values.FirstOrDefault(x => x.Members.Any(z => z.CharacterId == characterId));
-        }
+        public Party GetPartyByMember(long characterId) => PartyList.Values.FirstOrDefault(x => x.Members.Any(z => z.CharacterId == characterId));
 
         public Party GetPartyByLeader(Player leader)
         {

--- a/MapleServer2/Types/Party.cs
+++ b/MapleServer2/Types/Party.cs
@@ -56,13 +56,13 @@ namespace MapleServer2.Types
         public void AddMember(Player player)
         {
             Members.Add(player);
-            player.PartyId = Id;
+            player.Party = this;
         }
 
         public void RemoveMember(Player player)
         {
             Members.Remove(player);
-            player.PartyId = 0;
+            player.Party = null;
 
             if (Leader.CharacterId == player.CharacterId && Members.Count > 2)
             {
@@ -74,11 +74,9 @@ namespace MapleServer2.Types
 
         public void FindNewLeader()
         {
-            Player newLeader = Members.First();
+            Player newLeader = Members.First(x => x.CharacterId != Leader.CharacterId);
             BroadcastPacketParty(PartyPacket.SetLeader(newLeader));
             Leader = newLeader;
-            Members.Remove(newLeader);
-            Members.Insert(0, newLeader);
         }
 
         public void CheckDisband()
@@ -90,10 +88,25 @@ namespace MapleServer2.Types
 
             BroadcastParty(session =>
             {
-                session.Player.PartyId = 0;
+                session.Player.Party = null;
                 session.Send(PartyPacket.Disband());
             });
             GameServer.PartyManager.RemoveParty(this);
+        }
+
+        public void CheckOffineParty(Player player)
+        {
+            List<GameSession> sessions = GetSessions();
+            if (sessions.Count == 0)
+            {
+                GameServer.PartyManager.RemoveParty(this);
+                return;
+            }
+            BroadcastPacketParty(PartyPacket.LogoutNotice(player.CharacterId));
+            if (Leader == player)
+            {
+                FindNewLeader();
+            }
         }
 
         public void BroadcastPacketParty(Packet packet, GameSession sender = null)
@@ -123,7 +136,15 @@ namespace MapleServer2.Types
 
         private List<GameSession> GetSessions()
         {
-            return Members.Where(member => member.Session.Connected()).Select(member => member.Session).ToList();
+            List<GameSession> sessions = new List<GameSession>();
+            foreach (Player member in Members)
+            {
+                if (member.Session.Connected())
+                {
+                    sessions.Add(GameServer.Storage.GetPlayerById(member.CharacterId).Session);
+                }
+            }
+            return sessions;
         }
 
         public Task StartReadyCheck()

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -113,7 +113,7 @@ namespace MapleServer2.Types
 
         public List<Buddy> BuddyList;
 
-        public long PartyId;
+        public Party Party;
         public long ClubId;
         // TODO make this as an array
 
@@ -459,6 +459,10 @@ namespace MapleServer2.Types
                         // TODO: Check if regen-enabled
                         Stats[statId] = AddStatRegen(statId, regenStatId);
                         Session.Send(StatPacket.UpdateStats(Session.FieldPlayer, statId));
+                        if (Party != null)
+                        {
+                            Party.BroadcastPacketParty(PartyPacket.UpdateHitpoints(this));
+                        }
                     }
                 }
             });


### PR DESCRIPTION
This fixes it so parties are only in memory now (removing PartyID from DB) and function to work in memory.

Fixed ensembles - should now be working properly now.
Also as a side note, not sure if it's because of .NET 6, but it had trouble with the determining "Instrument" from some other function that didn't pop up before. This is why I had to change it to define which Instrument in InstrumentHandler
#85 

EDIT:
Fixed an issue where if an item ID exists in your inventory, spawning a new itemID with a different rarity will disregard that rarity, and stack with the existing ItemID's rarity.