### PR TITLE
Fix "Type can be IEnumerable<T>" inspections

### DIFF
--- a/GameDataParser/Parsers/ScriptParser.cs
+++ b/GameDataParser/Parsers/ScriptParser.cs
@@ -72,7 +72,7 @@ public class ScriptParser : Exporter<List<ScriptMetadata>>
         return scripts;
     }
 
-    private static List<ScriptMetadata> ParseQuest(MetadataResources resources)
+    private static IEnumerable<ScriptMetadata> ParseQuest(MetadataResources resources)
     {
         List<ScriptMetadata> scripts = new();
         foreach (PackFileEntry entry in resources.XmlReader.Files)

--- a/Maple2Storage/Types/Metadata/MapEntityMetadata.cs
+++ b/Maple2Storage/Types/Metadata/MapEntityMetadata.cs
@@ -366,7 +366,7 @@ public class MapEventNpcSpawnPoint
 
     public MapEventNpcSpawnPoint() { }
 
-    public MapEventNpcSpawnPoint(int id, uint count, List<string> npcIds, string spawnAnimation, float spawnRadius, CoordF position, CoordF rotation)
+    public MapEventNpcSpawnPoint(int id, uint count, IEnumerable<string> npcIds, string spawnAnimation, float spawnRadius, CoordF position, CoordF rotation)
     {
         Id = id;
         Count = count;

--- a/MapleServer2/Data/Static/AnimationStorage.cs
+++ b/MapleServer2/Data/Static/AnimationStorage.cs
@@ -18,14 +18,14 @@ public static class AnimationStorage
         }
     }
 
-    public static List<SequenceMetadata> GetSequencesByActorId(string actorId)
+    public static IEnumerable<SequenceMetadata> GetSequencesByActorId(string actorId)
     {
         return Animations.GetValueOrDefault(actorId.ToLower()).Sequence;
     }
 
     public static short GetSequenceIdBySequenceName(string actorId, string sequenceName)
     {
-        List<SequenceMetadata> sequences = GetSequencesByActorId(actorId);
+        IEnumerable<SequenceMetadata> sequences = GetSequencesByActorId(actorId);
         SequenceMetadata metadata = sequences.FirstOrDefault(s => s.SequenceName == sequenceName);
 
         if (metadata != default)

--- a/MapleServer2/Data/Static/MapMetadataStorage.cs
+++ b/MapleServer2/Data/Static/MapMetadataStorage.cs
@@ -21,7 +21,7 @@ public static class MapMetadataStorage
 
     public static MapMetadata GetMetadata(int mapId) => Maps.GetValueOrDefault(mapId);
 
-    public static List<MapMetadata> GetAll() => Maps.Values.ToList();
+    public static IEnumerable<MapMetadata> GetAll() => Maps.Values.ToList();
 
     public static bool BlockExists(int mapId, CoordS coord)
     {

--- a/MapleServer2/Database/Classes/DatabaseEvent.cs
+++ b/MapleServer2/Database/Classes/DatabaseEvent.cs
@@ -44,7 +44,7 @@ public class DatabaseEvent : DatabaseTable
         return ReadUgcMapExtensionSaleEvent(result);
     }
 
-    public List<StringBoard> FindAllStringBoardEvent()
+    public IEnumerable<StringBoard> FindAllStringBoardEvent()
     {
         List<StringBoard> stringBoardEvents = new();
         IEnumerable<dynamic> results = QueryFactory.Query("event_string_boards").Get();

--- a/MapleServer2/Database/Classes/DatabaseMeretMarket.cs
+++ b/MapleServer2/Database/Classes/DatabaseMeretMarket.cs
@@ -11,7 +11,7 @@ public class DatabaseMeretMarket : DatabaseTable
 {
     public DatabaseMeretMarket() : base("meret_market_items") { }
 
-    public List<PremiumMarketItem> FindAllByCategory(MeretMarketSection section, MeretMarketCategory category, GenderFlag gender, JobFlag jobFlag, string searchString)
+    public IEnumerable<PremiumMarketItem> FindAllByCategory(MeretMarketSection section, MeretMarketCategory category, GenderFlag gender, JobFlag jobFlag, string searchString)
     {
         List<PremiumMarketItem> items = new();
         IEnumerable<dynamic> results = QueryFactory.Query(TableName).Get();

--- a/MapleServer2/Managers/MobAIManager.cs
+++ b/MapleServer2/Managers/MobAIManager.cs
@@ -61,7 +61,7 @@ public static class MobAIManager
             NpcState stateValue = GetMobState(node.Name);
             NpcAction newActionValue = GetMobAction(node.Attributes["action"]?.Value);
             MobMovement movementValue = GetMobMovement(node.Attributes["movement"]?.Value);
-            MobAI.Condition[] conditions = GetConditions( /*node*/);
+            IEnumerable<MobAI.Condition> conditions = GetConditions( /*node*/);
 
             ai.Rules.TryAdd(stateValue, (newActionValue, movementValue, Array.Empty<MobAI.Condition>()));
         }
@@ -103,7 +103,7 @@ public static class MobAIManager
         };
     }
 
-    private static MobAI.Condition[] GetConditions( /*XmlNode node*/)
+    private static IEnumerable<MobAI.Condition> GetConditions( /*XmlNode node*/)
     {
         // TODO: Parse actions' conditions
         return Array.Empty<MobAI.Condition>();

--- a/MapleServer2/Managers/UgcMarketManager.cs
+++ b/MapleServer2/Managers/UgcMarketManager.cs
@@ -61,7 +61,7 @@ public class UgcMarketManager
         return Items.Values.FirstOrDefault(x => x.MarketId == id);
     }
 
-    public List<UgcMarketItem> FindItems(List<string> categories, GenderFlag genderFlag, JobFlag job, string searchString)
+    public IEnumerable<UgcMarketItem> FindItems(List<string> categories, GenderFlag genderFlag, JobFlag job, string searchString)
     {
         List<UgcMarketItem> items = new();
         foreach (UgcMarketItem item in Items.Values)

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -111,7 +111,7 @@ public class FishingHandler : GamePacketHandler
         session.Send(FishingPacket.PrepareFishing(fishingRodUid));
     }
 
-    private static CoordF GetObjectBlock(List<MapBlock> blocks, CoordF playerCoord)
+    private static CoordF GetObjectBlock(IEnumerable<MapBlock> blocks, CoordF playerCoord)
     {
         MapBlock guideBlock = blocks.OrderBy(o => Math.Sqrt(Math.Pow(playerCoord.X - o.Coord.X, 2) + Math.Pow(playerCoord.Y - o.Coord.Y, 2))).First();
         return guideBlock.Coord.ToFloat();

--- a/MapleServer2/PacketHandlers/Game/Helpers/MeretMarketHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/MeretMarketHelper.cs
@@ -21,7 +21,7 @@ public static class MeretMarketHelper
         };
     }
 
-    public static List<MeretMarketItem> TakeLimit(List<MeretMarketItem> items, int startPage, byte itemsPerPage)
+    public static List<MeretMarketItem> TakeLimit(IEnumerable<MeretMarketItem> items, int startPage, byte itemsPerPage)
     {
         int count = startPage * itemsPerPage - itemsPerPage;
         int offset = count;

--- a/MapleServer2/Servers/Game/GameServer.cs
+++ b/MapleServer2/Servers/Game/GameServer.cs
@@ -59,7 +59,7 @@ public class GameServer : Server<GameSession>
         Logger.Info($"Game client disconnected: {session}");
     }
 
-    public List<GameSession> GetSessions()
+    public IEnumerable<GameSession> GetSessions()
     {
         return Sessions;
     }

--- a/MapleServer2/Servers/Login/LoginServer.cs
+++ b/MapleServer2/Servers/Login/LoginServer.cs
@@ -31,7 +31,7 @@ public class LoginServer : Server<LoginSession>
         Logger.Info($"Login client disconnected: {session}");
     }
 
-    public List<LoginSession> GetSessions()
+    public IEnumerable<LoginSession> GetSessions()
     {
         return Sessions;
     }

--- a/MapleServer2/Types/Guild/Guild.cs
+++ b/MapleServer2/Types/Guild/Guild.cs
@@ -165,7 +165,7 @@ public class Guild
         }
     }
 
-    private List<GameSession> GetSessions()
+    private IEnumerable<GameSession> GetSessions()
     {
         List<GameSession> sessions = new();
         foreach (GuildMember guildMember in Members)

--- a/MapleServer2/Types/IInventory.cs
+++ b/MapleServer2/Types/IInventory.cs
@@ -47,7 +47,7 @@ public interface IInventory
     /// <summary>
     /// Gets all non-null items in the inventory
     /// </summary>
-    IReadOnlyCollection<Item> GetItemsNotNull();
+    IEnumerable<Item> GetItemsNotNull();
 
     /// <summary>
     /// Gets all items matching the given Item ID
@@ -68,7 +68,7 @@ public interface IInventory
     /// </summary>
     /// <param name="functionId">The Function ID of the item</param>
     /// <remarks>Never returns null, can return empty</remarks>
-    IReadOnlyCollection<Item> GetAllByFunctionId(int functionId);
+    IEnumerable<Item> GetAllByFunctionId(int functionId);
     bool Replace(Item item);
     void SortInventory(GameSession session, InventoryTab tab);
     void LoadInventoryTab(GameSession session, InventoryTab tab);

--- a/MapleServer2/Types/Inventory.cs
+++ b/MapleServer2/Types/Inventory.cs
@@ -330,13 +330,13 @@ public sealed class Inventory : IInventory
 
     public Item GetById(int id) => Items.Values.FirstOrDefault(x => x.Id == id);
 
-    public IReadOnlyCollection<Item> GetItemsNotNull() => Items.Values.Where(x => x != null).ToArray();
+    public IEnumerable<Item> GetItemsNotNull() => Items.Values.Where(x => x != null).ToArray();
 
     public IReadOnlyCollection<Item> GetAllById(int id) => Items.Values.Where(x => x.Id == id).ToArray();
 
     public IReadOnlyCollection<Item> GetAllByTag(string tag) => Items.Values.Where(i => i.Tag == tag).ToArray();
 
-    public IReadOnlyCollection<Item> GetAllByFunctionId(int functionId) =>
+    public IEnumerable<Item> GetAllByFunctionId(int functionId) =>
         Items.Values.Where(x => x.Function.Id == functionId).ToArray();
 
     // Replaces an existing item with an updated copy of itself

--- a/MapleServer2/Types/ItemStats.cs
+++ b/MapleServer2/Types/ItemStats.cs
@@ -233,13 +233,13 @@ public class ItemStats
         Random random = RandomProvider.Get();
         int slots = random.Next(randomOptions.Slots[0], randomOptions.Slots[1]);
 
-        List<ItemStat> itemStats = RollStats(randomOptions, randomId, itemId);
+        IEnumerable<ItemStat> itemStats = RollStats(randomOptions, randomId, itemId);
         List<ItemStat> selectedStats = itemStats.OrderBy(x => random.Next()).Take(slots).ToList();
 
         BonusStats.AddRange(selectedStats);
     }
 
-    public static List<ItemStat> RollStats(ItemOptionRandom randomOptions, int randomId, int itemId)
+    public static IEnumerable<ItemStat> RollStats(ItemOptionRandom randomOptions, int randomId, int itemId)
     {
         List<ItemStat> itemStats = new();
 

--- a/MapleServer2/Types/MobSpawn.cs
+++ b/MapleServer2/Types/MobSpawn.cs
@@ -50,7 +50,7 @@ public class MobSpawn
         return SelectPoints(spawnRadius).Take(count).ToList();
     }
 
-    public static List<NpcMetadata> SelectMobs(int difficulty, int minDifficulty, string[] tags)
+    public static List<NpcMetadata> SelectMobs(int difficulty, int minDifficulty, IEnumerable<string> tags)
     {
         // Look into optimizing this.
         HashSet<NpcMetadata> matchedNpcs = new();


### PR DESCRIPTION
I'm doing this as a first step to chip away at this
![image](https://user-images.githubusercontent.com/22443587/157446166-1c5f31e3-8715-4d11-9c19-a5a37002db52.png)

IMO it's important that we start enforcing use of IEnumerable/IReadOnlyCollection/ICollection to promote flexibility in our codebase, and to get people thinking about writing side effect free code.

Consider the following method:

```csharp
public void Foo(List<int> fooParam)
{
    foreach(int foo in fooParam)
    {
        /*Do something*/
    }
}
```

When trying to call this method, we must pass in a List, despite the method not requiring any functionality belonging to a list. It does not add/remove/index in to the collection.

And so we find the following:
```csharp
List<int> myList = new { 1, 2, 3 };
int[] myArray = new { 1, 4, 5, 7  };
Foo(myList); // All is well
Foo(myArray); // All is not well
```

Now the temptation to work around this issue, is to simply call `ToList()` on `myArray` and pass it in anyway. But swapping out the parameter type for `IEnumerable` allows both lists and arrays to be passed in without any unnecessary allocations or casting.

A method like this
```csharp
public void Foo(IEnumerable<int> fooParam)
{
    foreach(int foo in fooParam)
    {
        /*Do something*/
    }
}
```

Can be called just fine
```csharp
List<int> myList = new { 1, 2, 3 };
int[] myArray = new { 1, 4, 5, 7 };
Foo(myList); // All is well
Foo(myArray); // All is well
```