### PR TITLE
Feat: Channels

### DIFF
--- a/MapleServer2/Data/AuthStorage.cs
+++ b/MapleServer2/Data/AuthStorage.cs
@@ -1,4 +1,6 @@
-﻿namespace MapleServer2.Data;
+﻿using MapleServer2.Types;
+
+namespace MapleServer2.Data;
 
 // TODO: This is mostly temporary while I think about how auth really should work
 // It's mostly just required to pass login data to GameSession (which is why it's static)
@@ -20,5 +22,5 @@ public class AuthData
 {
     public int TokenA;
     public int TokenB;
-    public long CharacterId;
+    public Player Player;
 }

--- a/MapleServer2/Network/Session.cs
+++ b/MapleServer2/Network/Session.cs
@@ -162,13 +162,6 @@ public abstract class Session : IDisposable
         SendInternal(packet, packet.Length);
     }
 
-    // Ensures no more communication before sending a final packet.
-    public void SendFinal(PacketWriter packet)
-    {
-        SendInternal(packet, packet.Length);
-        Disconnect();
-    }
-
     public override string ToString()
     {
         return $"{GetType().Name} from {Name}";

--- a/MapleServer2/PacketHandlers/Common/QuitHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/QuitHandler.cs
@@ -58,13 +58,12 @@ public class QuitHandler : CommonPacketHandler
         DatabaseManager.Characters.Update(session.Player);
         AuthData authData = AuthStorage.GetData(session.Player.AccountId);
 
-        session.SendFinal(MigrationPacket.GameToLogin(LoginEndpoint, authData));
+        session.Send(MigrationPacket.GameToLogin(LoginEndpoint, authData));
     }
 
     private static void HandleQuit(GameSession session)
     {
-        session.ReleaseField(session.Player);
-        session.FieldManager.RemovePlayer(session, session.FieldPlayer);
         DatabaseManager.Characters.Update(session.Player);
+        session.Disconnect();
     }
 }

--- a/MapleServer2/PacketHandlers/Game/ChannelHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChannelHandler.cs
@@ -1,0 +1,23 @@
+﻿
+using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Servers.Game;
+using MapleServer2.Types;
+
+namespace MapleServer2.PacketHandlers.Game;
+
+public class ChannelHandler : GamePacketHandler
+{
+    public override RecvOp OpCode => RecvOp.CHANNEL;
+
+    public override void Handle(GameSession session, PacketReader packet)
+    {
+        short channelId = packet.ReadShort();
+
+        Player player = session.Player;
+        player.InstanceId = channelId;
+        player.ChannelId = channelId;
+
+        player.WarpGameToGame(player.MapId, channelId);
+    }
+}

--- a/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
@@ -52,7 +52,7 @@ public class HomeActionHandler : GamePacketHandler
             return;
         }
 
-        target.Warp(target.ReturnMapId, target.ReturnCoord, target.Rotation, 0);
+        target.Warp(target.ReturnMapId, target.ReturnCoord, target.Rotation);
         target.ReturnMapId = 0;
         target.VisitingHomeId = 0;
     }

--- a/MapleServer2/PacketHandlers/Game/LoadUgcMapHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LoadUgcMapHandler.cs
@@ -66,10 +66,7 @@ public class LoadUgcMapHandler : GamePacketHandler
             session.Player.Coord = coord;
             session.Player.SafeBlock = coord;
             session.Player.Rotation = rotation;
-            if (session.Player.InstanceId == 0)
-            {
-                session.Player.InstanceId = home.InstanceId;
-            }
+            session.Player.InstanceId = home.InstanceId;
         }
         else
         {

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -174,7 +174,7 @@ public class MoveFieldHandler : GamePacketHandler
                 {
                     return;
                 }
-                session.Player.Warp((int) Map.PrivateResidence, instanceId: home.InstanceId);
+                session.Player.WarpGameToGame((int) Map.PrivateResidence, instanceId: home.InstanceId);
                 break;
         }
     }
@@ -182,7 +182,7 @@ public class MoveFieldHandler : GamePacketHandler
     private static void HandleLeaveInstance(GameSession session)
     {
         Player player = session.Player;
-        player.Warp(player.ReturnMapId, player.ReturnCoord, player.Rotation, 0);
+        player.Warp(player.ReturnMapId, player.ReturnCoord, player.Rotation);
     }
 
     private static void HandleVisitHouse(GameSession session, PacketReader packet)
@@ -234,7 +234,7 @@ public class MoveFieldHandler : GamePacketHandler
         player.VisitingHomeId = home.Id;
         session.Send(ResponseCubePacket.LoadHome(session.FieldPlayer.ObjectId, home));
 
-        player.Warp(home.MapId, player.Coord, player.Rotation, home.InstanceId);
+        player.WarpGameToGame(home.MapId, home.InstanceId, player.Coord, player.Rotation);
     }
 
     // This also leaves decor planning
@@ -245,13 +245,13 @@ public class MoveFieldHandler : GamePacketHandler
         {
             player.IsInDecorPlanner = false;
             player.Guide = null;
-            player.Warp((int) Map.PrivateResidence, instanceId: --player.InstanceId);
+            player.WarpGameToGame((int) Map.PrivateResidence, instanceId: --player.InstanceId);
             return;
         }
 
         CoordF returnCoord = player.ReturnCoord;
         returnCoord.Z += Block.BLOCK_SIZE;
-        player.Warp(player.ReturnMapId, returnCoord, player.Rotation);
+        player.WarpGameToGame(player.ReturnMapId, 0, returnCoord, player.Rotation);
         player.ReturnMapId = 0;
         player.VisitingHomeId = 0;
     }
@@ -270,6 +270,6 @@ public class MoveFieldHandler : GamePacketHandler
         home.DecorPlannerHeight = home.Height;
         home.DecorPlannerSize = home.Size;
         home.DecorPlannerInventory = new();
-        player.Warp((int) Map.PrivateResidence, instanceId: ++player.InstanceId);
+        player.WarpGameToGame((int) Map.PrivateResidence, instanceId: ++player.InstanceId);
     }
 }

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -251,7 +251,7 @@ public class MoveFieldHandler : GamePacketHandler
 
         CoordF returnCoord = player.ReturnCoord;
         returnCoord.Z += Block.BLOCK_SIZE;
-        player.WarpGameToGame(player.ReturnMapId, 0, returnCoord, player.Rotation);
+        player.WarpGameToGame(player.ReturnMapId, 1, returnCoord, player.Rotation);
         player.ReturnMapId = 0;
         player.VisitingHomeId = 0;
     }

--- a/MapleServer2/PacketHandlers/Game/RequestHomeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestHomeHandler.cs
@@ -81,8 +81,7 @@ public class RequestHomeHandler : GamePacketHandler
 
         player.VisitingHomeId = player.Account.Home.Id;
         player.Guide = null;
-        session.Send(ResponseCubePacket.LoadHome(session.FieldPlayer.ObjectId, session.Player.Account.Home));
 
-        player.Warp(home.MapId, player.Coord, player.Rotation, home.InstanceId);
+        player.WarpGameToGame(home.MapId, home.InstanceId);
     }
 }

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -93,7 +93,8 @@ public class LoginHandler : LoginPacketHandler
         List<Banner> banners = DatabaseManager.Banners.FindAllBanners();
         session.Send(NpsInfoPacket.SendUsername(account.Username));
         session.Send(BannerListPacket.SetBanner(banners));
-        session.SendFinal(ServerListPacket.SetServers(ServerName, ServerIPs));
+        session.Send(ServerListPacket.SetServers(ServerName, ServerIPs));
+        session.Disconnect();
     }
 
     private void SendCharacters(LoginSession session, Account account)

--- a/MapleServer2/Packets/GuildPacket.cs
+++ b/MapleServer2/Packets/GuildPacket.cs
@@ -781,7 +781,7 @@ public static class GuildPacket
         pWriter.WriteShort(member.Levels.Level);
         pWriter.WriteInt(); // player gearscore
         pWriter.WriteInt(member.MapId);
-        pWriter.WriteShort(); // player.channel
+        pWriter.WriteShort(member.ChannelId);
         pWriter.WriteUnicodeString(member.ProfileUrl);
         pWriter.WriteInt(member.Account.Home?.PlotMapId ?? 0);
         pWriter.WriteInt(member.Account.Home?.PlotNumber ?? 0);

--- a/MapleServer2/Packets/MigrationPacket.cs
+++ b/MapleServer2/Packets/MigrationPacket.cs
@@ -2,6 +2,7 @@
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Data;
+using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
@@ -49,7 +50,7 @@ public static class MigrationPacket
         return pWriter;
     }
 
-    public static PacketWriter GameToGame(IPEndPoint endpoint, AuthData authTokens)
+    public static PacketWriter GameToGame(IPEndPoint endpoint, AuthData authTokens, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GAME_TO_GAME);
         pWriter.WriteByte(); // 0 = Success
@@ -57,8 +58,8 @@ public static class MigrationPacket
         pWriter.WriteInt(authTokens.TokenB);
         pWriter.WriteBytes(endpoint.Address.GetAddressBytes());
         pWriter.Write((ushort) endpoint.Port);
-        pWriter.WriteInt(); // Map
-        pWriter.WriteByte();
+        pWriter.WriteInt(player.MapId); // Map
+        pWriter.WriteByte(); //unknown
 
         return pWriter;
     }

--- a/MapleServer2/Packets/ServerEnterPacket.cs
+++ b/MapleServer2/Packets/ServerEnterPacket.cs
@@ -1,6 +1,7 @@
 ﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
 using MapleServer2.Servers.Game;
+using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
@@ -8,37 +9,41 @@ public static class ServerEnterPacket
 {
     public static PacketWriter Enter(GameSession session)
     {
+        Player player = session.Player;
+        Account account = player.Account;
+        Wallet wallet = player.Wallet;
+
         PacketWriter pWriter = PacketWriter.Of(SendOp.SERVER_ENTER);
         pWriter.WriteInt(session.FieldPlayer.ObjectId);
-        pWriter.WriteLong(session.Player.CharacterId);
-        pWriter.WriteShort(1); // channel
-        pWriter.WriteLong(session.Player.Levels.Exp);
-        pWriter.WriteLong(session.Player.Levels.RestExp);
-        pWriter.WriteLong(session.Player.Wallet.Meso.Amount);
+        pWriter.WriteLong(player.CharacterId);
+        pWriter.WriteShort(player.ChannelId);
+        pWriter.WriteLong(player.Levels.Exp);
+        pWriter.WriteLong(player.Levels.RestExp);
+        pWriter.WriteLong(wallet.Meso.Amount);
 
         pWriter.WriteLong(); // Total Merets
-        pWriter.WriteLong(session.Player.Account.Meret.Amount); // Merets
-        pWriter.WriteLong(session.Player.Account.GameMeret.Amount); // Game Merets
-        pWriter.WriteLong(session.Player.Account.EventMeret.Amount); // Event Merets
+        pWriter.WriteLong(account.Meret.Amount); // Merets
+        pWriter.WriteLong(account.GameMeret.Amount); // Game Merets
+        pWriter.WriteLong(account.EventMeret.Amount); // Event Merets
 
         pWriter.WriteLong();
 
-        pWriter.WriteLong(session.Player.Wallet.ValorToken.Amount);
-        pWriter.WriteLong(session.Player.Wallet.Treva.Amount);
-        pWriter.WriteLong(session.Player.Wallet.Rue.Amount);
-        pWriter.WriteLong(session.Player.Wallet.HaviFruit.Amount);
+        pWriter.WriteLong(wallet.ValorToken.Amount);
+        pWriter.WriteLong(wallet.Treva.Amount);
+        pWriter.WriteLong(wallet.Rue.Amount);
+        pWriter.WriteLong(wallet.HaviFruit.Amount);
         pWriter.WriteLong();
         pWriter.WriteLong();
         pWriter.WriteLong();
         pWriter.WriteLong();
-        pWriter.WriteLong(session.Player.Account.MesoToken.Amount);
-        pWriter.WriteUnicodeString(""); // Profile Url
+        pWriter.WriteLong(account.MesoToken.Amount);
+        pWriter.WriteUnicodeString(player.ProfileUrl); // Profile Url
         pWriter.WriteByte();
         pWriter.WriteByte();
         // REQUIRED OR CRASH
 
         // Unlocked Maps (World Map)
-        List<int> unlockedMaps = session.Player.UnlockedMaps;
+        List<int> unlockedMaps = player.UnlockedMaps;
         pWriter.WriteShort((short) unlockedMaps.Count);
         foreach (int mapId in unlockedMaps)
         {
@@ -46,7 +51,7 @@ public static class ServerEnterPacket
         }
 
         // Unlocked Taxis
-        List<int> unlockedTaxis = session.Player.UnlockedTaxis;
+        List<int> unlockedTaxis = player.UnlockedTaxis;
         pWriter.WriteShort((short) unlockedTaxis.Count);
         foreach (int mapId in unlockedTaxis)
         {

--- a/MapleServer2/Packets/ServerListPacket.cs
+++ b/MapleServer2/Packets/ServerListPacket.cs
@@ -14,7 +14,7 @@ public static class ServerListPacket
         pWriter.WriteByte(1); // If false packet isn't processed
         pWriter.WriteInt(1); // Unk.
         pWriter.WriteUnicodeString(serverName);
-        pWriter.WriteByte(0); // Unk.
+        pWriter.WriteByte(); // Unk.
 
         pWriter.Write((ushort) serverIps.Count);
         foreach (IPEndPoint endpoint in serverIps)
@@ -25,8 +25,9 @@ public static class ServerListPacket
 
         pWriter.WriteInt(100); // Unk.
 
-        short nMultiServerChannel = 1; // Need at least 1
-        for (short i = 0; i < nMultiServerChannel; ++i)
+        short nMultiServerChannel = 10; // Doesn't seems to go past 9 channels ingame ??
+        pWriter.WriteShort(nMultiServerChannel);
+        for (short i = 1; i <= nMultiServerChannel; ++i)
         {
             pWriter.WriteShort(i);
         }


### PR DESCRIPTION
### Channels
Using the packet **GameToGame**, it's possible to change servers (with different IPs) when changing channels. That's why the current session is closed and then re opened. 

- Now retrieving the player from database when selecting it in `CharacterManagementHandler` and saving it in **AuthData** so it can be shared between **Sessions**.
- When changing channels or anytime **GameToGame** is used, set `player.IsChangingChannel` to true so we don't send login/logout messages.

Fixed packets:
- SERVER_ENTER
- GUILD
- GAME_TO_GAME
- SERVER_LIST
