### PR TITLE
Implement sending of guild mail

### DIFF
--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -555,6 +555,15 @@ public class GuildHandler : GamePacketHandler
         Player sender = session.Player;
         Guild guild = session.Player.Guild;
 
+        byte senderRank = sender.GuildMember.Rank;
+        GuildRank guildRank = guild.Ranks[senderRank];
+
+        if (!guildRank.HasRight(GuildRights.CanGuildMail))
+        {
+            session.Send(GuildPacket.ErrorNotice((byte)GuildErrorNotice.InsufficientPermissions));
+            return;
+        }
+
         IEnumerable<long> guildMemberCharacterIds = guild.Members
             .Select(m => m.Player.CharacterId)
             .Where(i => i != sender.CharacterId);

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -568,7 +568,7 @@ public class GuildHandler : GamePacketHandler
             session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.InsufficientPermissions));
             return;
         }
-        
+
         session.Send(GuildPacket.SendMail());
 
         IEnumerable<long> recipientIds = guild.Members.Select(c => c.Player.CharacterId);

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -4,8 +4,6 @@ using MapleServer2.Constants;
 using MapleServer2.Data.Static;
 using MapleServer2.Database;
 using MapleServer2.Enums;
-using MapleServer2.Managers;
-using MapleServer2.Network;
 using MapleServer2.PacketHandlers.Game.Helpers;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -555,6 +555,11 @@ public class GuildHandler : GamePacketHandler
         Player sender = session.Player;
         Guild guild = session.Player.Guild;
 
+        if (guild == null)
+        {
+            return;
+        }
+
         byte senderRank = sender.GuildMember.Rank;
         GuildRank guildRank = guild.Ranks[senderRank];
 

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -4,6 +4,8 @@ using MapleServer2.Constants;
 using MapleServer2.Data.Static;
 using MapleServer2.Database;
 using MapleServer2.Enums;
+using MapleServer2.Managers;
+using MapleServer2.Network;
 using MapleServer2.PacketHandlers.Game.Helpers;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
@@ -568,16 +570,13 @@ public class GuildHandler : GamePacketHandler
             session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.InsufficientPermissions));
             return;
         }
+        
+        session.Send(GuildPacket.SendMail());
 
-        IEnumerable<long> guildMemberCharacterIds = guild.Members
-            .Select(m => m.Player.CharacterId)
-            .Where(i => i != sender.CharacterId);
-
-        foreach (long characterId in guildMemberCharacterIds)
+        IEnumerable<long> recipientIds = guild.Members.Select(c => c.Player.CharacterId);
+        foreach (long recipientId in recipientIds)
         {
-            MailHelper.SendMail(MailType.Player, characterId, sender.CharacterId, sender.Name, title, body, "", "", new(), 0, 0, out Mail mail);
-
-            session.Send(MailPacket.Send(mail));
+            MailHelper.SendMail(MailType.Player, recipientId, sender.CharacterId, sender.Name, title, body, "", "", new(), 0, 0, out Mail mail);
         }
     }
 

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -553,7 +553,7 @@ public class GuildHandler : GamePacketHandler
         string body = packet.ReadUnicodeString();
 
         Player sender = session.Player;
-        Guild guild = session.Player.Guild;
+        Guild guild = sender.Guild;
 
         if (guild == null)
         {

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -28,6 +28,7 @@ public class GuildHandler : GamePacketHandler
         GuildNotice = 0x3E,
         UpdateRank = 0x41,
         ListGuild = 0x42,
+        GuildMail = 0x45,
         SubmitApplication = 0x50,
         WithdrawApplication = 0x51,
         ApplicationResponse = 0x52,
@@ -122,6 +123,9 @@ public class GuildHandler : GamePacketHandler
                 break;
             case GuildMode.ListGuild:
                 HandleListGuild(session, packet);
+                break;
+            case GuildMode.GuildMail:
+                HandleGuildMail(session, packet);
                 break;
             case GuildMode.SubmitApplication:
                 HandleSubmitApplication(session, packet);
@@ -539,6 +543,11 @@ public class GuildHandler : GamePacketHandler
         guild.Searchable = toggle;
         session.Send(GuildPacket.ListGuildConfirm(toggle));
         session.Send(GuildPacket.ListGuildUpdate(session.Player, toggle));
+    }
+
+    private static void HandleGuildMail(GameSession session, PacketReader packet)
+    {
+        throw new NotImplementedException();
     }
 
     private static void HandleSubmitApplication(GameSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -565,14 +565,14 @@ public class GuildHandler : GamePacketHandler
 
         if (!guildRank.HasRight(GuildRights.CanGuildMail))
         {
-            session.Send(GuildPacket.ErrorNotice((byte)GuildErrorNotice.InsufficientPermissions));
+            session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.InsufficientPermissions));
             return;
         }
 
         IEnumerable<long> guildMemberCharacterIds = guild.Members
             .Select(m => m.Player.CharacterId)
             .Where(i => i != sender.CharacterId);
-        
+
         foreach (long characterId in guildMemberCharacterIds)
         {
             MailHelper.SendMail(MailType.Player, characterId, sender.CharacterId, sender.Name, title, body, "", "", new(), 0, 0, out Mail mail);

--- a/MapleServer2/Types/Guild/GuildRank.cs
+++ b/MapleServer2/Types/Guild/GuildRank.cs
@@ -10,6 +10,12 @@ public class GuildRank
         Name = name;
         Rights = rights;
     }
+
+    public bool HasRight(GuildRights guildRight)
+    {
+        GuildRights rights = (GuildRights) Rights;
+        return rights.HasFlag(guildRight);
+    }
 }
 [Flags]
 public enum GuildRights


### PR DESCRIPTION
Adds the ability to send guild mail
- Sends to all members including the sender
- Checks that the user has permission to do so, and displays appropriate error message if not
- Checks that the user is in a guild before sending, to avoid sneaky packet manipulating players
- Adds quick helper method to `GuildRank` to see if player's rank has appropriate flag set
  - This is useful in a couple other places in `GuildHandler`, but didn't want to create noise in this PR