### PR TITLE
Fix: Beauty crash and returning to correct map

### DIFF
--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -356,7 +356,7 @@ namespace MapleServer2.PacketHandlers.Game
                     return;
             }
 
-            if (session.Player.MapId is not (int) Map.RosettaBeautySalon or (int) Map.TriaPlasticSurgery or (int) Map.DouglasDyeWorkshop)
+            if (MapEntityStorage.HasSafePortal(session.Player.MapId))
             {
                 session.Player.ReturnCoord = session.FieldPlayer.Coord;
                 session.Player.ReturnMapId = session.Player.MapId;

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -168,7 +168,6 @@ namespace MapleServer2.PacketHandlers.Game
             }
 
             ModifyBeauty(session, packet, beautyItem);
-            session.Player.ShopId = 0;
         }
 
         private static void HandleModifyExistingBeauty(GameSession session, PacketReader packet)
@@ -197,7 +196,6 @@ namespace MapleServer2.PacketHandlers.Game
 
             beautyItem.Color = equipColor;
             ModifyBeauty(session, packet, beautyItem);
-            session.Player.ShopId = 0;
         }
 
         private static void HandleModifySkin(GameSession session, PacketReader packet)
@@ -215,7 +213,6 @@ namespace MapleServer2.PacketHandlers.Game
 
             session.Player.SkinColor = skinColor;
             session.FieldManager.BroadcastPacket(SkinColorPacket.Update(session.FieldPlayer, skinColor));
-            session.Player.ShopId = 0;
         }
         private static void HandleRandomHair(GameSession session, PacketReader packet)
         {
@@ -277,7 +274,6 @@ namespace MapleServer2.PacketHandlers.Game
 
             session.FieldManager.BroadcastPacket(EquipmentPacket.EquipItem(session.FieldPlayer, newHair, ItemSlot.HR));
             session.Send(BeautyPacket.RandomHairOption(previousHair, newHair));
-            session.Player.ShopId = 0;
         }
 
         private static void HandleChooseRandomHair(GameSession session, PacketReader packet)
@@ -360,8 +356,11 @@ namespace MapleServer2.PacketHandlers.Game
                     return;
             }
 
-            session.Player.ReturnCoord = session.FieldPlayer.Coord;
-            session.Player.ReturnMapId = session.Player.MapId;
+            if (session.Player.MapId is not (int) Map.RosettaBeautySalon or (int) Map.TriaPlasticSurgery or (int) Map.DouglasDyeWorkshop)
+            {
+                session.Player.ReturnCoord = session.FieldPlayer.Coord;
+                session.Player.ReturnMapId = session.Player.MapId;
+            }
             session.Player.Warp(mapId: (int) mapId, instanceId: session.Player.CharacterId);
         }
 
@@ -453,7 +452,6 @@ namespace MapleServer2.PacketHandlers.Game
 
                 item.Color = equipColor[i];
                 session.FieldManager.BroadcastPacket(ItemExtraDataPacket.Update(session.FieldPlayer, item));
-                session.Player.ShopId = 0;
             }
         }
 


### PR DESCRIPTION
Fixes crash when changing eyes/hair for the second time;
Only setting return map if character isn't inside an beauty map.