### PR TITLE
Fix: Attendance for different days & Parse first day

### DIFF
--- a/MapleServer2/PacketHandlers/Game/AttendanceHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/AttendanceHandler.cs
@@ -63,8 +63,8 @@ public class AttendanceHandler : GamePacketHandler
 
         GameEventUserValue timeValue = GameEventHelper.GetUserValue(session.Player, attendanceEvent.Id,
             TimeInfo.Tomorrow(), GameEventUserValueType.AttendanceAccumulatedTime);
-
-        if (TimeInfo.Now() - session.Player.LastLogTime + int.Parse(timeValue.EventValue) <
+        long.TryParse(timeValue.EventValue, out long accumuatedTime);
+        if (TimeInfo.Now() - session.Player.LastLogTime + accumuatedTime <
             attendanceEvent.TimeRequired)
         {
             return;
@@ -76,7 +76,7 @@ public class AttendanceHandler : GamePacketHandler
         long.TryParse(completeTimestampValue.EventValue, out long completedTimestamp);
 
         DateTimeOffset savedTime = DateTimeOffset.FromUnixTimeSeconds(completedTimestamp);
-        if (DateTimeOffset.Now.Day < savedTime.Day)
+        if (DateTimeOffset.Now.UtcDateTime < savedTime.UtcDateTime && DateTimeOffset.Now.Date != savedTime.Date)
         {
             session.Send(AttendancePacket.Notice((int) AttendanceNotice.EventHasAlreadyBeenCompleted));
             return;

--- a/MapleServer2/PacketHandlers/Game/AttendanceHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/AttendanceHandler.cs
@@ -63,8 +63,8 @@ public class AttendanceHandler : GamePacketHandler
 
         GameEventUserValue timeValue = GameEventHelper.GetUserValue(session.Player, attendanceEvent.Id,
             TimeInfo.Tomorrow(), GameEventUserValueType.AttendanceAccumulatedTime);
-        long.TryParse(timeValue.EventValue, out long accumuatedTime);
-        if (TimeInfo.Now() - session.Player.LastLogTime + accumuatedTime <
+        long.TryParse(timeValue.EventValue, out long accumulatedTime);
+        if (TimeInfo.Now() - session.Player.LastLogTime + accumulatedTime <
             attendanceEvent.TimeRequired)
         {
             return;

--- a/MapleServer2/Packets/GameEventUserValuePacket.cs
+++ b/MapleServer2/Packets/GameEventUserValuePacket.cs
@@ -40,7 +40,6 @@ public static class GameEventUserValuePacket
     private static void WriteUserValue(PacketWriter pWriter, GameEventUserValue userValue)
     {
         pWriter.Write(userValue.EventType);
-        Console.WriteLine(userValue.EventType);
         pWriter.WriteInt(userValue.EventId);
         pWriter.WriteUnicodeString(userValue.EventValue);
         pWriter.WriteLong(userValue.ExpirationTimestamp);


### PR DESCRIPTION
- Swapped from `Parse` to `TryParse`. This should address the crash
- Also now checking if the date is a later date AND not the same date. Previously was only checking Day # (would not work when a new month starts)