### PR TITLE
Fix: transparency badge, BeautyHandler and #401

### DIFF
--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -477,15 +477,19 @@ namespace MapleServer2.PacketHandlers.Game
             ItemSlot itemSlot = ItemMetadataStorage.GetSlot(beautyItem.Id);
             Dictionary<ItemSlot, Item> cosmetics = session.Player.Inventory.Cosmetics;
 
-            // remove current item
-            if (cosmetics.Remove(itemSlot, out Item removeItem))
+            if (cosmetics.TryGetValue(itemSlot, out Item removeItem))
             {
-                removeItem.Slot = -1;
-                DatabaseManager.Items.Delete(removeItem.Uid);
-                session.FieldManager.BroadcastPacket(EquipmentPacket.UnequipItem(session.FieldPlayer, removeItem));
+                // Only remove if it isn't the same item
+                if (removeItem.Uid != beautyItem.Uid)
+                {
+                    cosmetics.Remove(itemSlot);
+                    removeItem.Slot = -1;
+                    DatabaseManager.Items.Delete(removeItem.Uid);
+                    session.FieldManager.BroadcastPacket(EquipmentPacket.UnequipItem(session.FieldPlayer, removeItem));
+                }
             }
-            // equip new item
 
+            // equip & update new item
             switch (itemSlot)
             {
                 case ItemSlot.HR:
@@ -503,7 +507,6 @@ namespace MapleServer2.PacketHandlers.Game
                     session.FieldManager.BroadcastPacket(EquipmentPacket.EquipItem(session.FieldPlayer, beautyItem, itemSlot));
                     break;
                 case ItemSlot.FA:
-
                     cosmetics[itemSlot] = beautyItem;
 
                     session.FieldManager.BroadcastPacket(EquipmentPacket.EquipItem(session.FieldPlayer, beautyItem, itemSlot));

--- a/MapleServer2/PacketHandlers/Game/Helpers/QuestHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/QuestHelper.cs
@@ -13,26 +13,29 @@ namespace MapleServer2.PacketHandlers.Game.Helpers
         public static void UpdateExplorationQuest(GameSession session, string code, string type)
         {
             List<QuestStatus> questList = session.Player.QuestList;
-            foreach (QuestStatus quest in questList.Where(x => x.Basic.QuestType == QuestType.Exploration && x.Condition != null))
+            foreach (QuestStatus quest in questList.Where(x => x.Basic.QuestType == QuestType.Exploration && x.Condition != null && !x.Completed && x.Started))
             {
                 Condition condition = quest.Condition.Where(x => x.Type == type)
-                    .FirstOrDefault(x => x.Codes.Length != 0 && x.Codes.Contains(code));
+                    .FirstOrDefault(x => x.Codes.Length != 0 && x.Codes.Contains(code) && !x.Completed);
                 if (condition == null)
                 {
                     continue;
                 }
 
-                if (condition.Goal != condition.Current)
+                condition.Current++;
+
+                if (condition.Current >= condition.Goal)
                 {
-                    condition.Current++;
+                    condition.Completed = true;
                 }
 
                 session.Send(QuestPacket.UpdateCondition(quest.Basic.Id, quest.Condition));
 
-                if (condition.Goal != condition.Current) // Quest completed
+                if (!condition.Completed)
                 {
                     return;
                 }
+
                 quest.Completed = true;
                 quest.CompleteTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 DatabaseManager.Quests.Update(quest);
@@ -46,11 +49,11 @@ namespace MapleServer2.PacketHandlers.Game.Helpers
 
         public static void UpdateQuest(GameSession session, string code, string type, string target = "")
         {
-            List<QuestStatus> questList = session.Player.QuestList.Where(x => x.Condition != null && x.Condition.Any(x => x.Type == type)).ToList();
+            List<QuestStatus> questList = session.Player.QuestList.Where(x => x.Condition != null && x.Condition.Any(x => x.Type == type) && x.Started && !x.Completed).ToList();
             foreach (QuestStatus quest in questList)
             {
                 Condition condition = quest.Condition
-                    .FirstOrDefault(x => x.Codes != null && x.Codes.Length != 0 && x.Codes.Contains(code) && x.Target.Contains(target));
+                    .FirstOrDefault(x => x.Codes != null && x.Codes.Length != 0 && x.Codes.Contains(code) && x.Target.Contains(target) && !x.Completed);
                 if (condition == null)
                 {
                     continue;

--- a/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
@@ -94,6 +94,14 @@ namespace MapleServer2.PacketHandlers.Game
             }
             else if (npc.Value.IsBeauty())
             {
+                NpcMetadata npcTarget = NpcMetadataStorage.GetNpc(session.Player.NpcTalk.Npc.Id);
+                if (npcTarget.ShopId == 507) // mirror
+                {
+                    session.Send(NpcTalkPacket.Respond(npc, NpcType.Default, DialogType.Beauty, 0));
+                    HandleBeauty(session);
+                    return;
+                }
+
                 session.Send(NpcTalkPacket.Respond(npc, NpcType.Default, DialogType.Beauty, 1));
                 return;
             }

--- a/MapleServer2/Types/Item.cs
+++ b/MapleServer2/Types/Item.cs
@@ -81,6 +81,10 @@ namespace MapleServer2.Types
             IsTemplate = ItemMetadataStorage.GetIsTemplate(id);
             Level = ItemMetadataStorage.GetLevel(id);
             ItemSlot = ItemMetadataStorage.GetSlot(id);
+            if (GemSlot == GemSlot.TRANS)
+            {
+                TransparencyBadgeBools = new byte[10];
+            }
             Rarity = ItemMetadataStorage.GetRarity(id);
             PlayCount = ItemMetadataStorage.GetPlayCount(id);
             Color = ItemMetadataStorage.GetEquipColor(id);
@@ -189,10 +193,6 @@ namespace MapleServer2.Types
         {
             InventoryTab = ItemMetadataStorage.GetTab(Id);
             GemSlot = ItemMetadataStorage.GetGem(Id);
-            if (GemSlot == GemSlot.TRANS)
-            {
-                TransparencyBadgeBools = new byte[10];
-            }
             StackLimit = ItemMetadataStorage.GetStackLimit(Id);
             EnableBreak = ItemMetadataStorage.GetEnableBreak(Id);
             IsTwoHand = ItemMetadataStorage.GetIsTwoHand(Id);


### PR DESCRIPTION
- Fixes #401 ;
- Resolves #381 
- Fixes BeautyHandler to only delete previous beauty item if there is an new one to replace it;
- Transparency bools were always being initialized as an empty array
