### PR TITLE
Fix: Fishing

### DIFF
--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -69,7 +69,6 @@ namespace MapleServer2.PacketHandlers.Game
         {
             long fishingRodUid = packet.ReadLong();
             MasteryExp masteryExp = session.Player.Levels.MasteryExp.FirstOrDefault(x => x.Type == MasteryType.Fishing);
-            session.Player.Levels.MasteryExp.Add(masteryExp);
 
             if (!FishingSpotMetadataStorage.CanFish(session.Player.MapId, masteryExp.CurrentExp))
             {


### PR DESCRIPTION
- Fishing was adding a new MasteryExp, which made the packet 4 bytes longer than expected by client.