### PR TITLE
NPC scripts implementation and reformatting

### DIFF
--- a/Maple2Storage/Scripts/Npcs/11000003.lua
+++ b/Maple2Storage/Scripts/Npcs/11000003.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000021) then return 60 end
+    return 50
+end

--- a/Maple2Storage/Scripts/Npcs/11000005.lua
+++ b/Maple2Storage/Scripts/Npcs/11000005.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000061) then return 80 end
+    return 90
+end

--- a/Maple2Storage/Scripts/Npcs/11000007.lua
+++ b/Maple2Storage/Scripts/Npcs/11000007.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.GetCurrentMapId() == 2000146 then return 30 end
+    return 40
+end

--- a/Maple2Storage/Scripts/Npcs/11000024.lua
+++ b/Maple2Storage/Scripts/Npcs/11000024.lua
@@ -1,6 +1,4 @@
 function getFirstScriptId()
-    if Helper.HasQuestStarted(91000020) then
-        return 40
-    end
+    if Helper.HasQuestStarted(91000020) then return 40 end
     return -1
 end

--- a/Maple2Storage/Scripts/Npcs/11000025.lua
+++ b/Maple2Storage/Scripts/Npcs/11000025.lua
@@ -1,6 +1,4 @@
 function getFirstScriptId()
-    if Helper.HasQuestStarted(91000020) then
-        return 60
-    end
+    if Helper.HasQuestStarted(91000020) then return 60 end
     return -1
 end

--- a/Maple2Storage/Scripts/Npcs/11000033.lua
+++ b/Maple2Storage/Scripts/Npcs/11000033.lua
@@ -1,0 +1,5 @@
+function getFirstScriptId()
+    --funni long line haha
+    if Helper.HasQuestStarted({50001573,50001580,50001581,50001582,50001583,50001584,50001603,50001604,50001665,50001669}) and Helper.GetCurrentMapId() == 02000023 then return 40 end
+    return 50
+end

--- a/Maple2Storage/Scripts/Npcs/11000037.lua
+++ b/Maple2Storage/Scripts/Npcs/11000037.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.GetItemCount(30000435) > 0 then return 40 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11000040.lua
+++ b/Maple2Storage/Scripts/Npcs/11000040.lua
@@ -1,0 +1,5 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    return jobId + 10;
+end

--- a/Maple2Storage/Scripts/Npcs/11000041.lua
+++ b/Maple2Storage/Scripts/Npcs/11000041.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    if jobId == 10 then return 30 end
+    if jobId == 20 then return 20 end
+    return jobId + 10;
+end

--- a/Maple2Storage/Scripts/Npcs/11000042.lua
+++ b/Maple2Storage/Scripts/Npcs/11000042.lua
@@ -1,14 +1,8 @@
 function getFirstScriptId()
-    if Helper.GetPlayerJobId() == 1 then
-        return 10
-    elseif Helper.GetPlayerJobId() == 10 then
-        return 30
-    elseif Helper.GetPlayerJobId() == 20 then
-        return 40
-    elseif Helper.GetPlayerJobId() == 30 then
-        return 20
-    elseif Helper.GetPlayerJobId() >= 40 then
-        return Helper.GetPlayerJobId() + 10;
-    end
+    if Helper.GetPlayerJobId() == 1 then return 10
+    elseif Helper.GetPlayerJobId() == 10 then return 30 end
+    if Helper.GetPlayerJobId() == 20 then return 40 end
+    if Helper.GetPlayerJobId() == 30 then return 20 end
+    if Helper.GetPlayerJobId() >= 40 then return Helper.GetPlayerJobId() + 10; end
     return -1
 end

--- a/Maple2Storage/Scripts/Npcs/11000043.lua
+++ b/Maple2Storage/Scripts/Npcs/11000043.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    if jobId == 40 then return 20 end
+    if jobId < 50 then return jobId + 20 end
+    return jobId + 10
+  end

--- a/Maple2Storage/Scripts/Npcs/11000045.lua
+++ b/Maple2Storage/Scripts/Npcs/11000045.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    if jobId == 50 then return 20 end
+    if jobId < 50 then return jobId + 20 end
+    return jobId + 10
+  end

--- a/Maple2Storage/Scripts/Npcs/11000046.lua
+++ b/Maple2Storage/Scripts/Npcs/11000046.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    if jobId == 60 then return 20 end
+    if jobId < 60 then return jobId + 20 end
+    return jobId + 10
+  end

--- a/Maple2Storage/Scripts/Npcs/11000050.lua
+++ b/Maple2Storage/Scripts/Npcs/11000050.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    if jobId == 70 then return 20 end
+    if jobId < 70 then return jobId + 20 end
+    return jobId + 10
+  end

--- a/Maple2Storage/Scripts/Npcs/11000051.lua
+++ b/Maple2Storage/Scripts/Npcs/11000051.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    local jobId = Helper.GetPlayerJobId()
+    if jobId == 1 then return 10 end
+    if jobId == 80 then return 20 end
+    if jobId < 80 then return jobId + 20 end
+    return jobId + 10
+  end

--- a/Maple2Storage/Scripts/Npcs/11000064.lua
+++ b/Maple2Storage/Scripts/Npcs/11000064.lua
@@ -1,0 +1,7 @@
+function getFirstScriptId()
+    math.randomseed(os.time())
+    local x = math.random()
+    if x > 0.66 then return 50 end
+    if x > 0.33 and x < 0.66 then return 40 end
+    return 30
+end

--- a/Maple2Storage/Scripts/Npcs/11000074.lua
+++ b/Maple2Storage/Scripts/Npcs/11000074.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000022) then return 40 end
+    return -1 --TO DO: GET KMS2 FOOTAGE THAT CONFIRMS WHETHER SCRIPT ID 20 IS USED ALONGSIDE ID 10
+end

--- a/Maple2Storage/Scripts/Npcs/11000075.lua
+++ b/Maple2Storage/Scripts/Npcs/11000075.lua
@@ -1,0 +1,9 @@
+function getFirstScriptId()
+    --[[In GMS2, the original behavior of this NPC was that it randomly picked between scripts 10 and 20, and seen in the commented code below.
+    math.randomseed(os.time())
+    return (math.random() > 0.5 and 10 or 20)
+    However, script 10 directly references the old pre-restart and, therefore, harms the game's lore, worldbuilding and UX.
+    Due to these issues, I have personally decided to change the NPC's behavior, even if it means contradicting the original game's.
+    If you'd rather use the original NPC's script, please uncomment the code above and comment the code below.]]
+    return 20
+end

--- a/Maple2Storage/Scripts/Npcs/11000106.lua
+++ b/Maple2Storage/Scripts/Npcs/11000106.lua
@@ -1,6 +1,4 @@
 function getFirstScriptId()
-    if Helper.HasQuestStarted(91000020) then
-        return 50
-    end
+    if Helper.HasQuestStarted(91000020) then return 50 end
     return -1
 end

--- a/Maple2Storage/Scripts/Npcs/11000119.lua
+++ b/Maple2Storage/Scripts/Npcs/11000119.lua
@@ -1,0 +1,5 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000022) then return 70 end
+    math.randomseed(os.time())
+    return (math.random() > 0.7 and 40 or 120)
+end

--- a/Maple2Storage/Scripts/Npcs/11000157.lua
+++ b/Maple2Storage/Scripts/Npcs/11000157.lua
@@ -1,0 +1,6 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000061) then
+        return 30
+    end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11000158.lua
+++ b/Maple2Storage/Scripts/Npcs/11000158.lua
@@ -1,0 +1,5 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000061) then return 40 end
+    math.randomseed(os.time())
+    return (math.random() > 0.5 and 20 or 30)
+end

--- a/Maple2Storage/Scripts/Npcs/11000160.lua
+++ b/Maple2Storage/Scripts/Npcs/11000160.lua
@@ -1,0 +1,5 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000022) then return 70 end
+	if Helper.HasQuestStarted(80000614) then return 80 end
+    return 60
+end

--- a/Maple2Storage/Scripts/Npcs/11000373.lua
+++ b/Maple2Storage/Scripts/Npcs/11000373.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000021) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11000601.lua
+++ b/Maple2Storage/Scripts/Npcs/11000601.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000022) then return 40 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11001953.lua
+++ b/Maple2Storage/Scripts/Npcs/11001953.lua
@@ -1,13 +1,10 @@
 ﻿function handleGotoFail(nextScript)
-    if nextScript == 31 and Helper.GetItemCount(30000610) >= 1 then
-        return 31
-    elseif nextScript == 10 and Helper.GetItemCount(30000610) >= 10 then
-        return 10
-    elseif nextScript == 100 and Helper.GetItemCount(30000610) >= 100 then
+    if nextScript == 31 and Helper.GetItemCount(30000610) >= 1 then return 31 end
+    if nextScript == 10 and Helper.GetItemCount(30000610) >= 10 then return 10 end
+    if nextScript == 100 and Helper.GetItemCount(30000610) >= 100 then
         return 100
     else
         return 32
     end
-
     return 0
 end

--- a/Maple2Storage/Scripts/Npcs/11004319.lua
+++ b/Maple2Storage/Scripts/Npcs/11004319.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000680) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004320.lua
+++ b/Maple2Storage/Scripts/Npcs/11004320.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000680) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004321.lua
+++ b/Maple2Storage/Scripts/Npcs/11004321.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000680) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004322.lua
+++ b/Maple2Storage/Scripts/Npcs/11004322.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000680) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004323.lua
+++ b/Maple2Storage/Scripts/Npcs/11004323.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000690) then return 10 end
+    return 40
+end

--- a/Maple2Storage/Scripts/Npcs/11004324.lua
+++ b/Maple2Storage/Scripts/Npcs/11004324.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000690) then return 10 end
+    return 30
+end

--- a/Maple2Storage/Scripts/Npcs/11004329.lua
+++ b/Maple2Storage/Scripts/Npcs/11004329.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000720) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004330.lua
+++ b/Maple2Storage/Scripts/Npcs/11004330.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000720) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004331.lua
+++ b/Maple2Storage/Scripts/Npcs/11004331.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000700) then return 30 end
+    return -1
+end

--- a/Maple2Storage/Scripts/Npcs/11004332.lua
+++ b/Maple2Storage/Scripts/Npcs/11004332.lua
@@ -1,0 +1,4 @@
+function getFirstScriptId()
+    if Helper.HasQuestStarted(91000700) then return 30 end
+    return -1
+end

--- a/MapleServer2/Managers/ScriptManager.cs
+++ b/MapleServer2/Managers/ScriptManager.cs
@@ -1,4 +1,4 @@
-﻿using MapleServer2.Servers.Game;
+using MapleServer2.Servers.Game;
 using MoonSharp.Interpreter;
 
 namespace MapleServer2.Managers
@@ -17,7 +17,9 @@ namespace MapleServer2.Managers
         public int GetItemCount(int itemId) => Session.Player.Inventory.Items.Values.Where(x => x.Id == itemId).Sum(x => x.Amount);
 
         public int GetPlayerJobId() => (int) Session.Player.Job;
+        
+        public int GetCurrentMapId() => Session.Player.MapId;
 
-        public bool HasQuestStarted(int questId) => Session.Player.QuestList.Any(x => x.Id == questId && x.Started == true && x.Completed == false);
+        public bool HasQuestStarted(List<int> questIds) => Session.Player.QuestList.Any(x => questIds.Contains(x.Id) && x.Started == true && x.Completed == false);
     }
 }


### PR DESCRIPTION
NPC 11000003 (Growlie) displays script ID 60 for as long as quest 91000021 (Whispers from Tria) is active. Otherwise, displays script ID 50. 
There is another randomPick script, of ID 40, that appears to be unused.

NPC 11000005 (Anne) displays script ID 80 for as long as quest 91000061 (The Hottest Gossip) is active. Otherwise, displays script ID 90.

NPC 11000007 (Ellie) displays script ID 30 for as long as when talked to in map 02000146 (Shadow Gate). Otherwise, displays script ID 40.

NPC 11000033 (Jorge) displays script ID 40 for as long as one of these quests ["50001573","50001580","50001581","50001582","50001583","50001584","50001603","50001604","50001665","50001669"] is active (I also added a check for being in map 02000023, just in case). Otherwise displays script ID 50.
NOTE: It is possible I may have missed a quest or two. Testing through the Ellinia arcs is required to be certain.
NOTE 2: Please implement Jorge's function.

NPC 11000037 (Lea) checks for item 30000435 (Havi Flower) in the player's inventory, and displays script ID 40. Otherwise, displays script ID 30. 

NPC 11000040 (Rovey) displays a script ID of jobid+10 or script ID 10 if you're a beginner.

NPC 11000041 (Rekk) displays a script ID of jobid+10, 10 if you're a beginner, 30 if you're a knight and 20 if you're a berserker.

NPC 11000043 (Trini) displays a script ID of jobid+20 if your jobid<50, 10 if you're a beginner, 20 if you're a priest, or jobid+10.

NPC 11000045 (Ikas) displays a script ID of jobid+20 if your jobid<50, 10 if you're a beginner, 20 if you're an archer, or jobid+10.

NPC 11000046 (Jenna) displays a script ID of jobid+20 if your jobid<60, 10 if you're a beginner, 20 if you're a heavygunner, or jobid+10.

NPC 11000050 (Char) displays a script ID of jobid+20 if your jobid<70, 10 if you're a beginner, 20 if you're a thief, or jobid+10.
NOTE: This NPC has multiple functions, of ids 1,10,20,30,40,50,60,70,80,90,100 and110, that do literally nothing.

NPC 11000051 (Ruki) displays a script ID of jobid+20 if your jobid<80, 10 if you're a beginner, 20 if you're an assassin, or jobid+10.

NPC 11000064 (Lennon) randomizes between scripts 30, 40 and 50.

NPC 11000074 (Karl) displays script ID 40 for as long as quest 91000022 (Whispers from the Royal Court) is active. Otherwise, displays ID 10.
NOTE: It is possible ID 20 is used as well, but further footage from KMS2 is necessary to prove this. 
ID 30 makes reference to the pre-restart lore and is therefore not used.

NPC 11000075 (Ereve) displays script ID 20; please see the comments in the code for more information.

NPC 11000119 (Frey) displays script ID 70 for as long as quest 91000022 (Whispers from the Royal Court) is active. Otherwise, randomizes between script ID 40 and 120. for lore haha wow!!!! reasons i decided to leave that chance as 70/30
There is another randomPick script, of ID 50, that was directly related to the pre-restart lore and is therefore unused.

NPC 11000157 (Paul) displays script ID 40 for as long as quest 91000061 (The Hottest Gossip) is active. Otherwise, displays script ID 20.

NPC 11000158 (Bruno) displays script ID 40 for as long as quest 91000061 (The Hottest Gossip) is active. Otherwise, randomizes 50/50 between ID 20 and 30.

NPC 11000160 (Napolie) displays script ID 70 for as long as quest 91000021 (Whispers from Tria) is active. Otherwise, displays script ID 60. 
Script ID 30 is unused as it makes reference to the old job system. Also has another script, of ID 80 and locale KR, that was used during an event (quest 80000614).

NPC 11000373 (Denver) displays script ID 30 for as long as quest 91000021 (Whispers from Tria) is active. Otherwise, displays script ID 20. 

NPC 11000601 (Luanna) displays script ID 40 for as long as quest 91000022 (Whispers from the Royal Court) is active. Otherwise, displays script ID 30. 

NPC 11004319 (Mika) displays script ID 30 for as long as quest 91000680 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 

NPC 11004320 (Dunba) displays script ID 30 for as long as quest 91000680 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 

NPC 11004321 (Tara) displays script ID 30 for as long as quest 91000680 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 

NPC 11004322 (Startz) displays script ID 30 for as long as quest 91000680 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 

NPC 11004323 (Eve) displays script ID 10 for as long as quest 91000690 (Kritian Pioneers) is active. Otherwise, displays script ID 40. 

NPC 11004324 (Lennon) displays script ID 10 for as long as quest 91000690 (Kritian Pioneers) is active. Otherwise, displays script ID 30. 

NPC 11004329 (Jorge) displays script ID 30 for as long as quest 91000720 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 

NPC 11004330 (Kaitlyn) displays script ID 30 for as long as quest 91000720 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 

NPC 11004331 (Orde) displays script ID 30 for as long as quest 91000700 (Kritian Pioneers) is active. Otherwise, displays script ID 10. 
Also has a script, of ID 70 and locale KR, that was used during an event I'm not familiar with.

NPC 11004332 (Lanemone) displays script ID 30 for as long as quest 91000700 (Kritian Pioneers) is active. Otherwise, displays script ID 10.