### PR TITLE
Fix: Dismantle & ShopPacket

### DIFF
--- a/MapleServer2/Packets/ShopPacket.cs
+++ b/MapleServer2/Packets/ShopPacket.cs
@@ -122,7 +122,7 @@ namespace MapleServer2.Packets
             pWriter.WriteInt(product.RequiredFameGrade);
             pWriter.WriteBool(product.AutoPreviewEquip);
             pWriter.WriteByte();
-            pWriter.WriteItem(new Item(product.ItemId, product.Quantity));
+            pWriter.WriteItem(new Item(product.ItemId, product.Quantity, saveToDatabase: false));
 
             return pWriter;
         }

--- a/MapleServer2/Types/DismantleInventory.cs
+++ b/MapleServer2/Types/DismantleInventory.cs
@@ -83,6 +83,11 @@ namespace MapleServer2.Types
         {
             int index = Array.FindIndex(Slots, 0, Slots.Length, x => x != null && x.Item1 == uid);
 
+            if (index == -1)
+            {
+                return;
+            }
+
             Slots[index] = null;
             session.Send(ItemBreakPacket.Remove(uid));
             UpdateRewards(session);

--- a/MapleServer2/Types/Item.cs
+++ b/MapleServer2/Types/Item.cs
@@ -152,11 +152,6 @@ namespace MapleServer2.Types
             Stats = new ItemStats(other.Stats);
         }
 
-        internal static Item Of(int itemId, short quantity)
-        {
-            throw new NotImplementedException();
-        }
-
         public bool TrySplit(int amount, out Item splitItem)
         {
             if (Amount <= amount)

--- a/MapleServer2/Types/Item.cs
+++ b/MapleServer2/Types/Item.cs
@@ -74,7 +74,7 @@ namespace MapleServer2.Types
 
         public Item() { }
 
-        public Item(int id)
+        public Item(int id, bool saveToDatabase = true)
         {
             Id = id;
             SetMetadataValues();
@@ -90,10 +90,13 @@ namespace MapleServer2.Types
             Amount = 1;
             Score = new MusicScore();
             Stats = new ItemStats(id, Rarity, ItemSlot, Level);
-            Uid = DatabaseManager.Items.Insert(this);
+            if (saveToDatabase)
+            {
+                Uid = DatabaseManager.Items.Insert(this);
+            }
         }
 
-        public Item(int id, int amount) : this(id)
+        public Item(int id, int amount, bool saveToDatabase = true) : this(id, saveToDatabase)
         {
             Amount = amount;
         }
@@ -147,6 +150,11 @@ namespace MapleServer2.Types
             HatData = other.HatData;
             Score = new MusicScore();
             Stats = new ItemStats(other.Stats);
+        }
+
+        internal static Item Of(int itemId, short quantity)
+        {
+            throw new NotImplementedException();
         }
 
         public bool TrySplit(int amount, out Item splitItem)


### PR DESCRIPTION
- Added bool to `Item` constructor so it's possible to create an new Item object without adding it to the database. Fixes #392 
- Checking if index was not found before trying to access the array in DismantleInventory.