### PR TITLE
Item Equipping and Item Rarity Command Fix

### DIFF
--- a/MapleServer2/Commands/Game/ItemCommands.cs
+++ b/MapleServer2/Commands/Game/ItemCommands.cs
@@ -34,9 +34,16 @@ public class ItemCommand : InGameCommand
             return;
         }
 
+        rarity = rarity switch
+        {
+            < 1 => 1,
+            > 6 => 6,
+            _ => rarity
+        };
+
         Item item = new(itemId)
         {
-            Rarity = rarity >= 0 ? rarity : ItemMetadataStorage.GetRarity(itemId),
+            Rarity = rarity,
             TransferFlag = ItemMetadataStorage.GetTransferFlag(itemId, rarity),
             Amount = Math.Max(1, amount)
         };

--- a/MapleServer2/Commands/Game/ItemCommands.cs
+++ b/MapleServer2/Commands/Game/ItemCommands.cs
@@ -34,12 +34,8 @@ public class ItemCommand : InGameCommand
             return;
         }
 
-        rarity = rarity switch
-        {
-            < 1 => 1,
-            > 6 => 6,
-            _ => rarity
-        };
+        rarity = Math.Min(rarity, 6);
+        rarity = Math.Max(rarity, 1);
 
         Item item = new(itemId)
         {

--- a/MapleServer2/Managers/Actors/Character.cs
+++ b/MapleServer2/Managers/Actors/Character.cs
@@ -52,7 +52,6 @@ public partial class FieldManager
 
             ConsumeSp(spiritCost);
             ConsumeStamina(staminaCost);
-            Value.Session.SendNotice(skillCast.SkillId.ToString());
 
             // TODO: Move this and all others combat cases like recover sp to its own class.
             // Since the cast is always sent by the skill, we have to check buffs even when not doing damage.

--- a/MapleServer2/Types/Item.cs
+++ b/MapleServer2/Types/Item.cs
@@ -251,7 +251,7 @@ public class Item
 
     public bool IsExpired()
     {
-        return TimeInfo.Now() > ExpiryTime;
+        return TimeInfo.Now() > ExpiryTime && ExpiryTime != 0;
     }
 
     public void DecreaseTradeCount()


### PR DESCRIPTION
- Fixes able to equip items with no expiration date
- Prevents player from spawning in an item with a rarity less than 1 or higher than 6 to avoid crashes
- Removes skill Id notice packet being sent when using a skill