### PR TITLE
Fix: Level up packets

### DIFF
--- a/MapleServer2/Enums/FieldObjectUpdate.cs
+++ b/MapleServer2/Enums/FieldObjectUpdate.cs
@@ -6,7 +6,7 @@ public enum FieldObjectUpdate : byte
     None = 0,
     Type1 = 1,
     Move = 2,
-    Type3 = 4,
+    Level = 4,
     Type4 = 8,
     Type5 = 16,
     Type6 = 32,

--- a/MapleServer2/Packets/ExperiencePacket.cs
+++ b/MapleServer2/Packets/ExperiencePacket.cs
@@ -10,23 +10,12 @@ public static class ExperiencePacket
         PacketWriter pWriter = PacketWriter.Of(SendOp.EXP_UP);
 
         pWriter.WriteByte();
-        pWriter.WriteInt(expGained);
-        pWriter.WriteInt();
-        pWriter.WriteShort();
+        pWriter.WriteLong(expGained);
+        pWriter.WriteShort(); // means something
         pWriter.WriteLong(expTotal);
         pWriter.WriteLong(restExp);
         pWriter.WriteInt(); // counter? increments after every exp_up
         pWriter.WriteByte();
-
-        return pWriter;
-    }
-
-    public static PacketWriter LevelUp(int playerObjectId, int level)
-    {
-        PacketWriter pWriter = PacketWriter.Of(SendOp.LEVEL_UP);
-
-        pWriter.WriteInt(playerObjectId);
-        pWriter.WriteInt(level);
 
         return pWriter;
     }

--- a/MapleServer2/Packets/FieldObjectPacket.cs
+++ b/MapleServer2/Packets/FieldObjectPacket.cs
@@ -70,31 +70,50 @@ public static class FieldObjectPacket
         {
             pWriter.WriteByte();
         }
+
         if (flag.HasFlag(FieldObjectUpdate.Move))
         {
             pWriter.Write(player.Coord);
         }
-        if (flag.HasFlag(FieldObjectUpdate.Type3))
+
+        if (flag.HasFlag(FieldObjectUpdate.Level))
         {
-            pWriter.WriteShort();
+            pWriter.WriteShort(player.Value.Levels.Level);
         }
+
         if (flag.HasFlag(FieldObjectUpdate.Type4))
         {
             pWriter.WriteShort();
             pWriter.WriteInt();
         }
+
         if (flag.HasFlag(FieldObjectUpdate.Type5))
         {
             pWriter.WriteUnicodeString("Unknown");
         }
+
         if (flag.HasFlag(FieldObjectUpdate.Type6))
         {
             pWriter.WriteInt();
         }
+
         if (flag.HasFlag(FieldObjectUpdate.Animate))
         {
             pWriter.WriteShort(player.Animation);
         }
+
+        return pWriter;
+    }
+
+    // Temporary packet, we should be using the packet above
+    public static PacketWriter UpdateCharacterLevel(Player player)
+    {
+        PacketWriter pWriter = PacketWriter.Of(SendOp.FIELD_OBJECT);
+
+        pWriter.Write(FieldObjectMode.UpdateEntity);
+        pWriter.WriteInt(player.FieldPlayer.ObjectId);
+        pWriter.Write(FieldObjectUpdate.Level);
+        pWriter.WriteShort(player.Levels.Level);
 
         return pWriter;
     }

--- a/MapleServer2/Packets/LevelUpPacket.cs
+++ b/MapleServer2/Packets/LevelUpPacket.cs
@@ -1,0 +1,17 @@
+﻿using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+
+namespace MapleServer2.Packets;
+
+public static class LevelUpPacket
+{
+    public static PacketWriter LevelUp(int playerObjectId, short level)
+    {
+        PacketWriter pWriter = PacketWriter.Of(SendOp.LEVEL_UP);
+
+        pWriter.WriteInt(playerObjectId);
+        pWriter.WriteShort(level);
+
+        return pWriter;
+    }
+}

--- a/MapleServer2/Packets/RevivalConfirmPacket.cs
+++ b/MapleServer2/Packets/RevivalConfirmPacket.cs
@@ -1,0 +1,17 @@
+﻿using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+
+namespace MapleServer2.Packets;
+
+public class RevivalConfirmPacket
+{
+    public static PacketWriter Send(int objectId, long unk)
+    {
+        PacketWriter pWriter = PacketWriter.Of(SendOp.REVIVAL_CONFIRM);
+
+        pWriter.WriteInt(objectId);
+        pWriter.WriteLong(unk);
+
+        return pWriter;
+    }
+}

--- a/MapleServer2/Packets/StatPacket.cs
+++ b/MapleServer2/Packets/StatPacket.cs
@@ -60,6 +60,17 @@ public static class StatPacket
         return pWriter;
     }
 
+    public static PacketWriter UpdateFieldStats(IFieldActor<Player> player)
+    {
+        PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);
+        pWriter.WriteInt(player.ObjectId);
+        pWriter.WriteByte(); // Unknown (0x00/0x01)
+        pWriter.Write(StatsMode.SendStats);
+        pWriter.WriteFieldStats(player.Stats);
+
+        return pWriter;
+    }
+
     public static PacketWriter UpdateMobStats(IFieldActor mob)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.STAT);

--- a/MapleServer2/Types/Levels.cs
+++ b/MapleServer2/Types/Levels.cs
@@ -48,7 +48,8 @@ public class Levels
         Level = level;
         Exp = 0;
         Session.Send(ExperiencePacket.ExpUp(0, Exp, 0));
-        Session.Send(ExperiencePacket.LevelUp(FieldPlayer.ObjectId, Level));
+        Session.Send(LevelUpPacket.LevelUp(FieldPlayer.ObjectId, Level));
+        Session.FieldManager.BroadcastPacket(FieldObjectPacket.UpdateCharacterLevel(Player));
 
         QuestHelper.GetNewQuests(Player);
     }
@@ -62,14 +63,21 @@ public class Levels
 
         Level++;
 
-        TrophyManager.OnLevelUp(Player);
-
         Player.Stats.AddBaseStats(Player);
         Player.FieldPlayer.RecoverHp(FieldPlayer.Stats[StatId.Hp].Bonus);
 
-        Session.FieldManager.BroadcastPacket(ExperiencePacket.LevelUp(FieldPlayer.ObjectId, Level));
-        Session.Send(StatPacket.SetStats(FieldPlayer));
+        Session.FieldManager.BroadcastPacket(RevivalConfirmPacket.Send(FieldPlayer.ObjectId, 0));
+        Session.FieldManager.BroadcastPacket(LevelUpPacket.LevelUp(FieldPlayer.ObjectId, Level));
+        Session.FieldManager.BroadcastPacket(FieldObjectPacket.UpdateCharacterLevel(Player));
 
+        Session.FieldManager.BroadcastPacket(JobPacket.SendJob(FieldPlayer));
+
+        Session.Send(StatPacket.SetStats(FieldPlayer));
+        Session.FieldManager.BroadcastPacket(StatPacket.UpdateFieldStats(FieldPlayer), Session);
+
+        Session.Send(KeyTablePacket.SendFullOptions(Player.GameOptions));
+
+        TrophyManager.OnLevelUp(Player);
         QuestHelper.GetNewQuests(Player);
         return true;
     }

--- a/MapleServer2/Types/Levels.cs
+++ b/MapleServer2/Types/Levels.cs
@@ -48,7 +48,7 @@ public class Levels
         Level = level;
         Exp = 0;
         Session.Send(ExperiencePacket.ExpUp(0, Exp, 0));
-        Session.Send(LevelUpPacket.LevelUp(FieldPlayer.ObjectId, Level));
+        Session.FieldManager.BroadcastPacket(LevelUpPacket.LevelUp(FieldPlayer.ObjectId, Level));
         Session.FieldManager.BroadcastPacket(FieldObjectPacket.UpdateCharacterLevel(Player));
 
         QuestHelper.GetNewQuests(Player);


### PR DESCRIPTION
- Added Revival Confirm packet
- Separated Experience Up and Level up packets
- Renamed `FieldObjectUpdate.Type3` to `FieldObjectUpdate.Level`