### PR TITLE
Fix: Mounts now consume stamina when sprinting

### DIFF
--- a/MapleServer2/Constants/Constant.cs
+++ b/MapleServer2/Constants/Constant.cs
@@ -3,4 +3,5 @@
 public static class Constant
 {
     public const float UnitPerMs = 0.001f; // Velocity in which all NPCs move per ms. 150 units per second.
+    public const int MountStaminaConsumption = 50; // Amount of stamina consumed each tick when sprinting with a ground mount.
 }

--- a/MapleServer2/PacketHandlers/Game/RideConsumeEpHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideConsumeEpHandler.cs
@@ -1,0 +1,18 @@
+﻿using Maple2Storage.Enums;
+using MaplePacketLib2.Tools;
+using MapleServer2.Constants;
+using MapleServer2.Packets;
+using MapleServer2.Servers.Game;
+
+namespace MapleServer2.PacketHandlers.Game;
+
+internal class RideConsumeEpHandler : GamePacketHandler<RideConsumeEpHandler>
+{
+    public override RecvOp OpCode => RecvOp.RideConsumeEp;
+
+    public override void Handle(GameSession session, PacketReader packet)
+    {
+        session.Player.FieldPlayer.ConsumeStamina(Constant.MountStaminaConsumption);
+        session.Send(StatPacket.UpdateStats(session.Player.FieldPlayer, StatAttribute.Stamina));
+    }
+}


### PR DESCRIPTION
Fixes #650 

The current amount that the stamina consumption is set to isn't exactly the same as in the original servers, but I believe this is unable to be fixed at the moment because of how stamina regeneration currently works.