### PR TITLE
fix: add check for mysql version

### DIFF
--- a/MapleServer2/Database/DatabaseManager.cs
+++ b/MapleServer2/Database/DatabaseManager.cs
@@ -56,6 +56,14 @@ namespace MapleServer2.Database
 
         public static void RunQuery(string query) => new QueryFactory(new MySqlConnection(ConnectionString), new MySqlCompiler()).Statement(query);
 
+        public static int getVersion()
+        {
+            MySqlConnection conn = new MySqlConnection(ConnectionString);
+            conn.Open();
+
+            return int.Parse(conn.ServerVersion.Split(".")[0]);
+        }
+
         public static bool DatabaseExists()
         {
             dynamic result = new QueryFactory(new MySqlConnection($"SERVER={Server};PORT={Port};USER={User};PASSWORD={Password};"), new MySqlCompiler())

--- a/MapleServer2/Database/DatabaseManager.cs
+++ b/MapleServer2/Database/DatabaseManager.cs
@@ -10,6 +10,7 @@ namespace MapleServer2.Database
 {
     public class DatabaseManager
     {
+        public const int MIN_MYSQL_VERSION = 8;
         protected static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         public static readonly string ConnectionString;
 

--- a/MapleServer2/Database/DatabaseManager.cs
+++ b/MapleServer2/Database/DatabaseManager.cs
@@ -56,9 +56,9 @@ namespace MapleServer2.Database
 
         public static void RunQuery(string query) => new QueryFactory(new MySqlConnection(ConnectionString), new MySqlCompiler()).Statement(query);
 
-        public static int getVersion()
+        public static int GetVersion()
         {
-            MySqlConnection conn = new MySqlConnection(ConnectionString);
+            MySqlConnection conn = new MySqlConnection($"SERVER={Server};PORT={Port};USER={User};PASSWORD={Password};");
             conn.Open();
 
             return int.Parse(conn.ServerVersion.Split(".")[0]);

--- a/MapleServer2/MapleServer.cs
+++ b/MapleServer2/MapleServer.cs
@@ -132,6 +132,13 @@ namespace MapleServer2
 
         private static void InitDatabase()
         {
+            int MIN_MYSQL_VERSION = 8;
+            if (DatabaseManager.getVersion() < MIN_MYSQL_VERSION)
+            {
+                Logger.Error("MySQL version out-of-date, please upgrade to version " + MIN_MYSQL_VERSION + ".");
+                return;
+            }
+
             if (DatabaseManager.DatabaseExists())
             {
                 Logger.Info("Database already exists.");

--- a/MapleServer2/MapleServer.cs
+++ b/MapleServer2/MapleServer.cs
@@ -13,10 +13,13 @@ using MapleServer2.Tools;
 using MapleServer2.Types;
 using NLog;
 
+
 namespace MapleServer2
 {
+
     public static class MapleServer
     {
+        const int MIN_MYSQL_VERSION = 9;
         private static GameServer GameServer;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -132,11 +135,9 @@ namespace MapleServer2
 
         private static void InitDatabase()
         {
-            int MIN_MYSQL_VERSION = 8;
-            if (DatabaseManager.getVersion() < MIN_MYSQL_VERSION)
+            if (DatabaseManager.GetVersion() < MIN_MYSQL_VERSION)
             {
-                Logger.Error("MySQL version out-of-date, please upgrade to version " + MIN_MYSQL_VERSION + ".");
-                return;
+                throw new Exception("MySQL version out-of-date, please upgrade to version " + MIN_MYSQL_VERSION + ".");
             }
 
             if (DatabaseManager.DatabaseExists())

--- a/MapleServer2/MapleServer.cs
+++ b/MapleServer2/MapleServer.cs
@@ -15,10 +15,8 @@ using NLog;
 
 namespace MapleServer2
 {
-
     public static class MapleServer
     {
-        const int MIN_MYSQL_VERSION = 8;
         private static GameServer GameServer;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -134,9 +132,9 @@ namespace MapleServer2
 
         private static void InitDatabase()
         {
-            if (DatabaseManager.GetVersion() < MIN_MYSQL_VERSION)
+            if (DatabaseManager.GetVersion() < DatabaseManager.MIN_MYSQL_VERSION)
             {
-                throw new Exception("MySQL version out-of-date, please upgrade to version " + MIN_MYSQL_VERSION + ".");
+                throw new Exception("MySQL version out-of-date, please upgrade to version " + DatabaseManager.MIN_MYSQL_VERSION + ".");
             }
 
             if (DatabaseManager.DatabaseExists())

--- a/MapleServer2/MapleServer.cs
+++ b/MapleServer2/MapleServer.cs
@@ -13,13 +13,12 @@ using MapleServer2.Tools;
 using MapleServer2.Types;
 using NLog;
 
-
 namespace MapleServer2
 {
 
     public static class MapleServer
     {
-        const int MIN_MYSQL_VERSION = 9;
+        const int MIN_MYSQL_VERSION = 8;
         private static GameServer GameServer;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 


### PR DESCRIPTION
Fixes #452 

Remaks:
- Is there a central place to put the required version number? Currently I put it in `InitDatabase`
- The original issue suggested returning from `InitDatabase` when the check fails. This does not stop the emulator from running. Should a shutdown be enforced or just let it crash and possibly burn?