### PR TITLE
Add unit test project - and example unit tests for ConditionHelper

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,10 +41,3 @@ jobs:
 
       - name: Run dotnet format
         run: dotnet format --verify-no-changes
-        
-  tests:
-    name: Unit Testing
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2.1.0
-      - run: dotnet test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,10 +42,9 @@ jobs:
       - name: Run dotnet format
         run: dotnet format --verify-no-changes
         
-  unit-tests:
+  tests:
+    name: Unit Testing
     runs-on: windows-latest
-    
     steps:
-      - name: Run Unit Tests
-        uses: actions/checkout@v2
-        run: dotnet test
+      - uses: actions/checkout@v2.1.0
+      - run: dotnet test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,3 +41,11 @@ jobs:
 
       - name: Run dotnet format
         run: dotnet format --verify-no-changes
+        
+  unit-tests:
+    runs-on: windows-latest
+    
+    steps:
+      - name: Run Unit Tests
+        uses: actions/checkout@v2
+        run: dotnet test

--- a/MapleServer2.Tests/MapleServer2.Tests.csproj
+++ b/MapleServer2.Tests/MapleServer2.Tests.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
       <PackageReference Include="NUnit" Version="3.13.2" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/MapleServer2.Tests/MapleServer2.Tests.csproj
+++ b/MapleServer2.Tests/MapleServer2.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+      <PackageReference Include="NUnit" Version="3.13.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\MapleServer2\MapleServer2.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/MapleServer2.Tests/Tools/ConditionHelperTests.cs
+++ b/MapleServer2.Tests/Tools/ConditionHelperTests.cs
@@ -1,0 +1,81 @@
+﻿using MapleServer2.Tools;
+using NUnit.Framework;
+
+namespace MapleServer2.Tests.Tools;
+
+public sealed class ConditionHelperTests
+{
+    [Test]
+    public void IsMatching_returns_true_for_exact_string_match()
+    {
+        Assert.That(ConditionHelper.IsMatching("1234", "1234"), Is.True);
+    }
+
+    [Test]
+    public void IsMatching_returns_true_regardless_of_case()
+    {
+        Assert.That(ConditionHelper.IsMatching("foobar", "FoObAr"), Is.True);
+    }
+
+    [Test]
+    public void IsMatching_returns_false_for_non_matching_string()
+    {
+        Assert.That(ConditionHelper.IsMatching("not", "a-match"), Is.False);
+    }
+
+    [Test]
+    public void IsMatching_returns_true_for_exact_number_match()
+    {
+        Assert.That(ConditionHelper.IsMatching("1234", 1234), Is.True);
+    }
+
+    [Test]
+    public void IsMatching_returns_true_for_condition_with_leading_zeroes()
+    {
+        Assert.That(ConditionHelper.IsMatching("000001234", 1234), Is.True);
+    }
+
+    [Test]
+    public void IsMatching_returns_false_for_condition_with_trailing_zeroes()
+    {
+        Assert.That(ConditionHelper.IsMatching("123400000", 1234), Is.False);
+    }
+
+    private static IEnumerable<TestCaseData> List_test_cases()
+    {
+        yield return new TestCaseData("1,2,3", 1);
+        yield return new TestCaseData("1,2,3", 2);
+        yield return new TestCaseData("1,2,3", 3);
+    }
+
+    [TestCaseSource(nameof(List_test_cases))]
+    public void IsMatching_returns_true_for_value_in_list(string conditionList, int match)
+    {
+        Assert.That(ConditionHelper.IsMatching(conditionList, match), Is.True);
+    }
+
+    [Test]
+    public void IsMatching_returns_false_for_value_not_in_list()
+    {
+        Assert.That(ConditionHelper.IsMatching("1,2,3", 4), Is.False);
+    }
+
+    private static IEnumerable<TestCaseData> Range_test_cases()
+    {
+        yield return new TestCaseData("1-3", 1);
+        yield return new TestCaseData("1-3", 2);
+        yield return new TestCaseData("1-3", 3);
+    }
+
+    [TestCaseSource(nameof(Range_test_cases))]
+    public void IsMatching_returns_true_for_value_in_range(string conditionRange, int match)
+    {
+        Assert.That(ConditionHelper.IsMatching(conditionRange, match), Is.True);
+    }
+
+    [Test]
+    public void IsMatching_returns_false_for_value_outside_range()
+    {
+        Assert.That(ConditionHelper.IsMatching("1-3", 4), Is.False);
+    }
+}

--- a/MapleServer2.sln
+++ b/MapleServer2.sln
@@ -20,6 +20,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MapleWebServer", "MapleWebServer\MapleWebServer.csproj", "{C8155CD0-226E-4A7B-8016-94F0FB55858C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0711998C-75B9-4B4C-B8AF-C5227FE9EB27}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapleServer2.Tests", "MapleServer2.Tests\MapleServer2.Tests.csproj", "{A694A8FF-DCD2-4A0A-821C-F134D35E4E95}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,11 +49,18 @@ Global
 		{C8155CD0-226E-4A7B-8016-94F0FB55858C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8155CD0-226E-4A7B-8016-94F0FB55858C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8155CD0-226E-4A7B-8016-94F0FB55858C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A694A8FF-DCD2-4A0A-821C-F134D35E4E95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A694A8FF-DCD2-4A0A-821C-F134D35E4E95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A694A8FF-DCD2-4A0A-821C-F134D35E4E95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A694A8FF-DCD2-4A0A-821C-F134D35E4E95}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {916C0D22-565A-4BB2-B94D-D1CC2926E3A3}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A694A8FF-DCD2-4A0A-821C-F134D35E4E95} = {0711998C-75B9-4B4C-B8AF-C5227FE9EB27}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
I'm making this as a draft as it's a demonstration to show people what a project with unit tests might look like. tl;dr this is an idea that I think is worth investing time in as it provides many benefits.

- Provided that they are comprehensive, they act as a safety net and increase confidence.
  - Developers can now freely make changes in ConditionHelper, and if they break existing behaviour, they will know about it instantly without having to manually test anything.
- They encourage good development practices, good code is easily testable code. You can only test via public methods/constructors.
- They are quick and repeatable, and can be automated and used for PR gating.
- They are easy to run, Rider and R# add buttons to run all in a class, or individual tests, or all tests in project/solution.
![image](https://user-images.githubusercontent.com/22443587/156947770-2e06669b-9c04-4b4c-a73b-100a2a0be2ca.png)
- All modern IDEs have built in tools for running/managing unit tests.
![image](https://user-images.githubusercontent.com/22443587/156947793-c85a9c29-e446-4017-bfce-90247713e829.png)
- Failing tests have clear error messages, with stack traces (dependent on the framework).
![image](https://user-images.githubusercontent.com/22443587/156947820-2f6b96d9-430f-45a2-915b-be7639081954.png)

Also, throwback
![image](https://user-images.githubusercontent.com/22443587/157010620-5df92481-1ab9-47f9-8bb8-53cc0448e729.png)
Yes :D