### PR TITLE
Channel count constant

### DIFF
--- a/Maple2Storage/Json/Constants.json
+++ b/Maple2Storage/Json/Constants.json
@@ -54,5 +54,9 @@
   {
     "Key": "UGCShopProfitDelayInDays",
     "Value": "864000"
+  },
+  {
+    "Key": "ChannelCount",
+    "Value": "15"
   }
 ]

--- a/MapleServer2/Database/Classes/DatabaseAccount.cs
+++ b/MapleServer2/Database/Classes/DatabaseAccount.cs
@@ -31,9 +31,9 @@ public class DatabaseAccount : DatabaseTable
     public Account FindById(long id)
     {
         return ReadAccount(QueryFactory.Query(TableName).Where("accounts.id", id)
-                               .LeftJoin("homes", "homes.account_id", "accounts.id")
-                               .Select("accounts.{*}", "homes.id as home_id")
-                               .FirstOrDefault());
+            .LeftJoin("homes", "homes.account_id", "accounts.id")
+            .Select("accounts.{*}", "homes.id as home_id")
+            .FirstOrDefault());
     }
 
     public Account FindByUsername(string username)
@@ -51,6 +51,7 @@ public class DatabaseAccount : DatabaseTable
             account = dbAccount;
             return true;
         }
+
         return false;
     }
 
@@ -88,8 +89,8 @@ public class DatabaseAccount : DatabaseTable
         MushkingRoyaleStats royaleStats = DatabaseManager.MushkingRoyaleStats.FindById(data.mushking_royale_id);
         List<Medal> medals = DatabaseManager.MushkingRoyaleMedals.FindAllByAccountId(data.id);
 
-        return new Account(data.id, data.username, data.password_hash, data.creation_time, data.last_login_time,
-                           data.character_slots, data.meret, data.game_meret, data.event_meret, data.meso_token, data.home_id ?? 0,
-                           data.vip_expiration, data.meso_market_daily_listings, data.meso_market_monthly_purchases, bankInventory, royaleStats, medals, null);
+        return new(data.id, data.username, data.password_hash, data.creation_time, data.last_login_time,
+            data.character_slots, data.meret, data.game_meret, data.event_meret, data.meso_token, data.home_id ?? 0,
+            data.vip_expiration, data.meso_market_daily_listings, data.meso_market_monthly_purchases, bankInventory, royaleStats, medals, null, null);
     }
 }

--- a/MapleServer2/Network/Session.cs
+++ b/MapleServer2/Network/Session.cs
@@ -88,14 +88,14 @@ public abstract class Session : IDisposable
             return;
         }
 
-        if (this is LoginSession)
+        if (this is LoginSession loginSession)
         {
-            MapleServer.GetLoginServer().RemoveSession(this as LoginSession);
+            MapleServer.GetLoginServer().RemoveSession(loginSession);
         }
 
-        if (this is GameSession)
+        if (this is GameSession gameSession)
         {
-            MapleServer.GetGameServer().RemoveSession(this as GameSession);
+            MapleServer.GetGameServer().RemoveSession(gameSession);
         }
 
         Disposed = true;

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -39,7 +39,6 @@ public class LoginHandler : LoginPacketHandler
         ServerIPs = builder.ToImmutable();
         ServerName = Environment.GetEnvironmentVariable("NAME");
         ChannelCount = short.Parse(ConstantsMetadataStorage.GetConstant("ChannelCount"));
-
     }
 
     public override void Handle(LoginSession session, PacketReader packet)

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Data.Static;
 using MapleServer2.Database;
 using MapleServer2.Database.Types;
 using MapleServer2.Network;
@@ -20,6 +21,7 @@ public class LoginHandler : LoginPacketHandler
     // TODO: This data needs to be dynamic
     private readonly ImmutableList<IPEndPoint> ServerIPs;
     private readonly string ServerName;
+    private readonly short ChannelCount;
 
     private enum LoginMode : byte
     {
@@ -36,6 +38,8 @@ public class LoginHandler : LoginPacketHandler
 
         ServerIPs = builder.ToImmutable();
         ServerName = Environment.GetEnvironmentVariable("NAME");
+        ChannelCount = short.Parse(ConstantsMetadataStorage.GetConstant("ChannelCount"));
+
     }
 
     public override void Handle(LoginSession session, PacketReader packet)
@@ -87,6 +91,9 @@ public class LoginHandler : LoginPacketHandler
             case LoginMode.SendCharacters:
                 SendCharacters(session, account);
                 break;
+            default:
+                IPacketHandler<LoginSession>.LogUnknownMode(mode);
+                break;
         }
     }
 
@@ -95,7 +102,7 @@ public class LoginHandler : LoginPacketHandler
         List<Banner> banners = DatabaseManager.Banners.FindAllBanners();
         session.Send(NpsInfoPacket.SendUsername(account.Username));
         session.Send(BannerListPacket.SetBanner(banners));
-        session.SendFinal(ServerListPacket.SetServers(ServerName, ServerIPs), logoutNotice: true);
+        session.SendFinal(ServerListPacket.SetServers(ServerName, ServerIPs, ChannelCount), logoutNotice: true);
     }
 
     private void SendCharacters(LoginSession session, Account account)

--- a/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Data.Static;
 using MapleServer2.Database;
 using MapleServer2.Database.Types;
 using MapleServer2.Packets;
@@ -17,23 +18,26 @@ public class ServerEnterPacketHandler : LoginPacketHandler
     // TODO: This data needs to be dynamic
     private readonly ImmutableList<IPEndPoint> ServerIPs;
     private readonly string ServerName;
+    private readonly short ChannelCount;
 
     public ServerEnterPacketHandler()
     {
         ImmutableList<IPEndPoint>.Builder builder = ImmutableList.CreateBuilder<IPEndPoint>();
         string ipAddress = Environment.GetEnvironmentVariable("IP");
         int port = int.Parse(Environment.GetEnvironmentVariable("LOGIN_PORT"));
+
         builder.Add(new(IPAddress.Parse(ipAddress), port));
 
         ServerIPs = builder.ToImmutable();
         ServerName = Environment.GetEnvironmentVariable("NAME");
+        ChannelCount = short.Parse(ConstantsMetadataStorage.GetConstant("ChannelCount"));
     }
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
         List<Banner> banners = DatabaseManager.Banners.FindAllBanners();
         session.Send(BannerListPacket.SetBanner(banners));
-        session.Send(ServerListPacket.SetServers(ServerName, ServerIPs));
+        session.Send(ServerListPacket.SetServers(ServerName, ServerIPs, ChannelCount));
 
         List<Player> characters = DatabaseManager.Characters.FindAllByAccountId(session.AccountId);
 

--- a/MapleServer2/Packets/DynamicChannelPacket.cs
+++ b/MapleServer2/Packets/DynamicChannelPacket.cs
@@ -3,14 +3,14 @@ using MapleServer2.Constants;
 
 namespace MapleServer2.Packets;
 
-public class DynamicChannelPacket
+public static class DynamicChannelPacket
 {
-    public static PacketWriter DynamicChannel()
+    public static PacketWriter DynamicChannel(short channelCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.DYNAMIC_CHANNEL);
         pWriter.WriteByte();
         pWriter.WriteShort(10);
-        pWriter.WriteShort(9);
+        pWriter.WriteShort(channelCount);
         pWriter.WriteShort(9);
         pWriter.WriteShort(9);
         pWriter.WriteShort(9);

--- a/MapleServer2/Packets/ExperiencePacket.cs
+++ b/MapleServer2/Packets/ExperiencePacket.cs
@@ -1,6 +1,5 @@
 ﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
-using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
@@ -22,11 +21,11 @@ public static class ExperiencePacket
         return pWriter;
     }
 
-    public static PacketWriter LevelUp(IFieldObject<Player> fieldPlayer, int level)
+    public static PacketWriter LevelUp(int playerObjectId, int level)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.LEVEL_UP);
 
-        pWriter.WriteInt(fieldPlayer.ObjectId);
+        pWriter.WriteInt(playerObjectId);
         pWriter.WriteInt(level);
 
         return pWriter;

--- a/MapleServer2/Packets/PrestigePacket.cs
+++ b/MapleServer2/Packets/PrestigePacket.cs
@@ -32,23 +32,23 @@ public static class PrestigePacket
         return pWriter;
     }
 
-    public static PacketWriter ExpUp(Player player, long amount)
+    public static PacketWriter ExpUp(long prestigeExp, long amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PRESTIGE);
 
         pWriter.Write(PrestigePacketMode.PrestigeExp);
-        pWriter.WriteLong(player.Levels.PrestigeExp);
+        pWriter.WriteLong(prestigeExp);
         pWriter.WriteLong(amount);
 
         return pWriter;
     }
 
-    public static PacketWriter LevelUp(IFieldObject<Player> player, int level)
+    public static PacketWriter LevelUp(int playerObjectId, int level)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PRESTIGE);
 
         pWriter.Write(PrestigePacketMode.PrestigeLevel);
-        pWriter.WriteInt(player.ObjectId);
+        pWriter.WriteInt(playerObjectId);
         pWriter.WriteInt(level);
 
         return pWriter;

--- a/MapleServer2/Packets/ServerListPacket.cs
+++ b/MapleServer2/Packets/ServerListPacket.cs
@@ -7,11 +7,11 @@ namespace MapleServer2.Packets;
 
 public static class ServerListPacket
 {
-    public static PacketWriter SetServers(string serverName, ImmutableList<IPEndPoint> serverIps)
+    public static PacketWriter SetServers(string serverName, ImmutableList<IPEndPoint> serverIps, short channelCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SERVER_LIST);
 
-        pWriter.WriteByte(1); // If false packet isn't processed
+        pWriter.WriteBool(true); // If false packet isn't processed
         pWriter.WriteInt(1); // Unk.
         pWriter.WriteUnicodeString(serverName);
         pWriter.WriteByte(); // Unk.
@@ -25,9 +25,8 @@ public static class ServerListPacket
 
         pWriter.WriteInt(100); // Unk.
 
-        short nMultiServerChannel = 10; // Doesn't seems to go past 9 channels ingame ??
-        pWriter.WriteShort(nMultiServerChannel);
-        for (short i = 1; i <= nMultiServerChannel; ++i)
+        pWriter.WriteShort(channelCount);
+        for (short i = 1; i <= channelCount; ++i)
         {
             pWriter.WriteShort(i);
         }

--- a/MapleServer2/Types/Account.cs
+++ b/MapleServer2/Types/Account.cs
@@ -37,7 +37,7 @@ public class Account
     public Account(long accountId, string username, string passwordHash,
         long creationTime, long lastLoginTime, int characterSlots, long meretAmount,
         long gameMeretAmount, long eventMeretAmount, long mesoTokens, long homeId, long vipExpiration, int mesoMarketDailyListings, int mesoMarketMonthlyPurchases,
-        BankInventory bankInventory, MushkingRoyaleStats royaleStats, List<Medal> medals, AuthData authData)
+        BankInventory bankInventory, MushkingRoyaleStats royaleStats, List<Medal> medals, AuthData authData, GameSession gameSession)
     {
         Id = accountId;
         Username = username;
@@ -45,10 +45,10 @@ public class Account
         CreationTime = creationTime;
         LastLoginTime = lastLoginTime;
         CharacterSlots = characterSlots;
-        Meret = new(CurrencyType.Meret, meretAmount);
-        GameMeret = new(CurrencyType.GameMeret, gameMeretAmount);
-        EventMeret = new(CurrencyType.EventMeret, eventMeretAmount);
-        MesoToken = new(CurrencyType.MesoToken, mesoTokens);
+        Meret = new(CurrencyType.Meret, meretAmount, gameSession);
+        GameMeret = new(CurrencyType.GameMeret, gameMeretAmount, gameSession);
+        EventMeret = new(CurrencyType.EventMeret, eventMeretAmount, gameSession);
+        MesoToken = new(CurrencyType.MesoToken, mesoTokens, gameSession);
         BankInventory = bankInventory;
         MushkingRoyaleStats = royaleStats;
         VIPExpiration = vipExpiration;

--- a/MapleServer2/Types/Currency.cs
+++ b/MapleServer2/Types/Currency.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Types;
 
 public class Currency
 {
-    public GameSession Session;
+    private readonly GameSession Session;
     private readonly CurrencyType Type;
     public long Amount { get; private set; }
 

--- a/MapleServer2/Types/Currency.cs
+++ b/MapleServer2/Types/Currency.cs
@@ -6,16 +6,15 @@ namespace MapleServer2.Types;
 
 public class Currency
 {
-    public GameSession Session { private get; set; }
+    public GameSession Session;
     private readonly CurrencyType Type;
     public long Amount { get; private set; }
 
-    public Currency() { }
-
-    public Currency(CurrencyType type, long input)
+    public Currency(CurrencyType type, long input, GameSession gameSession = null)
     {
         Type = type;
         Amount = input;
+        Session = gameSession;
     }
 
     public bool Modify(long input)

--- a/MapleServer2/Types/Levels.cs
+++ b/MapleServer2/Types/Levels.cs
@@ -5,13 +5,17 @@ using MapleServer2.Enums;
 using MapleServer2.Managers;
 using MapleServer2.PacketHandlers.Game.Helpers;
 using MapleServer2.Packets;
+using MapleServer2.Servers.Game;
 
 namespace MapleServer2.Types;
 
 public class Levels
 {
     public readonly long Id;
-    public Player Player;
+    private readonly GameSession Session;
+    private Player Player => Session.Player;
+    private IFieldActor<Player> FieldPlayer => Player.FieldPlayer;
+
     public short Level { get; private set; }
     public long Exp { get; private set; }
     public long RestExp { get; private set; }
@@ -19,10 +23,8 @@ public class Levels
     public long PrestigeExp { get; private set; }
     public List<MasteryExp> MasteryExp { get; private set; }
 
-    public Levels() { }
-
     public Levels(short playerLevel, long exp, long restExp, int prestigeLevel, long prestigeExp,
-        List<MasteryExp> masteryExp, long id = 0)
+        List<MasteryExp> masteryExp, GameSession gameSession, long id = 0)
     {
         Level = playerLevel;
         Exp = exp;
@@ -30,6 +32,7 @@ public class Levels
         PrestigeLevel = prestigeLevel;
         PrestigeExp = prestigeExp;
         MasteryExp = masteryExp;
+        Session = gameSession;
 
         if (id == 0)
         {
@@ -44,8 +47,8 @@ public class Levels
     {
         Level = level;
         Exp = 0;
-        Player.Session.Send(ExperiencePacket.ExpUp(0, Exp, 0));
-        Player.Session.Send(ExperiencePacket.LevelUp(Player.FieldPlayer, Level));
+        Session.Send(ExperiencePacket.ExpUp(0, Exp, 0));
+        Session.Send(ExperiencePacket.LevelUp(FieldPlayer.ObjectId, Level));
 
         QuestHelper.GetNewQuests(Player);
     }
@@ -62,10 +65,10 @@ public class Levels
         TrophyManager.OnLevelUp(Player);
 
         Player.StatPointDistribution.AddTotalStatPoints(5);
-        Player.Session.FieldManager.BroadcastPacket(ExperiencePacket.LevelUp(Player.FieldPlayer, Level));
+        Session.FieldManager.BroadcastPacket(ExperiencePacket.LevelUp(FieldPlayer.ObjectId, Level));
         // TODO: Gain max HP
-        Player.FieldPlayer.RecoverHp(Player.FieldPlayer.Stats[StatId.Hp].Bonus);
-        Player.Session.Send(StatPointPacket.WriteTotalStatPoints(Player));
+        FieldPlayer.RecoverHp(FieldPlayer.Stats[StatId.Hp].Bonus);
+        Session.Send(StatPointPacket.WriteTotalStatPoints(Player));
 
         QuestHelper.GetNewQuests(Player);
         return true;
@@ -75,14 +78,14 @@ public class Levels
     {
         PrestigeLevel = level;
         PrestigeExp = 0;
-        Player.Session.Send(PrestigePacket.ExpUp(Player, 0));
-        Player.Session.Send(PrestigePacket.LevelUp(Player.FieldPlayer, PrestigeLevel));
+        Session.Send(PrestigePacket.ExpUp(0, 0));
+        Session.Send(PrestigePacket.LevelUp(FieldPlayer.ObjectId, PrestigeLevel));
     }
 
     public void PrestigeLevelUp()
     {
         PrestigeLevel++;
-        Player.Session.Send(PrestigePacket.LevelUp(Player.FieldPlayer, PrestigeLevel));
+        Session.Send(PrestigePacket.LevelUp(FieldPlayer.ObjectId, PrestigeLevel));
     }
 
     public void GainExp(int amount)
@@ -114,7 +117,7 @@ public class Levels
         }
 
         Exp = newExp;
-        Player.Session.Send(ExperiencePacket.ExpUp(amount, newExp, RestExp));
+        Session.Send(ExperiencePacket.ExpUp(amount, newExp, RestExp));
     }
 
     public void GainPrestigeExp(long amount)
@@ -135,7 +138,7 @@ public class Levels
         }
 
         PrestigeExp = newPrestigeExp;
-        Player.Session.Send(PrestigePacket.ExpUp(Player, amount));
+        Session.Send(PrestigePacket.ExpUp(PrestigeExp, amount));
     }
 
     public void GainMasteryExp(MasteryType type, long amount)
@@ -148,7 +151,7 @@ public class Levels
         }
 
         // user already has some exp in mastery, so simply update it
-        Player.Session.Send(MasteryPacket.SetExp(type, masteryExp.CurrentExp += amount));
+        Session.Send(MasteryPacket.SetExp(type, masteryExp.CurrentExp += amount));
         int currLevel = MasteryMetadataStorage.GetGradeFromXP(type, masteryExp.CurrentExp);
 
         if (currLevel <= masteryExp.Level)

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -162,8 +162,8 @@ public class Player
         Gender = gender;
         Job = job;
         GameOptions = new();
-        Wallet = new(0, 0, 0, 0, 0);
-        Levels = new(1, 0, 0, 1, 0, new()
+        Wallet = new(meso: 0, valorToken: 0, treva: 0, rue: 0, haviFruit: 0, gameSession: null);
+        Levels = new(playerLevel: 1, exp: 0, restExp: 0, prestigeLevel: 1, prestigeExp: 0, masteryExp: new()
         {
             new(MasteryType.Fishing),
             new(MasteryType.Performance),
@@ -176,7 +176,7 @@ public class Player
             new(MasteryType.Alchemy),
             new(MasteryType.Cooking),
             new(MasteryType.PetTaming)
-        });
+        }, gameSession: null);
         MapId = JobMetadataStorage.GetStartMapId((int) job);
         SavedCoord = MapEntityStorage.GetRandomPlayerSpawn(MapId).Coord.ToFloat();
         Stats = new(10, 10, 10, 10, 500, 10);

--- a/MapleServer2/Types/Wallet.cs
+++ b/MapleServer2/Types/Wallet.cs
@@ -1,5 +1,6 @@
 ﻿using Maple2Storage.Enums;
 using MapleServer2.Database;
+using MapleServer2.Servers.Game;
 
 namespace MapleServer2.Types;
 
@@ -13,13 +14,13 @@ public class Wallet
     public Currency Rue { get; private set; }
     public Currency HaviFruit { get; private set; }
 
-    public Wallet(long meso, long valorToken, long treva, long rue, long haviFruit, long id = 0)
+    public Wallet(long meso, long valorToken, long treva, long rue, long haviFruit, GameSession gameSession, long id = 0)
     {
-        Meso = new(CurrencyType.Meso, meso);
-        ValorToken = new(CurrencyType.ValorToken, valorToken);
-        Treva = new(CurrencyType.Treva, treva);
-        Rue = new(CurrencyType.Rue, rue);
-        HaviFruit = new(CurrencyType.HaviFruit, haviFruit);
+        Meso = new(CurrencyType.Meso, meso, gameSession);
+        ValorToken = new(CurrencyType.ValorToken, valorToken, gameSession);
+        Treva = new(CurrencyType.Treva, treva, gameSession);
+        Rue = new(CurrencyType.Rue, rue, gameSession);
+        HaviFruit = new(CurrencyType.HaviFruit, haviFruit, gameSession);
 
         if (id == 0)
         {


### PR DESCRIPTION
- Added a constant for channel count;
- Fixed packet `DynamicChannel`, no more hardcoded 9 channels limit;
- Simplified `Player.Session` initialization in `ResponseKeyHandler`;
- Simplified `Levels` use of **GameSession**, **Player** and **FieldPlayer**