### PR TITLE
Fix: Server crashing after making a character or closing client

### DIFF
--- a/MapleServer2/Servers/Game/GameSession.cs
+++ b/MapleServer2/Servers/Game/GameSession.cs
@@ -61,7 +61,7 @@ public class GameSession : Session
         FieldManager.RemovePlayer(Player);
         GameServer.PlayerManager.RemovePlayer(Player);
 
-        Player.OnlineCTS.Cancel();
+        Player.OnlineCTS?.Cancel();
         Player.OnlineTimeThread = null;
 
         CoordF safeCoord = Player.SafeBlock;

--- a/MapleServer2/Types/SkillTab.cs
+++ b/MapleServer2/Types/SkillTab.cs
@@ -82,7 +82,7 @@ public class SkillTab
             {
                 SkillMetadata subSkill = SkillMetadataStorage.GetSkill(subSkillId);
 
-                if (subSkill.Type == type)
+                if (subSkill != null && subSkill.Type == type)
                 {
                     skills.Add((subSkillId, level));
                 }


### PR DESCRIPTION
Added some safe checking nulls of `SkillTab.cs` and `GameSession.cs`

# The reason of crashing
1. When making character, subSkill in SkillTab.cs might be null.
2. Sometimes, when you are closing client OnlineCTS might be null.