### PR TITLE
Fix: Guilds not saving correctly

### DIFF
--- a/MapleServer2/Database/DatabaseManager.cs
+++ b/MapleServer2/Database/DatabaseManager.cs
@@ -204,6 +204,10 @@ namespace MapleServer2.Database
                 {
                     context.Entry(player.GuildMember).State = EntityState.Modified;
                 }
+                if (player.Guild != null)
+                {
+                    context.Entry(player.Guild).State = EntityState.Modified;
+                }
                 if (player.Account != null)
                 {
                     context.Entry(player.Account).State = EntityState.Modified;


### PR DESCRIPTION
Missing `Guild` attribute in **DatabaseManager.UpdateCharacter()** .