### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,14 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "6.0.x"
           include-prerelease: true
+
       - name: Build
         run: dotnet build
+
       - name: Test
         run: dotnet test --no-build --verbosity normal
 
@@ -31,9 +35,6 @@ jobs:
         with:
           dotnet-version: "6.0.x"
           include-prerelease: true
-
-      - name: Install dotnet-format tool
-        run: dotnet tool install -g dotnet-format
 
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
No need to install dotnet-format since it's part of .NET 6 SDK

This doesn't fix the recently issues with dotnet-format action.