### PR TITLE
Extract Inventory interface - Make items private, restrict access to methods only

### DIFF
--- a/MapleServer2/Database/Classes/DatabaseCharacter.cs
+++ b/MapleServer2/Database/Classes/DatabaseCharacter.cs
@@ -85,7 +85,7 @@ public class DatabaseCharacter : DatabaseTable
 
         List<Hotbar> hotbars = DatabaseManager.Hotbars.FindAllByGameOptionsId(data.game_options_id);
         List<SkillTab> skillTabs = DatabaseManager.SkillTabs.FindAllByCharacterId(data.character_id, data.job);
-        Inventory inventory = DatabaseManager.Inventories.FindById(data.inventory_id);
+        IInventory inventory = DatabaseManager.Inventories.FindById(data.inventory_id);
         BankInventory bankInventory = DatabaseManager.BankInventories.FindById(data.bank_inventory_id);
         MushkingRoyaleStats royaleStats = DatabaseManager.MushkingRoyaleStats.FindById(data.mushking_royale_id);
         List<Medal> medals = DatabaseManager.MushkingRoyaleMedals.FindAllByAccountId(data.account_id);

--- a/MapleServer2/Database/Classes/DatabaseInventory.cs
+++ b/MapleServer2/Database/Classes/DatabaseInventory.cs
@@ -30,7 +30,7 @@ public class DatabaseInventory : DatabaseTable
         });
 
         List<Item> items = new();
-        items.AddRange(inventory.Items.Values.Where(x => x != null).ToList());
+        items.AddRange(inventory.GetItemsNotNull().ToList());
         items.AddRange(inventory.Equips.Values.Where(x => x != null).ToList());
         items.AddRange(inventory.Badges.Where(x => x != null).ToList());
         items.AddRange(inventory.Cosmetics.Values.Where(x => x != null).ToList());

--- a/MapleServer2/Database/Classes/DatabaseInventory.cs
+++ b/MapleServer2/Database/Classes/DatabaseInventory.cs
@@ -9,7 +9,7 @@ public class DatabaseInventory : DatabaseTable
 {
     public DatabaseInventory() : base("inventories") { }
 
-    public long Insert(Inventory inventory)
+    public long Insert(IInventory inventory)
     {
         return QueryFactory.Query(TableName).InsertGetId<long>(new
         {
@@ -17,12 +17,12 @@ public class DatabaseInventory : DatabaseTable
         });
     }
 
-    public Inventory FindById(long id)
+    public IInventory FindById(long id)
     {
         return ReadInventory(QueryFactory.Query(TableName).Where("id", id).FirstOrDefault());
     }
 
-    public void Update(Inventory inventory)
+    public void Update(IInventory inventory)
     {
         QueryFactory.Query(TableName).Where("id", inventory.Id).Update(new
         {
@@ -50,7 +50,7 @@ public class DatabaseInventory : DatabaseTable
         return QueryFactory.Query(TableName).Where("id", id).Delete() == 1;
     }
 
-    private static Inventory ReadInventory(dynamic data)
+    private static IInventory ReadInventory(dynamic data)
     {
         return new Inventory(data.id, JsonConvert.DeserializeObject<Dictionary<InventoryTab, short>>(data.extra_size), DatabaseManager.Items.FindAllByInventoryId(data.id));
     }

--- a/MapleServer2/Managers/ScriptManager.cs
+++ b/MapleServer2/Managers/ScriptManager.cs
@@ -22,7 +22,8 @@ public class ScriptManager
 
     public int GetItemCount(int itemId)
     {
-        return Player.Inventory.Items.Values.Where(x => x.Id == itemId).Sum(x => x.Amount);
+        return Player.Inventory.GetAllById(itemId)
+            .Sum(x => x.Amount);
     }
 
     public bool CanHold(int itemId, int amount)

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -557,7 +557,7 @@ public class BeautyHandler : GamePacketHandler
                 return false;
         }
 
-        Item voucher = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Tag == voucherTag).Value;
+        Item voucher = session.Player.Inventory.GetAllByTag(voucherTag).FirstOrDefault();
         if (voucher == null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.ItemNotFound, NoticeType.FastText));
@@ -606,7 +606,7 @@ public class BeautyHandler : GamePacketHandler
             case ShopCurrencyType.EventMeret:
                 return session.Player.Account.RemoveMerets(tokenCost);
             case ShopCurrencyType.Item:
-                Item itemCost = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == requiredItemId).Value;
+                Item itemCost = session.Player.Inventory.GetByUid(requiredItemId);
                 if (itemCost == null)
                 {
                     return false;

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -452,7 +452,7 @@ public class BeautyHandler : GamePacketHandler
         long itemUid = packet.ReadLong();
 
         Player player = session.Player;
-        Item voucher = player.Inventory.Items[itemUid];
+        Item voucher = player.Inventory.GetByUid(itemUid);
         if (voucher == null || voucher.Function.Name != "ItemChangeBeauty")
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -606,7 +606,7 @@ public class BeautyHandler : GamePacketHandler
             case ShopCurrencyType.EventMeret:
                 return session.Player.Account.RemoveMerets(tokenCost);
             case ShopCurrencyType.Item:
-                Item itemCost = session.Player.Inventory.GetByUid(requiredItemId);
+                Item itemCost = session.Player.Inventory.GetById(requiredItemId);
                 if (itemCost == null)
                 {
                     return false;

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -81,7 +81,8 @@ public class BlackMarketHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         int rarity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.Any(x => x.Value.Id == itemId && x.Value.Rarity == rarity))
+        IReadOnlyCollection<Item> items = session.Player.Inventory.GetAllById(itemId);
+        if (items.All(x => x.Rarity != rarity))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -120,7 +120,7 @@ public class BlackMarketHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = session.Player.Inventory.GetByUid(itemUid);
         if (item.Amount < quantity)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -103,7 +103,7 @@ public class BlackMarketHandler : GamePacketHandler
         long price = packet.ReadLong();
         int quantity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             session.Send(BlackMarketPacket.Error((int) BlackMarketError.ItemNotInInventory));
             return;

--- a/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
@@ -49,7 +49,7 @@ public class CardReverseGameHandler : GamePacketHandler
 
     private static void HandleMix(GameSession session)
     {
-        Item token = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == CardReverseGame.TOKEN_ITEM_ID).Value;
+        Item token = session.Player.Inventory.GetById(CardReverseGame.TOKEN_ITEM_ID);
         if (token == null || token.Amount < CardReverseGame.TOKEN_COST)
         {
             session.Send(CardReverseGamePacket.Notice());

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
@@ -49,7 +49,7 @@ public class ChangeAttributesHandler : GamePacketHandler
             lockStatId = packet.ReadShort();
         }
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
 
         int greenCrystalTotalAmount = 0;
         int metacellTotalAmount = 0;
@@ -176,7 +176,7 @@ public class ChangeAttributesHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         Item gear = inventory.TemporaryStorage.FirstOrDefault(x => x.Key == itemUid).Value;
         if (gear == null)
         {
@@ -190,7 +190,7 @@ public class ChangeAttributesHandler : GamePacketHandler
 
     private static void ConsumeMaterials(GameSession session, int greenCrystalCost, int metacellCosts, int crystalFragmentsCosts, List<KeyValuePair<long, Item>> greenCrystals, List<KeyValuePair<long, Item>> metacells, List<KeyValuePair<long, Item>> crystalFragments)
     {
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         foreach ((long uid, Item item) in greenCrystals)
         {
             if (item.Amount >= greenCrystalCost)

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
@@ -47,7 +47,7 @@ public class ChangeAttributesScrollHandler : GamePacketHandler
             lockStatId = packet.ReadShort();
         }
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         Item scroll = inventory.Items.FirstOrDefault(x => x.Key == scrollUid).Value;
         Item gear = inventory.Items.FirstOrDefault(x => x.Key == gearUid).Value;
         Item scrollLock = null;
@@ -106,7 +106,7 @@ public class ChangeAttributesScrollHandler : GamePacketHandler
     {
         long gearUid = packet.ReadLong();
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         Item gear = inventory.TemporaryStorage.FirstOrDefault(x => x.Key == gearUid).Value;
         if (gear == null)
         {

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
@@ -80,7 +80,7 @@ public class ChangeAttributesScrollHandler : GamePacketHandler
         {
             scrollLock = inventory.GetAllByTag(tag)
                 .FirstOrDefault(x => x.Rarity == gear.Rarity);
-            
+
             // Check if scroll lock exists in inventory
             if (scrollLock == null)
             {

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
@@ -48,8 +48,8 @@ public class ChangeAttributesScrollHandler : GamePacketHandler
         }
 
         IInventory inventory = session.Player.Inventory;
-        Item scroll = inventory.Items.FirstOrDefault(x => x.Key == scrollUid).Value;
-        Item gear = inventory.Items.FirstOrDefault(x => x.Key == gearUid).Value;
+        Item scroll = inventory.GetByUid(scrollUid);
+        Item gear = inventory.GetByUid(gearUid);
         Item scrollLock = null;
 
         // Check if gear and scroll exists in inventory
@@ -78,7 +78,9 @@ public class ChangeAttributesScrollHandler : GamePacketHandler
 
         if (useLock)
         {
-            scrollLock = inventory.Items.FirstOrDefault(x => x.Value.Tag == tag && x.Value.Rarity == gear.Rarity).Value;
+            scrollLock = inventory.GetAllByTag(tag)
+                .FirstOrDefault(x => x.Rarity == gear.Rarity);
+            
             // Check if scroll lock exists in inventory
             if (scrollLock == null)
             {

--- a/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
@@ -43,7 +43,7 @@ public class EmoteHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = session.Player.Inventory.GetByUid(itemUid);
 
         if (session.Player.Emotes.Contains(item.SkillId))
         {

--- a/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
@@ -38,7 +38,7 @@ public class EmoteHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -78,7 +78,7 @@ public class FishingHandler : GamePacketHandler
             return;
         }
 
-        Item fishingRod = session.Player.Inventory.Items[fishingRodUid];
+        Item fishingRod = session.Player.Inventory.GetByUid(fishingRodUid);
         FishingRodMetadata rodMetadata = FishingRodMetadataStorage.GetMetadata(fishingRod.Function.Id);
 
         if (rodMetadata.MasteryLimit < masteryExp.CurrentExp)

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -72,7 +72,7 @@ public class FishingHandler : GamePacketHandler
             return;
         }
 
-        if (!session.Player.Inventory.Items.ContainsKey(fishingRodUid))
+        if (!session.Player.Inventory.HasItem(fishingRodUid))
         {
             session.Send(FishingPacket.Notice((short) FishingNotice.InvalidFishingRod));
             return;

--- a/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
@@ -52,7 +52,7 @@ public static class ItemBoxHelper
             return;
         }
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         inventory.ConsumeItem(session, sourceItem.Uid, 1);
 
         // Select boxes disregards group ID. Adding these all to a filtered list
@@ -106,7 +106,7 @@ public static class ItemBoxHelper
             return;
         }
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         if (box.RequiredItemId > 0)
         {
             Item requiredItem = inventory.Items[box.RequiredItemId];

--- a/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
@@ -109,7 +109,7 @@ public static class ItemBoxHelper
         IInventory inventory = session.Player.Inventory;
         if (box.RequiredItemId > 0)
         {
-            Item requiredItem = inventory.Items[box.RequiredItemId];
+            Item requiredItem = inventory.GetByUid(box.RequiredItemId);
             if (requiredItem == null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -73,7 +73,7 @@ public class InstrumentHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             return;
         }
@@ -118,7 +118,7 @@ public class InstrumentHandler : GamePacketHandler
         long instrumentItemUid = packet.ReadLong();
         long scoreItemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(scoreItemUid) || !session.Player.Inventory.Items.ContainsKey(instrumentItemUid))
+        if (!session.Player.Inventory.HasItem(scoreItemUid) || !session.Player.Inventory.HasItem(instrumentItemUid))
         {
             return;
         }
@@ -168,7 +168,7 @@ public class InstrumentHandler : GamePacketHandler
         string scoreName = packet.ReadUnicodeString();
         string scoreNotes = packet.ReadString();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             return;
         }
@@ -196,7 +196,7 @@ public class InstrumentHandler : GamePacketHandler
             return;
         }
 
-        if (!session.Player.Inventory.Items.ContainsKey(scoreItemUid) || !session.Player.Inventory.Items.ContainsKey(instrumentItemUid))
+        if (!session.Player.Inventory.HasItem(scoreItemUid) || !session.Player.Inventory.HasItem(instrumentItemUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -78,7 +78,7 @@ public class InstrumentHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = session.Player.Inventory.GetByUid(itemUid);
 
         InstrumentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(item.Function.Id);
         InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
@@ -123,12 +123,12 @@ public class InstrumentHandler : GamePacketHandler
             return;
         }
 
-        Item instrumentItem = session.Player.Inventory.Items[instrumentItemUid];
+        Item instrumentItem = session.Player.Inventory.GetByUid(instrumentItemUid);
 
         InstrumentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(instrumentItem.Function.Id);
         InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
 
-        Item score = session.Player.Inventory.Items[scoreItemUid];
+        Item score = session.Player.Inventory.GetByUid(scoreItemUid);
 
         if (score.PlayCount <= 0)
         {
@@ -173,7 +173,7 @@ public class InstrumentHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = session.Player.Inventory.GetByUid(itemUid);
 
         item.Score.Length = length;
         item.Score.Type = instrumentType;
@@ -202,14 +202,14 @@ public class InstrumentHandler : GamePacketHandler
         }
 
 
-        Item score = session.Player.Inventory.Items[scoreItemUid];
+        Item score = session.Player.Inventory.GetByUid(scoreItemUid);
 
         if (score.PlayCount <= 0)
         {
             return;
         }
 
-        Item instrumentItem = session.Player.Inventory.Items[instrumentItemUid];
+        Item instrumentItem = session.Player.Inventory.GetByUid(instrumentItemUid);
         InstrumentInfoMetadata instrumentInfo = InstrumentInfoMetadataStorage.GetMetadata(instrumentItem.Function.Id);
         InstrumentCategoryInfoMetadata instrumentCategory = InstrumentCategoryInfoMetadataStorage.GetMetadata(instrumentInfo.Category);
         Instrument instrument = new(instrumentCategory.GMId, instrumentCategory.PercussionId, score.IsCustomScore, session.Player.FieldPlayer.ObjectId)

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
@@ -46,39 +46,51 @@ public class ItemEnchantHandler : GamePacketHandler
         byte type = packet.ReadByte();
         long itemUid = packet.ReadLong();
 
-        if (session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        Item item = session.Player.Inventory.GetByUid(itemUid);
+
+        if (item == null)
         {
-            session.Send(ItemEnchantPacket.BeginEnchant(type, item));
+            return;
         }
+
+        session.Send(ItemEnchantPacket.BeginEnchant(type, item));
     }
 
     private static void HandleOpheliaEnchant(GameSession session, PacketReader packet)
     {
         long itemUid = packet.ReadLong();
 
-        if (session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        Item item = session.Player.Inventory.GetByUid(itemUid);
+
+        if (item == null)
         {
-            item.Enchants += 5;
-            item.Charges += 10;
-            session.Send(ItemEnchantPacket.EnchantResult(item));
+            return;
         }
+
+        item.Enchants += 5;
+        item.Charges += 10;
+        session.Send(ItemEnchantPacket.EnchantResult(item));
     }
 
     private static void HandlePeachyEnchant(GameSession session, PacketReader packet)
     {
         long itemUid = packet.ReadLong();
 
-        if (session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        Item item = session.Player.Inventory.GetByUid(itemUid);
+        
+        if (item == null)
         {
-            item.EnchantExp += 5000;
-            if (item.EnchantExp >= 10000)
-            {
-                item.EnchantExp %= 10000;
-                item.Enchants++;
-            }
-
-            session.Send(ItemEnchantPacket.EnchantResult(item));
-            session.Send(ItemEnchantPacket.UpdateCharges(item));
+            return;
         }
+
+        item.EnchantExp += 5000;
+        if (item.EnchantExp >= 10000)
+        {
+            item.EnchantExp %= 10000;
+            item.Enchants++;
+        }
+
+        session.Send(ItemEnchantPacket.EnchantResult(item));
+        session.Send(ItemEnchantPacket.UpdateCharges(item));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
@@ -77,7 +77,7 @@ public class ItemEnchantHandler : GamePacketHandler
         long itemUid = packet.ReadLong();
 
         Item item = session.Player.Inventory.GetByUid(itemUid);
-        
+
         if (item == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -46,7 +46,7 @@ public class ItemEquipHandler : GamePacketHandler
         }
 
         // Remove the item from the users inventory
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         inventory.RemoveItem(session, itemUid, out Item item);
         if (item == null)
         {
@@ -128,7 +128,7 @@ public class ItemEquipHandler : GamePacketHandler
     private static void HandleUnequipItem(GameSession session, PacketReader packet)
     {
         long itemUid = packet.ReadLong();
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
 
         // Unequip gear
         (ItemSlot itemSlot, Item item) = inventory.Equips.FirstOrDefault(x => x.Value.Uid == itemUid);

--- a/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
@@ -90,12 +90,10 @@ public class ItemExchangeHandler : GamePacketHandler
     {
         // TODO: Check if rarity matches
 
-        List<Item> playerInventoryItems = new(session.Player.Inventory.Items.Values);
-
         for (int i = 0; i < exchange.ItemCost.Count; i++)
         {
             ItemRequirementMetadata exchangeItem = exchange.ItemCost.ElementAt(i);
-            Item item = playerInventoryItems.FirstOrDefault(x => x.Id == exchangeItem.Id);
+            Item item = session.Player.Inventory.GetById(exchangeItem.Id);
 
             if (item == null)
             {
@@ -110,14 +108,12 @@ public class ItemExchangeHandler : GamePacketHandler
 
     private static bool RemoveRequiredItemsFromInventory(GameSession session, ItemExchangeScrollMetadata exchange, Item originItem, int quantity)
     {
-        List<Item> playerInventoryItems = new(session.Player.Inventory.Items.Values);
-
         if (exchange.ItemCost.Count != 0)
         {
             for (int i = 0; i < exchange.ItemCost.Count; i++)
             {
                 ItemRequirementMetadata exchangeItem = exchange.ItemCost.ElementAt(i);
-                Item item = playerInventoryItems.FirstOrDefault(x => x.Id == exchangeItem.Id);
+                Item item = session.Player.Inventory.GetById(exchangeItem.Id);
                 if (item == null)
                 {
                     continue;

--- a/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
@@ -50,7 +50,7 @@ public class ItemExchangeHandler : GamePacketHandler
         long unk = packet.ReadLong();
         int quantity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
@@ -55,7 +55,7 @@ public class ItemExchangeHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = session.Player.Inventory.GetByUid(itemUid);
 
         ItemExchangeScrollMetadata exchange = ItemExchangeScrollMetadataStorage.GetMetadata(item.Function.Id);
 

--- a/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
@@ -17,7 +17,7 @@ public class ItemExtractionHandler : GamePacketHandler
         long anvilItemUid = packet.ReadLong();
         long sourceItemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(sourceItemUid) || !session.Player.Inventory.Items.ContainsKey(anvilItemUid))
+        if (!session.Player.Inventory.HasItem(sourceItemUid) || !session.Player.Inventory.HasItem(anvilItemUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
@@ -30,9 +30,8 @@ public class ItemExtractionHandler : GamePacketHandler
             return;
         }
 
-        int anvilAmount = 0;
-        List<KeyValuePair<long, Item>> anvils = session.Player.Inventory.Items.Where(x => x.Value.Tag == "ItemExtraction").ToList();
-        anvils.ForEach(x => anvilAmount += x.Value.Amount);
+        IReadOnlyCollection<Item> anvils = session.Player.Inventory.GetAllByTag("ItemExtraction");
+        int anvilAmount = anvils.Sum(x => x.Amount);
 
         if (anvilAmount < metadata.ScrollCount)
         {

--- a/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
@@ -22,7 +22,7 @@ public class ItemExtractionHandler : GamePacketHandler
             return;
         }
 
-        Item sourceItem = session.Player.Inventory.Items[sourceItemUid];
+        Item sourceItem = session.Player.Inventory.GetByUid(sourceItemUid);
 
         ItemExtractionMetadata metadata = ItemExtractionMetadataStorage.GetMetadata(sourceItem.Id);
         if (metadata == null)

--- a/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
@@ -45,8 +45,8 @@ public class ItemRepackageHandler : GamePacketHandler
         long ribbonUid = packet.ReadLong();
         long repackingItemUid = packet.ReadLong();
 
-        Item ribbon = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Uid == ribbonUid);
-        Item repackingItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Uid == repackingItemUid);
+        Item ribbon = session.Player.Inventory.GetByUid(ribbonUid);
+        Item repackingItem = session.Player.Inventory.GetByUid(repackingItemUid);
         if (repackingItem == null || ribbon == null)
         {
             session.Send(ItemRepackagePacket.Notice((int) ItemRepackageNotice.ItemInvalid));

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -117,25 +117,24 @@ public class ItemSocketSystemHandler : GamePacketHandler
             crystalFragmentCost = 600;
         }
 
-        int crystalFragmentsTotalAmount = 0;
-        List<KeyValuePair<long, Item>> crystalFragments = inventory.Items.Where(x => x.Value.Tag == "CrystalPiece").ToList();
-        crystalFragments.ForEach(x => crystalFragmentsTotalAmount += x.Value.Amount);
+        IReadOnlyCollection<Item> crystalFragments = inventory.GetAllByTag("CrystalPiece");
+        int crystalFragmentsTotalAmount = crystalFragments.Sum(x => x.Amount);
 
         if (crystalFragmentsTotalAmount < crystalFragmentCost)
         {
             return;
         }
 
-        foreach ((long uid, Item item) in crystalFragments)
+        foreach (Item item in crystalFragments)
         {
             if (item.Amount >= crystalFragmentCost)
             {
-                inventory.ConsumeItem(session, uid, crystalFragmentCost);
+                inventory.ConsumeItem(session, item.Uid, crystalFragmentCost);
                 break;
             }
 
             crystalFragmentCost -= item.Amount;
-            inventory.ConsumeItem(session, uid, item.Amount);
+            inventory.ConsumeItem(session, item.Uid, item.Amount);
         }
         foreach (long uid in fodderUids)
         {
@@ -265,9 +264,8 @@ public class ItemSocketSystemHandler : GamePacketHandler
     {
         for (int i = 0; i < metadata.IngredientItems.Count; i++)
         {
-            int inventoryItemCount = 0;
-            List<KeyValuePair<long, Item>> ingredients = inventory.Items.Where(x => x.Value.Tag == metadata.IngredientItems[i]).ToList();
-            ingredients.ForEach(x => inventoryItemCount += x.Value.Amount);
+            IReadOnlyCollection<Item> ingredients = inventory.GetAllByTag(metadata.IngredientItems[i]);
+            int inventoryItemCount = ingredients.Sum(x => x.Amount);
 
             if (inventoryItemCount < metadata.IngredientAmounts[i])
             {
@@ -281,18 +279,18 @@ public class ItemSocketSystemHandler : GamePacketHandler
     {
         for (int i = 0; i < metadata.IngredientItems.Count; i++)
         {
-            List<KeyValuePair<long, Item>> ingredients = session.Player.Inventory.Items.Where(x => x.Value.Tag == metadata.IngredientItems[i]).ToList();
+            IReadOnlyCollection<Item> ingredients = session.Player.Inventory.GetAllByTag(metadata.IngredientItems[i]);
 
-            foreach ((long uid, Item item) in ingredients)
+            foreach (Item item in ingredients)
             {
                 if (item.Amount >= metadata.IngredientAmounts[i])
                 {
-                    session.Player.Inventory.ConsumeItem(session, uid, metadata.IngredientAmounts[i]);
+                    session.Player.Inventory.ConsumeItem(session, item.Uid, metadata.IngredientAmounts[i]);
                     break;
                 }
 
                 metadata.IngredientAmounts[i] -= item.Amount;
-                session.Player.Inventory.ConsumeItem(session, uid, item.Amount);
+                session.Player.Inventory.ConsumeItem(session, item.Uid, item.Amount);
             }
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -72,7 +72,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         }
 
         IInventory inventory = session.Player.Inventory;
-        if (!inventory.Items.ContainsKey(itemUid))
+        if (!inventory.HasItem(itemUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;
@@ -82,7 +82,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
 
         foreach (long uid in fodderUids)
         {
-            if (!inventory.Items.ContainsKey(uid))
+            if (!inventory.HasItem(uid))
             {
                 session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
                 return;
@@ -154,7 +154,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         byte slot = packet.ReadByte();
         long itemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;
@@ -174,7 +174,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         IInventory inventory = session.Player.Inventory;
         if (equipUid == 0) // this is a gemstone in the player's inventory
         {
-            if (!inventory.Items.ContainsKey(itemUid))
+            if (!inventory.HasItem(itemUid))
             {
                 session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
                 return;
@@ -210,7 +210,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         }
 
         // upgrade gem mounted on a equipment
-        if (!inventory.Items.ContainsKey(equipUid))
+        if (!inventory.HasItem(equipUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;
@@ -305,7 +305,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
 
         if (equipUid == 0) // this is a gemstone in the player's inventory
         {
-            if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+            if (!session.Player.Inventory.HasItem(itemUid))
             {
                 session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
                 return;
@@ -316,7 +316,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         }
 
         // select gem mounted on a equipment
-        if (!session.Player.Inventory.Items.ContainsKey(equipUid))
+        if (!session.Player.Inventory.HasItem(equipUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;
@@ -337,13 +337,13 @@ public class ItemSocketSystemHandler : GamePacketHandler
         long gemItemUid = packet.ReadLong();
         byte slot = packet.ReadByte();
 
-        if (!session.Player.Inventory.Items.ContainsKey(equipItemUid))
+        if (!session.Player.Inventory.HasItem(equipItemUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.TargetIsNotInYourInventory));
             return;
         }
 
-        if (!session.Player.Inventory.Items.ContainsKey(gemItemUid))
+        if (!session.Player.Inventory.HasItem(gemItemUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;
@@ -385,7 +385,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         long equipItemUid = packet.ReadLong();
         byte slot = packet.ReadByte();
 
-        if (!session.Player.Inventory.Items.ContainsKey(equipItemUid))
+        if (!session.Player.Inventory.HasItem(equipItemUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -77,7 +77,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
             return;
         }
-        Item equip = inventory.Items[itemUid];
+        Item equip = inventory.GetByUid(itemUid);
         int equipUnlockedSlotCount = equip.Stats.GemSockets.Count(x => x.IsUnlocked);
 
         foreach (long uid in fodderUids)
@@ -88,7 +88,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
                 return;
             }
 
-            Item fodder = inventory.Items[uid];
+            Item fodder = inventory.GetByUid(uid);
             int fodderUnlockedSlotCount = fodder.Stats.GemSockets.Count(x => x.IsUnlocked);
             if (equipUnlockedSlotCount == fodderUnlockedSlotCount)
             {
@@ -180,7 +180,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
                 return;
             }
 
-            Item gem = inventory.Items[itemUid];
+            Item gem = inventory.GetByUid(itemUid);
             if (gem == null)
             {
                 return;
@@ -216,7 +216,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             return;
         }
 
-        Gemstone gemstone = inventory.Items[equipUid].Stats.GemSockets[slot].Gemstone;
+        Gemstone gemstone = inventory.GetByUid(equipUid).Stats.GemSockets[slot].Gemstone;
         if (gemstone == null)
         {
             return;
@@ -257,7 +257,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             OwnerName = gemstone.OwnerName
         };
 
-        inventory.Items[equipUid].Stats.GemSockets[slot].Gemstone = gemstone;
+        inventory.GetByUid(equipUid).Stats.GemSockets[slot].Gemstone = gemstone;
         session.Send(ItemSocketSystemPacket.UpgradeGem(equipUid, slot, newGem));
     }
 
@@ -322,7 +322,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             return;
         }
 
-        Gemstone gemstone = session.Player.Inventory.Items[equipUid].Stats.GemSockets[slot].Gemstone;
+        Gemstone gemstone = session.Player.Inventory.GetByUid(equipUid).Stats.GemSockets[slot].Gemstone;
         if (gemstone == null)
         {
             return;
@@ -349,8 +349,8 @@ public class ItemSocketSystemHandler : GamePacketHandler
             return;
         }
 
-        Item equipItem = session.Player.Inventory.Items[equipItemUid];
-        Item gemItem = session.Player.Inventory.Items[gemItemUid];
+        Item equipItem = session.Player.Inventory.GetByUid(equipItemUid);
+        Item gemItem = session.Player.Inventory.GetByUid(gemItemUid);
 
         if (!equipItem.Stats.GemSockets[slot].IsUnlocked)
         {
@@ -391,7 +391,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             return;
         }
 
-        Item equipItem = session.Player.Inventory.Items[equipItemUid];
+        Item equipItem = session.Player.Inventory.GetByUid(equipItemUid);
 
         if (equipItem.Stats.GemSockets[slot].Gemstone == null)
         {

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -71,7 +71,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             fodderUids.Add(fodderUid);
         }
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         if (!inventory.Items.ContainsKey(itemUid))
         {
             session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
@@ -171,7 +171,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
 
         ItemGemstoneUpgradeMetadata metadata;
 
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
         if (equipUid == 0) // this is a gemstone in the player's inventory
         {
             if (!inventory.Items.ContainsKey(itemUid))
@@ -261,7 +261,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         session.Send(ItemSocketSystemPacket.UpgradeGem(equipUid, slot, newGem));
     }
 
-    private static bool CheckGemUpgradeIngredients(Inventory inventory, ItemGemstoneUpgradeMetadata metadata)
+    private static bool CheckGemUpgradeIngredients(IInventory inventory, ItemGemstoneUpgradeMetadata metadata)
     {
         for (int i = 0; i < metadata.IngredientItems.Count; i++)
         {

--- a/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
@@ -59,7 +59,7 @@ public class LapenshardHandler : GamePacketHandler
         int slotId = packet.ReadInt();
         long itemUid = packet.ReadLong();
 
-        session.Player.Inventory.Items.TryGetValue(itemUid, out Item item);
+        Item item = session.Player.Inventory.GetByUid(itemUid);
         if (item is null)
         {
             return;
@@ -112,8 +112,8 @@ public class LapenshardHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         packet.ReadInt();
         IInventory inventory = session.Player.Inventory;
-
-        if (!inventory.Items.TryGetValue(itemUid, out Item item))
+        
+        if (!inventory.HasItem(itemUid))
         {
             return;
         }
@@ -129,7 +129,8 @@ public class LapenshardHandler : GamePacketHandler
         int amount = packet.ReadInt();
         IInventory inventory = session.Player.Inventory;
 
-        if (!inventory.Items.TryGetValue(itemUid, out Item item) || item.Amount < amount)
+        Item item = inventory.GetByUid(itemUid);
+        if (item == null || item.Amount < amount)
         {
             return;
         }
@@ -158,7 +159,8 @@ public class LapenshardHandler : GamePacketHandler
         // Check if items are in inventory
         foreach ((long uid, int amount) in items)
         {
-            if (!inventory.Items.TryGetValue(uid, out Item item) || item.Amount < amount)
+            Item item = inventory.GetByUid(uid);
+            if (item == null || item.Amount < amount)
             {
                 return;
             }
@@ -193,12 +195,12 @@ public class LapenshardHandler : GamePacketHandler
             { 9, new(50, 305, 6100000) }
         };
 
-        int crystalsTotalAmount = 0;
 
         // There are multiple ids for each type of material
         // Count all items with the same tag in inventory
-        List<KeyValuePair<long, Item>> crystals = inventory.Items.Where(x => x.Value.Tag == crystal).ToList();
-        crystals.ForEach(x => crystalsTotalAmount += x.Value.Amount);
+        IReadOnlyCollection<Item> crystals = inventory.GetAllByTag(crystal).ToList();
+        int crystalsTotalAmount = crystals.Sum(x => x.Amount);
+        
         byte tier = (byte) (itemId % 10);
 
         if (costs[tier].CrystalsAmount > crystalsTotalAmount || !session.Player.Wallet.Meso.Modify(-costs[tier].Mesos))
@@ -209,15 +211,15 @@ public class LapenshardHandler : GamePacketHandler
         int crystalCost = costs[tier].CrystalsAmount;
 
         // Consume all Crystals
-        foreach ((long uid, Item item) in crystals)
+        foreach (Item item in crystals)
         {
             if (item.Amount >= crystalCost)
             {
-                session.Player.Inventory.ConsumeItem(session, uid, crystalCost);
+                session.Player.Inventory.ConsumeItem(session, item.Uid, crystalCost);
                 break;
             }
             crystalCost -= item.Amount;
-            session.Player.Inventory.ConsumeItem(session, uid, item.Amount);
+            session.Player.Inventory.ConsumeItem(session, item.Uid, item.Amount);
         }
 
         // Consume all Lapenshards

--- a/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
@@ -112,7 +112,7 @@ public class LapenshardHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         packet.ReadInt();
         IInventory inventory = session.Player.Inventory;
-        
+
         if (!inventory.HasItem(itemUid))
         {
             return;
@@ -200,7 +200,7 @@ public class LapenshardHandler : GamePacketHandler
         // Count all items with the same tag in inventory
         IReadOnlyCollection<Item> crystals = inventory.GetAllByTag(crystal).ToList();
         int crystalsTotalAmount = crystals.Sum(x => x.Amount);
-        
+
         byte tier = (byte) (itemId % 10);
 
         if (costs[tier].CrystalsAmount > crystalsTotalAmount || !session.Player.Wallet.Meso.Modify(-costs[tier].Mesos))

--- a/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
@@ -111,7 +111,7 @@ public class LapenshardHandler : GamePacketHandler
         long itemUid = packet.ReadLong();
         int itemId = packet.ReadInt();
         packet.ReadInt();
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
 
         if (!inventory.Items.TryGetValue(itemUid, out Item item))
         {
@@ -127,7 +127,7 @@ public class LapenshardHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         packet.ReadInt();
         int amount = packet.ReadInt();
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
 
         if (!inventory.Items.TryGetValue(itemUid, out Item item) || item.Amount < amount)
         {
@@ -144,7 +144,7 @@ public class LapenshardHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         packet.ReadInt();
         int catalystCount = packet.ReadInt();
-        Inventory inventory = session.Player.Inventory;
+        IInventory inventory = session.Player.Inventory;
 
         List<(long Uid, int Amount)> items = new();
         for (int i = 0; i < catalystCount; i++)

--- a/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
@@ -75,7 +75,7 @@ public class MapleopolyHandler : GamePacketHandler
 
         int tokenAmount = 0;
         int tokenItemId = int.Parse(ConstantsMetadataStorage.GetConstant("MapleopolyTokenItemId"));
-        Item token = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == tokenItemId).Value;
+        Item token = session.Player.Inventory.GetById(tokenItemId);
         if (token != null)
         {
             tokenAmount = token.Amount;
@@ -92,7 +92,7 @@ public class MapleopolyHandler : GamePacketHandler
         int tokenItemId = int.Parse(ConstantsMetadataStorage.GetConstant("MapleopolyTokenItemId"));
         int tokenCost = int.Parse(ConstantsMetadataStorage.GetConstant("MapleopolyTokenCost"));
 
-        Item token = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == tokenItemId).Value;
+        Item token = session.Player.Inventory.GetById(tokenItemId);
 
         int.TryParse(freeRollValue.EventValue, out int freeRolls);
 

--- a/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
@@ -135,7 +135,7 @@ public class MasteryHandler : GamePacketHandler
         {
             Item item = session.Player.Inventory.GetAllById(ingredient.ItemId)
                 .FirstOrDefault(x => x.Rarity == ingredient.Rarity);
-            
+
             if (item == null || item.Amount < ingredient.Amount)
             {
                 return false;
@@ -191,7 +191,7 @@ public class MasteryHandler : GamePacketHandler
         {
             Item item = session.Player.Inventory.GetAllById(ingredient.ItemId)
                 .FirstOrDefault(x => x.Rarity == ingredient.Rarity);
-            
+
             if (item == null || item.Amount < ingredient.Amount)
             {
                 return false;

--- a/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
@@ -133,7 +133,9 @@ public class MasteryHandler : GamePacketHandler
 
         foreach (RecipeItem ingredient in ingredients)
         {
-            Item item = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == ingredient.ItemId && x.Rarity == ingredient.Rarity);
+            Item item = session.Player.Inventory.GetAllById(ingredient.ItemId)
+                .FirstOrDefault(x => x.Rarity == ingredient.Rarity);
+            
             if (item == null || item.Amount < ingredient.Amount)
             {
                 return false;
@@ -187,7 +189,9 @@ public class MasteryHandler : GamePacketHandler
 
         foreach (RecipeItem ingredient in ingredients)
         {
-            Item item = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == ingredient.ItemId && x.Rarity == ingredient.Rarity);
+            Item item = session.Player.Inventory.GetAllById(ingredient.ItemId)
+                .FirstOrDefault(x => x.Rarity == ingredient.Rarity);
+            
             if (item == null || item.Amount < ingredient.Amount)
             {
                 return false;

--- a/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
@@ -115,7 +115,7 @@ public class MeretMarketHandler : GamePacketHandler
 
         if (session.Player.Inventory.HasItem(itemUid))
         {
-            item = session.Player.Inventory.Items[itemUid];
+            item = session.Player.Inventory.GetByUid(itemUid);
         }
         else if (session.Player.Account.Home.WarehouseInventory.ContainsKey(itemUid))
         {

--- a/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
@@ -113,7 +113,7 @@ public class MeretMarketHandler : GamePacketHandler
 
         Item item = null;
 
-        if (session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (session.Player.Inventory.HasItem(itemUid))
         {
             item = session.Player.Inventory.Items[itemUid];
         }

--- a/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
@@ -65,7 +65,7 @@ public class RequestItemStorage : GamePacketHandler
         short slot = packet.ReadShort();
         int amount = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.ContainsKey(uid))
+        if (!session.Player.Inventory.HasItem(uid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
@@ -23,7 +23,7 @@ public class RequestItemUseHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        if (!session.Player.Inventory.HasItem(itemUid))
         {
             return;
         }
@@ -350,7 +350,7 @@ public class RequestItemUseHandler : GamePacketHandler
     public static void HandlePetExtraction(GameSession session, PacketReader packet, Item item)
     {
         long petUid = long.Parse(packet.ReadUnicodeString());
-        if (!session.Player.Inventory.Items.ContainsKey(petUid))
+        if (!session.Player.Inventory.HasItem(petUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
@@ -28,7 +28,7 @@ public class RequestItemUseHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = session.Player.Inventory.GetByUid(itemUid);
 
         switch (item.Function.Name)
         {
@@ -355,7 +355,7 @@ public class RequestItemUseHandler : GamePacketHandler
             return;
         }
 
-        Item pet = session.Player.Inventory.Items[petUid];
+        Item pet = session.Player.Inventory.GetByUid(petUid);
 
         Item badge = new(70100000)
         {

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
@@ -32,7 +32,7 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
             return;
         }
 
-        Dictionary<long, Item> items = new(session.Player.Inventory.Items.Where(x => x.Value.Id == itemId)); // Make copy of items in-case new item is added
+        IReadOnlyCollection<Item> items = session.Player.Inventory.GetAllById(itemId); // Make copy of items in-case new item is added
         if (items.Count == 0)
         {
             return;
@@ -55,14 +55,12 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
         HandleOpenBox(session, items, /*openBox,*/ amount);
     }
 
-    private static void HandleSelectBox(GameSession session, Dictionary<long, Item> items, SelectItemBox box, int index, int amount)
+    private static void HandleSelectBox(GameSession session, IReadOnlyCollection<Item> items, SelectItemBox box, int index, int amount)
     {
         ItemDropMetadata metadata = ItemDropMetadataStorage.GetItemDropMetadata(box.BoxId);
         int opened = 0;
-        foreach (KeyValuePair<long, Item> kvp in items)
+        foreach (Item item in items)
         {
-            Item item = kvp.Value;
-
             for (int i = opened; i < amount; i++)
             {
                 if (item.Amount <= 0)
@@ -75,16 +73,14 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
             }
         }
 
-        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Value.Id, amount));
+        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Id, amount));
     }
 
-    private static void HandleOpenBox(GameSession session, Dictionary<long, Item> items, /*OpenItemBox box,*/ int amount)
+    private static void HandleOpenBox(GameSession session, IReadOnlyCollection<Item> items, /*OpenItemBox box,*/ int amount)
     {
         int opened = 0;
-        foreach (KeyValuePair<long, Item> kvp in items)
+        foreach (Item item in items)
         {
-            Item item = kvp.Value;
-
             for (int i = opened; i < amount; i++)
             {
                 if (item.Amount <= 0)
@@ -97,6 +93,6 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
             }
         }
 
-        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Value.Id, amount));
+        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Id, amount));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/RequestTutorialItemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestTutorialItemHandler.cs
@@ -17,7 +17,7 @@ public class RequestTutorialItemHandler : GamePacketHandler
 
         foreach (TutorialItemMetadata tutorialItem in metadata)
         {
-            int tutorialItemsCount = session.Player.Inventory.Items.Count(x => x.Value.Id == tutorialItem.ItemId);
+            int tutorialItemsCount = session.Player.Inventory.GetAllById(tutorialItem.ItemId).Count;
             tutorialItemsCount += session.Player.Inventory.Cosmetics.Count(x => x.Value.Id == tutorialItem.ItemId);
             tutorialItemsCount += session.Player.Inventory.Equips.Count(x => x.Value.Id == tutorialItem.ItemId);
 

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -56,7 +56,7 @@ public class RideHandler : GamePacketHandler
         long mountUid = packet.ReadLong();
         // [46-0s] (UgcPacketHelper.Ugc()) but client doesn't set this data?
 
-        if (type == RideType.UseItem && !session.Player.Inventory.Items.ContainsKey(mountUid))
+        if (type == RideType.UseItem && !session.Player.Inventory.HasItem(mountUid))
         {
             return;
         }
@@ -91,7 +91,7 @@ public class RideHandler : GamePacketHandler
         int mountId = packet.ReadInt();
         long mountUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(mountUid))
+        if (!session.Player.Inventory.HasItem(mountUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/RockPaperScissorsHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RockPaperScissorsHandler.cs
@@ -77,7 +77,7 @@ public class RockPaperScissorsHandler : GamePacketHandler
             return;
         }
 
-        if (!session.Player.Inventory.Items.Values.Any(x => x.Id == rpsEvent.VoucherId))
+        if (!session.Player.Inventory.HasItem(rpsEvent.VoucherId))
         {
             // TODO: Find correct packet to let player know they don't have a voucher
             session.Send(NoticePacket.Notice("You must have a Rock Papers Scissors Play Ticket",
@@ -105,7 +105,7 @@ public class RockPaperScissorsHandler : GamePacketHandler
             return;
         }
 
-        if (!session.Player.Inventory.Items.Values.Any(x => x.Id == rpsEvent.VoucherId))
+        if (!session.Player.Inventory.HasItem(rpsEvent.VoucherId))
         {
             // TODO: Find correct packet to let player know they don't have a voucher
             session.Send(NoticePacket.Notice("You must have a Rock Papers Scissors Play Ticket",
@@ -202,7 +202,7 @@ public class RockPaperScissorsHandler : GamePacketHandler
             return;
         }
 
-        Item voucher = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == rpsEvent.VoucherId);
+        Item voucher = session.Player.Inventory.GetById(rpsEvent.VoucherId);
         if (voucher is null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/ShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ShopHandler.cs
@@ -80,7 +80,8 @@ public class ShopHandler : GamePacketHandler
         long itemUid = packet.ReadLong();
         int quantity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        Item item = session.Player.Inventory.GetByUid(itemUid);
+        if (item == null)
         {
             return;
         }
@@ -123,7 +124,7 @@ public class ShopHandler : GamePacketHandler
                 session.Player.Account.RemoveMerets(shopItem.Price * quantity);
                 break;
             case ShopCurrencyType.Item:
-                Item itemCost = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == shopItem.RequiredItemId).Value;
+                Item itemCost = session.Player.Inventory.GetById(shopItem.RequiredItemId);
                 if (itemCost.Amount < shopItem.Price)
                 {
                     return;
@@ -152,9 +153,8 @@ public class ShopHandler : GamePacketHandler
         byte unk = packet.ReadByte();
         int itemId = packet.ReadInt();
 
-        List<Item> playerInventory = new(session.Player.Inventory.Items.Values);
-
-        Item item = playerInventory.FirstOrDefault(x => x.Id == itemId);
+        IInventory inventory = session.Player.Inventory;
+        Item item = inventory.GetById(itemId);
         if (item == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
@@ -36,9 +36,9 @@ public class SuperChatHandler : GamePacketHandler
 
     private static void HandleSelect(GameSession session, PacketReader packet)
     {
-        int item = packet.ReadInt();
+        int itemId = packet.ReadInt();
 
-        Item superChatItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == item);
+        Item superChatItem = session.Player.Inventory.GetById(itemId);
         if (superChatItem == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
@@ -51,7 +51,7 @@ public class SystemShopHandler : GamePacketHandler
 
         int itemId = packet.ReadInt();
 
-        Item item = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == itemId);
+        Item item = session.Player.Inventory.GetById(itemId);
         if (item == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/UgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UgcHandler.cs
@@ -70,7 +70,7 @@ public class UgcHandler : GamePacketHandler
 
         if (useVoucher)
         {
-            Item voucher = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Tag == "FreeDesignCoupon");
+            Item voucher = session.Player.Inventory.GetAllByTag("FreeDesignCoupon").FirstOrDefault();
             if (voucher is null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
@@ -88,7 +88,7 @@ public class UserChatHandler : GamePacketHandler
 
         Item voucher = player.Inventory.GetAllByTag("FreeChannelChatCoupon")
             .FirstOrDefault();
-        
+
         if (voucher is not null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.UsedChannelChatVoucher, NoticeType.ChatAndFastText));

--- a/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
@@ -86,7 +86,9 @@ public class UserChatHandler : GamePacketHandler
             meretCost = (int) (meretCost - (meretCost * Convert.ToSingle(saleEvent.ChannelChatDiscountAmount) / 100 / 100));
         }
 
-        Item voucher = player.Inventory.Items.Values.FirstOrDefault(x => x.Tag == "FreeChannelChatCoupon");
+        Item voucher = player.Inventory.GetAllByTag("FreeChannelChatCoupon")
+            .FirstOrDefault();
+        
         if (voucher is not null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.UsedChannelChatVoucher, NoticeType.ChatAndFastText));
@@ -117,7 +119,7 @@ public class UserChatHandler : GamePacketHandler
             return;
         }
 
-        Item superChatItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Function.Id == session.Player.SuperChat);
+        Item superChatItem = session.Player.Inventory.GetAllByFunctionId(session.Player.SuperChat).FirstOrDefault();
         if (superChatItem is null)
         {
             session.Player.SuperChat = 0;
@@ -148,7 +150,7 @@ public class UserChatHandler : GamePacketHandler
             meretCost = (int) (meretCost - (meretCost * Convert.ToSingle(saleEvent.WorldChatDiscountAmount) / 100 / 100));
         }
 
-        Item voucher = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Tag == "FreeWorldChatCoupon");
+        Item voucher = session.Player.Inventory.GetAllByTag("FreeWorldChatCoupon").FirstOrDefault();
         if (voucher is not null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.UsedWorldChatVoucher, NoticeType.ChatAndFastText));

--- a/MapleServer2/Packets/ItemInventoryPacket.cs
+++ b/MapleServer2/Packets/ItemInventoryPacket.cs
@@ -68,7 +68,7 @@ public static class ItemInventoryPacket
         return pWriter;
     }
 
-    public static PacketWriter LoadItem(ICollection<Item> items)
+    public static PacketWriter LoadItem(IReadOnlyCollection<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ITEM_INVENTORY);
         pWriter.Write(InventoryMode.LoadItem);
@@ -98,7 +98,7 @@ public static class ItemInventoryPacket
         return pWriter;
     }
 
-    public static PacketWriter LoadItemsToTab(InventoryTab tab, ICollection<Item> items)
+    public static PacketWriter LoadItemsToTab(InventoryTab tab, IReadOnlyCollection<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ITEM_INVENTORY);
         pWriter.Write(InventoryMode.LoadItemsToTab);

--- a/MapleServer2/Types/BankInventory.cs
+++ b/MapleServer2/Types/BankInventory.cs
@@ -37,7 +37,7 @@ public class BankInventory
 
     public void Add(GameSession session, long uid, int amount, short slot)
     {
-        Item item = session.Player.Inventory.Items[uid];
+        Item item = session.Player.Inventory.GetByUid(uid);
 
         if (amount < item.Amount)
         {

--- a/MapleServer2/Types/DismantleInventory.cs
+++ b/MapleServer2/Types/DismantleInventory.cs
@@ -34,11 +34,11 @@ public class DismantleInventory
 
     public void AutoAdd(GameSession session, InventoryTab inventoryTab, int rarityType)
     {
-        Dictionary<long, Item> items = session.Player.Inventory.Items;
+        IReadOnlyCollection<Item> items = session.Player.Inventory.GetItems(inventoryTab);
 
-        foreach ((long uid, Item item) in items)
+        foreach (Item item in items)
         {
-            if (item.InventoryTab != inventoryTab || item.Rarity > rarityType || !item.EnableBreak || Slots.Any(x => x != null && x.Item1 == uid))
+            if (item.InventoryTab != inventoryTab || item.Rarity > rarityType || !item.EnableBreak || Slots.Any(x => x != null && x.Item1 == item.Uid))
             {
                 continue;
             }
@@ -98,7 +98,7 @@ public class DismantleInventory
         Rewards = new();
         foreach ((long uid, int amount) in Slots.Where(x => x != null))
         {
-            Item item = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Uid == uid).Value;
+            Item item = session.Player.Inventory.GetByUid(uid);
             if (!ItemMetadataStorage.IsValid(item.Id))
             {
                 continue;

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -10,6 +10,7 @@ public interface IInventory
     bool RemoveItem(GameSession session, long uid, out Item item);
     void DropItem(GameSession session, long uid, int amount, bool isBound);
     void MoveItem(GameSession session, long uid, short dstSlot);
+    bool HasItem(long uid);
     bool Replace(Item item);
     void SortInventory(GameSession session, InventoryTab tab);
     void LoadInventoryTab(GameSession session, InventoryTab tab);

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -5,13 +5,27 @@ namespace MapleServer2.Types;
 
 public interface IInventory
 {
+    Dictionary<InventoryTab, short> ExtraSize { get; }
+    long Id { get; }
+    Dictionary<ItemSlot, Item> Equips { get; }
+    Dictionary<ItemSlot, Item> Cosmetics { get; }
+    Item[] Badges { get; }
+    Item[] LapenshardStorage { get; }
+    Dictionary<long, Item> TemporaryStorage { get; }
+    
     void AddItem(GameSession session, Item item, bool isNew);
     void ConsumeItem(GameSession session, long uid, int amount);
     bool RemoveItem(GameSession session, long uid, out Item item);
     void DropItem(GameSession session, long uid, int amount, bool isBound);
     void MoveItem(GameSession session, long uid, short dstSlot);
     bool HasItem(long uid);
+    bool HasItem(int id);
     Item GetByUid(long uid);
+    Item GetById(int id);
+    IReadOnlyCollection<Item> GetItemsNotNull();
+    IReadOnlyCollection<Item> GetAllById(int id);
+    IReadOnlyCollection<Item> GetAllByTag(string tag);
+    IReadOnlyCollection<Item> GetAllByFunctionId(int functionId);
     bool Replace(Item item);
     void SortInventory(GameSession session, InventoryTab tab);
     void LoadInventoryTab(GameSession session, InventoryTab tab);
@@ -20,5 +34,5 @@ public interface IInventory
     bool CanHold(Item item, int amount = -1);
     bool CanHold(int itemId, int amount);
     bool SlotTaken(Item item, short slot = -1);
-    ICollection<Item> GetItems(InventoryTab tab);
+    IReadOnlyCollection<Item> GetItems(InventoryTab tab);
 }

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -1,0 +1,22 @@
+﻿using Maple2Storage.Enums;
+using MapleServer2.Servers.Game;
+
+namespace MapleServer2.Types;
+
+public interface IInventory
+{
+    void AddItem(GameSession session, Item item, bool isNew);
+    void ConsumeItem(GameSession session, long uid, int amount);
+    bool RemoveItem(GameSession session, long uid, out Item item);
+    void DropItem(GameSession session, long uid, int amount, bool isBound);
+    void MoveItem(GameSession session, long uid, short dstSlot);
+    bool Replace(Item item);
+    void SortInventory(GameSession session, InventoryTab tab);
+    void LoadInventoryTab(GameSession session, InventoryTab tab);
+    void ExpandInventory(GameSession session, InventoryTab tab);
+    int GetFreeSlots(InventoryTab tab);
+    bool CanHold(Item item, int amount = -1);
+    bool CanHold(int itemId, int amount);
+    bool SlotTaken(Item item, short slot = -1);
+    ICollection<Item> GetItems(InventoryTab tab);
+}

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -12,7 +12,6 @@ public interface IInventory
     Item[] Badges { get; }
     Item[] LapenshardStorage { get; }
     Dictionary<long, Item> TemporaryStorage { get; }
-    
     void AddItem(GameSession session, Item item, bool isNew);
     void ConsumeItem(GameSession session, long uid, int amount);
     bool RemoveItem(GameSession session, long uid, out Item item);

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -25,7 +25,7 @@ public interface IInventory
     bool HasItem(long uid);
 
     /// <summary>
-    /// Determins whether the inventory contains an item with given Item ID
+    /// Determines whether the inventory contains an item with given Item ID
     /// </summary>
     /// <param name="id">The Item ID of the item</param>
     bool HasItem(int id);

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -11,6 +11,7 @@ public interface IInventory
     void DropItem(GameSession session, long uid, int amount, bool isBound);
     void MoveItem(GameSession session, long uid, short dstSlot);
     bool HasItem(long uid);
+    Item GetByUid(long uid);
     bool Replace(Item item);
     void SortInventory(GameSession session, InventoryTab tab);
     void LoadInventoryTab(GameSession session, InventoryTab tab);

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -17,13 +17,57 @@ public interface IInventory
     bool RemoveItem(GameSession session, long uid, out Item item);
     void DropItem(GameSession session, long uid, int amount, bool isBound);
     void MoveItem(GameSession session, long uid, short dstSlot);
+
+    /// <summary>
+    /// Determines whether the inventory contains an item with given Unique ID (UID)
+    /// </summary>
+    /// <param name="uid">The UID of the item</param>
     bool HasItem(long uid);
+
+    /// <summary>
+    /// Determins whether the inventory contains an item with given Item ID
+    /// </summary>
+    /// <param name="id">The Item ID of the item</param>
     bool HasItem(int id);
+
+    /// <summary>
+    /// Gets the first item matching the given Unique ID (UID)
+    /// </summary>
+    /// <param name="uid">The UID of the item</param>
+    /// <remarks>Can return null</remarks>
     Item GetByUid(long uid);
+
+    /// <summary>
+    /// Gets the first item matching the given Item ID
+    /// </summary>
+    /// <param name="id">The Item ID of the item</param>
+    /// <remarks>Can return null</remarks>
     Item GetById(int id);
+
+    /// <summary>
+    /// Gets all non-null items in the inventory
+    /// </summary>
     IReadOnlyCollection<Item> GetItemsNotNull();
+
+    /// <summary>
+    /// Gets all items matching the given Item ID
+    /// </summary>
+    /// <param name="id">The Item ID of the item</param>
+    /// <remarks>Never returns null, can return empty</remarks>
     IReadOnlyCollection<Item> GetAllById(int id);
+
+    /// <summary>
+    /// Gets all items matching the given tag
+    /// </summary>
+    /// <param name="tag">The tag of the item</param>
+    /// <remarks>Never returns null, can return empty</remarks>
     IReadOnlyCollection<Item> GetAllByTag(string tag);
+
+    /// <summary>
+    /// Gets all items matching the given Function ID
+    /// </summary>
+    /// <param name="functionId">The Function ID of the item</param>
+    /// <remarks>Never returns null, can return empty</remarks>
     IReadOnlyCollection<Item> GetAllByFunctionId(int functionId);
     bool Replace(Item item);
     void SortInventory(GameSession session, InventoryTab tab);

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -328,6 +328,11 @@ public sealed class Inventory : IInventory
         return Items.ContainsKey(uid);
     }
 
+    public Item GetByUid(long uid)
+    {
+        return Items[uid];
+    }
+
     // Replaces an existing item with an updated copy of itself
     public bool Replace(Item item)
     {

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -323,10 +323,15 @@ public sealed class Inventory : IInventory
         session.Send(ItemInventoryPacket.Move(dstUid, srcSlot, uid, dstSlot));
     }
 
+    public bool HasItem(long uid)
+    {
+        return Items.ContainsKey(uid);
+    }
+
     // Replaces an existing item with an updated copy of itself
     public bool Replace(Item item)
     {
-        if (!Items.ContainsKey(item.Uid))
+        if (!HasItem(item.Uid))
         {
             return false;
         }
@@ -534,7 +539,7 @@ public sealed class Inventory : IInventory
     // This REQUIRES item.Slot to be set appropriately
     private void AddInternal(Item item)
     {
-        Debug.Assert(!Items.ContainsKey(item.Uid), "Error adding an item that already exists");
+        Debug.Assert(!HasItem(item.Uid), "Error adding an item that already exists");
         Items[item.Uid] = item;
 
         Debug.Assert(!GetSlots(item.InventoryTab).ContainsKey(item.Slot), "Error adding item to slot that is already taken.");

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -16,7 +16,7 @@ public sealed class Inventory : IInventory
     public long Id { get; }
 
     // This contains ALL inventory Items regardless of tab
-    public readonly Dictionary<long, Item> Items;
+    private readonly Dictionary<long, Item> Items;
     public Dictionary<ItemSlot, Item> Equips { get; }
     public Dictionary<ItemSlot, Item> Cosmetics { get; }
     public Item[] Badges { get; }

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -10,7 +10,7 @@ using NLog;
 // TODO: make this class thread safe?
 namespace MapleServer2.Types;
 
-public class Inventory
+public sealed class Inventory : IInventory
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Maple2Storage.Enums;
 using MapleServer2.Data.Static;
 using MapleServer2.Database;

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -322,47 +322,22 @@ public sealed class Inventory : IInventory
         session.Send(ItemInventoryPacket.Move(dstUid, srcSlot, uid, dstSlot));
     }
 
-    public bool HasItem(long uid)
-    {
-        return Items.ContainsKey(uid);
-    }
+    public bool HasItem(long uid) => Items.ContainsKey(uid);
 
-    public bool HasItem(int id)
-    {
-        return Items.Values.Any(i => i.Id == id);
-    }
+    public bool HasItem(int id) => Items.Values.Any(i => i.Id == id);
 
-    public Item GetByUid(long uid)
-    {
-        return Items[uid];
-    }
+    public Item GetByUid(long uid) => Items[uid];
 
-    public Item GetById(int id)
-    {
-        return Items.Values.FirstOrDefault(x => x.Id == id);
-    }
+    public Item GetById(int id) => Items.Values.FirstOrDefault(x => x.Id == id);
 
-    public IReadOnlyCollection<Item> GetItemsNotNull()
-    {
-        return Items.Values.Where(x => x != null).ToArray();
-    }
+    public IReadOnlyCollection<Item> GetItemsNotNull() => Items.Values.Where(x => x != null).ToArray();
 
-    public IReadOnlyCollection<Item> GetAllById(int id)
-    {
-        return Items.Values.Where(x => x.Id == id).ToArray();
-    }
+    public IReadOnlyCollection<Item> GetAllById(int id) => Items.Values.Where(x => x.Id == id).ToArray();
 
-    public IReadOnlyCollection<Item> GetAllByTag(string tag)
-    {
-        return Items.Values.Where(i => i.Tag == tag)
-            .ToArray();
-    }
+    public IReadOnlyCollection<Item> GetAllByTag(string tag) => Items.Values.Where(i => i.Tag == tag).ToArray();
 
-    public IReadOnlyCollection<Item> GetAllByFunctionId(int functionId)
-    {
-        return Items.Values.Where(x => x.Function.Id == functionId)
-            .ToArray();
-    }
+    public IReadOnlyCollection<Item> GetAllByFunctionId(int functionId) =>
+        Items.Values.Where(x => x.Function.Id == functionId).ToArray();
 
     // Replaces an existing item with an updated copy of itself
     public bool Replace(Item item)

--- a/MapleServer2/Types/LockInventory.cs
+++ b/MapleServer2/Types/LockInventory.cs
@@ -46,15 +46,16 @@ public class LockInventory
 
     public void Update(GameSession session, byte mode)
     {
-        Dictionary<long, Item> inventory = session.Player.Inventory.Items;
+        IInventory inventory = session.Player.Inventory;
         List<Item> changedItems = new();
         foreach (long uid in Items[mode].Where(x => x != 0))
         {
-            if (inventory.ContainsKey(uid))
+            if (inventory.HasItem(uid))
             {
-                inventory[uid].IsLocked = mode == 0;
-                inventory[uid].UnlockTime = mode == 1 ? TimeInfo.AddDays(3) : 0;
-                changedItems.Add(inventory[uid]);
+                Item item = inventory.GetByUid(uid);
+                item.IsLocked = mode == 0;
+                item.UnlockTime = mode == 1 ? TimeInfo.AddDays(3) : 0;
+                changedItems.Add(item);
             }
         }
         session.Send(ItemLockPacket.UpdateItems(changedItems));

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -110,7 +110,7 @@ public class Player
 
     public GameOptions GameOptions { get; set; }
 
-    public Inventory Inventory;
+    public IInventory Inventory;
     public DismantleInventory DismantleInventory = new();
     public LockInventory LockInventory = new();
     public HairInventory HairInventory = new();

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -216,7 +216,7 @@ public class Player
             90200021
         };
         StatPointDistribution = new();
-        Inventory = new(true);
+        Inventory = new Inventory(true);
         Mailbox = new();
         BuddyList = new();
         QuestData = new();


### PR DESCRIPTION
Extracts interface for player inventory

Makes Items collection private, we should not allow the entire codebase to do whatever it likes with the underlying collection, as this makes it easy to introduce bugs.

Introduces some common methods to replace cases where other classes were "dipping in to" the underlying collection. This has some benefits:

E.g. Reduces cognitive complexity when reading code at a glance
```csharp
Item itemCost = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == requiredItemId).Value;
```
Vs
```csharp
Item itemCost = session.Player.Inventory.GetById(requiredItemId);
```
Removes Dictionary-specific behaviour outside of Inventory class, now the underlying collection can easily be replace with e.g. a List if required:
```csharp
if (!inventory.Items.TryGetValue(itemUid, out Item item))
{
    return;
}
// GMS2 Always 100% success rate
session.Send(LapenshardPacket.Select(10000));
```
vs
```csharp
if (!inventory.HasItem(itemUid))
{
    return;
}
// GMS2 Always 100% success rate
session.Send(LapenshardPacket.Select(10000));
```

Has potential for introducing more methods, e.g.
```csharp
Player.Inventory.GetAllById(itemId)
            .Sum(x => x.Amount);
```
Could be replaced with
```csharp
Player.Inventory.GetItemAmount(itemId);
```