### PR TITLE
Set max length of name in guilds schema to 25

### DIFF
--- a/MapleServer2/Database/SQL/Database.sql
+++ b/MapleServer2/Database/SQL/Database.sql
@@ -268,7 +268,7 @@ DROP TABLE IF EXISTS `guilds`;
 CREATE TABLE `guilds`
 (
     `id`                  bigint           NOT NULL AUTO_INCREMENT,
-    `name`                varchar(12)      NOT NULL,
+    `name`                varchar(25)      NOT NULL,
     `creation_timestamp`  bigint           NOT NULL,
     `leader_account_id`   bigint           NOT NULL,
     `leader_character_id` bigint           NOT NULL,


### PR DESCRIPTION
It was previously set to 12, which caused a crash when creating a guild with a longer name :D 

![image](https://user-images.githubusercontent.com/22443587/147424659-fd8e75c3-c6ca-42c2-b501-fb3ce92d83c4.png)

Unsure if I need to do anything else, but I guess if people have an existing DB they can make the change themselves easily enough.