### PR TITLE
Cleanup: MapleWebServer

### DIFF
--- a/MapleServer2/Database/Classes/DatabaseItem.cs
+++ b/MapleServer2/Database/Classes/DatabaseItem.cs
@@ -1,6 +1,5 @@
 ﻿using Maple2Storage.Enums;
 using Maple2Storage.Types;
-using MapleServer2.Data.Static;
 using MapleServer2.Enums;
 using MapleServer2.Types;
 using Newtonsoft.Json;
@@ -221,7 +220,6 @@ public class DatabaseItem : DatabaseTable
             PairedCharacterName = data.paired_character_name,
             PetSkinBadgeId = data.pet_skin_badge_id,
             RemainingGlamorForges = data.remaining_glamor_forges,
-            RecommendJobs = ItemMetadataStorage.GetRecommendJobs(data.id),
             RemainingTrades = data.remaining_trades,
             Score = JsonConvert.DeserializeObject<MusicScore>(data.score),
             Slot = data.slot,

--- a/MapleServer2/Managers/BlackMarketManager.cs
+++ b/MapleServer2/Managers/BlackMarketManager.cs
@@ -15,6 +15,7 @@ public class BlackMarketManager
         List<BlackMarketListing> list = DatabaseManager.BlackMarketListings.FindAll();
         foreach (BlackMarketListing listing in list)
         {
+            listing.Item.SetMetadataValues();
             AddListing(listing);
         }
     }

--- a/MapleWebServer/Controllers/ItemController.cs
+++ b/MapleWebServer/Controllers/ItemController.cs
@@ -3,38 +3,31 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace MapleWebServer.Controllers;
 
-[ApiController]
 public class ItemController : ControllerBase
 {
-    [Route("itemicon/ms2/01/{itemId}/{uuid}.png")]
-    [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileStream))]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpGet("itemicon/ms2/01/{itemId}/{uuid}.png")]
     public IActionResult GetItemIcon(string itemId, string uuid)
     {
-        string requestImagePath = HttpContext.Request.Path;
-        string fullPath = $"{Paths.DATA_DIR}/itemicon/{itemId}/{uuid}.png".Replace("$", "");
+        string fullPath = $"{Paths.DATA_DIR}/itemicon/{itemId}/{uuid}.png";
         if (!System.IO.File.Exists(fullPath))
         {
             return BadRequest();
         }
+
         Response.Headers.Add("content-type", "image/png");
         FileStream profileImage = System.IO.File.OpenRead(fullPath);
         return Ok(profileImage);
     }
 
-    [Route("item/ms2/01/{itemId}/{uuid}.m2u")]
-    [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileStream))]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpGet("item/ms2/01/{itemId}/{uuid}.m2u")]
     public IActionResult GetItem(string itemId, string uuid)
     {
-        string requestImagePath = HttpContext.Request.Path;
-        string fullPath = $"{Paths.DATA_DIR}/item/{itemId}/{uuid}.m2u".Replace("$", "");
+        string fullPath = $"{Paths.DATA_DIR}/item/{itemId}/{uuid}.m2u";
         if (!System.IO.File.Exists(fullPath))
         {
             return BadRequest();
         }
+
         Response.Headers.Add("content-type", "image/png");
         FileStream profileImage = System.IO.File.OpenRead(fullPath);
         return Ok(profileImage);

--- a/MapleWebServer/Controllers/ProfilesController.cs
+++ b/MapleWebServer/Controllers/ProfilesController.cs
@@ -3,28 +3,17 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace MapleWebServer.Controllers;
 
-[ApiController]
 public class ProfilesController : ControllerBase
 {
-    private readonly ILogger<ProfilesController> Logger;
-
-    public ProfilesController(ILogger<ProfilesController> logger)
-    {
-        Logger = logger;
-    }
-
-    [Route("data/profiles/avatar/{characterId}/{hash}.png")]
-    [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileStream))]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpGet("data/profiles/avatar/{characterId}/{hash}.png")]
     public IActionResult Get(string characterId, string hash)
     {
-        string requestImagePath = HttpContext.Request.Path;
-        string fullPath = $"{Paths.DATA_DIR}/profiles/{characterId}/{hash}.png".Replace("$", "");
+        string fullPath = $"{Paths.DATA_DIR}/profiles/{characterId}/{hash}.png";
         if (!System.IO.File.Exists(fullPath))
         {
             return BadRequest();
         }
+
         Response.Headers.Add("content-type", "image/png");
         FileStream profileImage = System.IO.File.OpenRead(fullPath);
         return Ok(profileImage);

--- a/MapleWebServer/Controllers/UploadController.cs
+++ b/MapleWebServer/Controllers/UploadController.cs
@@ -19,7 +19,7 @@ public class UploadController : ControllerBase
         Stream bodyStream = Request.Body;
 
         MemoryStream memoryStream = await CopyStream(bodyStream);
-        if (memoryStream.Capacity == 0)
+        if (memoryStream.Length == 0)
         {
             return BadRequest();
         }

--- a/MapleWebServer/Controllers/UploadController.cs
+++ b/MapleWebServer/Controllers/UploadController.cs
@@ -108,7 +108,7 @@ public class UploadController : ControllerBase
 
     private IActionResult HandleUnknownMode(PostUGCMode mode)
     {
-        Logger.Info($"Unknown mode: {mode}");
+        Logger.Info($"Unknown UGC post mode: {mode}");
         return BadRequest();
     }
 

--- a/MapleWebServer/Program.cs
+++ b/MapleWebServer/Program.cs
@@ -3,7 +3,7 @@ using Maple2Storage.Types;
 
 namespace MapleWebServer;
 
-public class Program
+public static class Program
 {
     public static void Main(string[] args)
     {
@@ -14,18 +14,17 @@ public class Program
         {
             throw new ArgumentException(".env file not found!");
         }
+
         DotEnv.Load(dotenv);
 
         CreateHostBuilder(args).Build().Run();
     }
 
-    public static IHostBuilder CreateHostBuilder(string[] args)
+    private static IHostBuilder CreateHostBuilder(string[] args)
     {
-        return Host.CreateDefaultBuilder(args)
-            .ConfigureWebHostDefaults(webBuilder =>
-            {
-                webBuilder.UseStartup<Startup>()
-                    .UseUrls(urls: $"http://*:{Environment.GetEnvironmentVariable("WEB_PORT")}");
-            });
+        return Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStartup<Startup>().UseUrls(urls: $"http://*:{Environment.GetEnvironmentVariable("WEB_PORT")}");
+        });
     }
 }

--- a/MapleWebServer/Startup.cs
+++ b/MapleWebServer/Startup.cs
@@ -4,17 +4,16 @@ namespace MapleWebServer;
 
 public class Startup
 {
+    private IConfiguration Configuration { get; }
+
     public Startup(IConfiguration configuration)
     {
         Configuration = configuration;
     }
 
-    public IConfiguration Configuration { get; }
-
     public void ConfigureServices(IServiceCollection services)
     {
-        services.Configure<KestrelServerOptions>(
-            Configuration.GetSection("Kestrel"));
+        services.Configure<KestrelServerOptions>(Configuration.GetSection("Kestrel"));
         services.AddControllers();
     }
 


### PR DESCRIPTION
- Fixed bug with creating UGC items:
    - Removed `ItemMetadataStorage` access from `DatabaseItem.ReadItem` function. If the **MapleWebServer** tries to use **ItemMetadataStorage** it'll fail since the metadata wasn't loaded.
    - Added missing `SetMetadataValues` in `BlackMarketManager`.