### PR TITLE
Consistent mode naming and handler/packet name changes

### DIFF
--- a/MapleServer2/Enums/BuildModeType.cs
+++ b/MapleServer2/Enums/BuildModeType.cs
@@ -1,0 +1,8 @@
+﻿namespace MapleServer2.Enums;
+
+public enum BuildModeType : byte
+{
+    Stop = 0,
+    House = 1,
+    Liftables = 2
+}

--- a/MapleServer2/Managers/FieldManager.cs
+++ b/MapleServer2/Managers/FieldManager.cs
@@ -628,7 +628,7 @@ public class FieldManager
         Broadcast(session =>
         {
             session.Send(FieldPetPacket.AddPet(pet));
-            session.Send(ResponsePetPacket.Add(pet));
+            session.Send(PetPacket.Add(pet));
         });
     }
 
@@ -638,7 +638,7 @@ public class FieldManager
 
         Broadcast(session =>
         {
-            session.Send(ResponsePetPacket.Remove(pet));
+            session.Send(PetPacket.Remove(pet));
             session.Send(FieldPetPacket.RemovePet(pet));
         });
     }

--- a/MapleServer2/Managers/FieldManager.cs
+++ b/MapleServer2/Managers/FieldManager.cs
@@ -681,7 +681,7 @@ public class FieldManager
     public void AddCube(IFieldObject<Cube> cube, int houseOwnerObjectId, int fieldPlayerObjectId)
     {
         State.AddCube(cube);
-        BroadcastPacket(ResponseCubePacket.PlaceFurnishing(cube, houseOwnerObjectId, fieldPlayerObjectId, false));
+        BroadcastPacket(CubePacket.PlaceFurnishing(cube, houseOwnerObjectId, fieldPlayerObjectId, false));
 
         if (cube.Value.Item.HousingCategory is ItemHousingCategory.Ranching or ItemHousingCategory.Farming)
         {
@@ -704,7 +704,7 @@ public class FieldManager
         }
 
         State.RemoveCube(cube.ObjectId);
-        BroadcastPacket(ResponseCubePacket.RemoveCube(houseOwnerObjectId, fieldPlayerObjectId, cube.Coord.ToByte()));
+        BroadcastPacket(CubePacket.RemoveCube(houseOwnerObjectId, fieldPlayerObjectId, cube.Coord.ToByte()));
     }
 
     public void AddInstrument(IFieldObject<Instrument> instrument)

--- a/MapleServer2/PacketHandlers/Common/QuitHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/QuitHandler.cs
@@ -19,7 +19,7 @@ public class QuitHandler : CommonPacketHandler<QuitHandler>
         LoginEndpoint = new(IPAddress.Parse(ipAddress), port);
     }
 
-    private enum QuitMode : byte
+    private enum Mode : byte
     {
         ChangeCharacter = 0x00,
         Quit = 0x01
@@ -27,17 +27,17 @@ public class QuitHandler : CommonPacketHandler<QuitHandler>
 
     protected override void HandleCommon(Session session, PacketReader packet)
     {
-        QuitMode mode = (QuitMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case QuitMode.ChangeCharacter:
+            case Mode.ChangeCharacter:
                 if (session is GameSession gameSession)
                 {
                     HandleChangeCharacter(gameSession);
                 }
                 break;
-            case QuitMode.Quit:
+            case Mode.Quit:
                 if (session is GameSession gameSession2)
                 {
                     HandleQuit(gameSession2);

--- a/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
@@ -202,7 +202,7 @@ public class ResponseKeyHandler : CommonPacketHandler<ResponseKeyHandler>
         session.Send(PvpPacket.Mode16());
         session.Send(PvpPacket.Mode17());
 
-        session.Send(ResponsePetPacket.LoadAlbum());
+        session.Send(PetPacket.LoadAlbum());
         // LegionBattle (0xF6)
         // CharacterAbility
         // E1 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -229,7 +229,7 @@ public class ResponseKeyHandler : CommonPacketHandler<ResponseKeyHandler>
         // 0xF0, ResponsePet P(0F 01)
         // RequestFieldEnter
         //session.Send("16 00 00 41 75 19 03 00 01 8A 42 0F 00 00 00 00 00 00 C0 28 C4 00 40 03 44 00 00 16 44 00 00 00 00 00 00 00 00 55 FF 33 42 E8 49 01 00".ToByteArray());
-        session.Send(RequestFieldEnterPacket.RequestEnter(player.FieldPlayer));
+        session.Send(FieldEnterPacket.RequestEnter(player.FieldPlayer));
 
         Party party = GameServer.PartyManager.GetPartyByMember(player.CharacterId);
         if (party != null)

--- a/MapleServer2/PacketHandlers/Game/AttendanceHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/AttendanceHandler.cs
@@ -15,7 +15,7 @@ public class AttendanceHandler : GamePacketHandler<AttendanceHandler>
 {
     public override RecvOp OpCode => RecvOp.Attendance;
 
-    private enum AttendanceMode : byte
+    private enum Mode : byte
     {
         Claim = 0x0,
         BeginTimer = 0x1,
@@ -33,17 +33,17 @@ public class AttendanceHandler : GamePacketHandler<AttendanceHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        AttendanceMode mode = (AttendanceMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case AttendanceMode.Claim:
+            case Mode.Claim:
                 HandleClaim(session);
                 break;
-            case AttendanceMode.BeginTimer:
+            case Mode.BeginTimer:
                 HandleBeginTimer(session);
                 break;
-            case AttendanceMode.EarlyParticipate:
+            case Mode.EarlyParticipate:
                 HandleEarlyParticipation(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -18,7 +18,7 @@ public class BeautyHandler : GamePacketHandler<BeautyHandler>
 {
     public override RecvOp OpCode => RecvOp.Beauty;
 
-    private enum BeautyMode : byte
+    private enum Mode : byte
     {
         LoadShop = 0x0,
         NewBeauty = 0x3,
@@ -36,44 +36,44 @@ public class BeautyHandler : GamePacketHandler<BeautyHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BeautyMode mode = (BeautyMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case BeautyMode.LoadShop:
+            case Mode.LoadShop:
                 HandleLoadShop(session, packet);
                 break;
-            case BeautyMode.NewBeauty:
+            case Mode.NewBeauty:
                 HandleNewBeauty(session, packet);
                 break;
-            case BeautyMode.ModifyExistingBeauty:
+            case Mode.ModifyExistingBeauty:
                 HandleModifyExistingBeauty(session, packet);
                 break;
-            case BeautyMode.ModifySkin:
+            case Mode.ModifySkin:
                 HandleModifySkin(session, packet);
                 break;
-            case BeautyMode.RandomHair:
+            case Mode.RandomHair:
                 HandleRandomHair(session, packet);
                 break;
-            case BeautyMode.ChooseRandomHair:
+            case Mode.ChooseRandomHair:
                 HandleChooseRandomHair(session, packet);
                 break;
-            case BeautyMode.SaveHair:
+            case Mode.SaveHair:
                 HandleSaveHair(session, packet);
                 break;
-            case BeautyMode.Teleport:
+            case Mode.Teleport:
                 HandleTeleport(session, packet);
                 break;
-            case BeautyMode.DeleteSavedHair:
+            case Mode.DeleteSavedHair:
                 HandleDeleteSavedHair(session, packet);
                 break;
-            case BeautyMode.ChangeToSavedHair:
+            case Mode.ChangeToSavedHair:
                 HandleChangeToSavedHair(session, packet);
                 break;
-            case BeautyMode.DyeItem:
+            case Mode.DyeItem:
                 HandleDyeItem(session, packet);
                 break;
-            case BeautyMode.BeautyVoucher:
+            case Mode.BeautyVoucher:
                 HandleBeautyVoucher(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -16,7 +16,7 @@ public class BlackMarketHandler : GamePacketHandler<BlackMarketHandler>
 {
     public override RecvOp OpCode => RecvOp.BlackMarket;
 
-    private enum BlackMarketMode : byte
+    private enum Mode : byte
     {
         Open = 0x1,
         CreateListing = 0x2,
@@ -42,26 +42,26 @@ public class BlackMarketHandler : GamePacketHandler<BlackMarketHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BlackMarketMode mode = (BlackMarketMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case BlackMarketMode.Open:
+            case Mode.Open:
                 HandleOpen(session);
                 break;
-            case BlackMarketMode.CreateListing:
+            case Mode.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case BlackMarketMode.CancelListing:
+            case Mode.CancelListing:
                 HandleCancelListing(session, packet);
                 break;
-            case BlackMarketMode.Search:
+            case Mode.Search:
                 HandleSearch(session, packet);
                 break;
-            case BlackMarketMode.Purchase:
+            case Mode.Purchase:
                 HandlePurchase(session, packet);
                 break;
-            case BlackMarketMode.PrepareListing:
+            case Mode.PrepareListing:
                 HandlePrepareListing(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
@@ -11,7 +11,7 @@ public class BuddyEmoteHandler : GamePacketHandler<BuddyEmoteHandler>
 {
     public override RecvOp OpCode => RecvOp.BuddyEmote;
 
-    private enum BuddyEmoteMode : byte
+    private enum Mode : byte
     {
         InviteBuddyEmote = 0x0,
         InviteBuddyEmoteConfirm = 0x1,
@@ -23,26 +23,26 @@ public class BuddyEmoteHandler : GamePacketHandler<BuddyEmoteHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BuddyEmoteMode mode = (BuddyEmoteMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case BuddyEmoteMode.InviteBuddyEmote:
+            case Mode.InviteBuddyEmote:
                 HandleInviteBuddyEmote(session, packet);
                 break;
-            case BuddyEmoteMode.InviteBuddyEmoteConfirm:
+            case Mode.InviteBuddyEmoteConfirm:
                 HandleInviteBuddyEmoteConfirm(session, packet);
                 break;
-            case BuddyEmoteMode.LearnEmote:
+            case Mode.LearnEmote:
                 HandleLearnEmote(session, packet);
                 break;
-            case BuddyEmoteMode.AcceptEmote:
+            case Mode.AcceptEmote:
                 HandleAcceptEmote(session, packet);
                 break;
-            case BuddyEmoteMode.DeclineEmote:
+            case Mode.DeclineEmote:
                 HandleDeclineEmote(session, packet);
                 break;
-            case BuddyEmoteMode.StopEmote:
+            case Mode.StopEmote:
                 HandleStopEmote(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/BuddyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyHandler.cs
@@ -13,7 +13,7 @@ public class BuddyHandler : GamePacketHandler<BuddyHandler>
 {
     public override RecvOp OpCode => RecvOp.Buddy;
 
-    private enum BuddyMode : byte
+    private enum Mode : byte
     {
         SendRequest = 0x2,
         Accept = 0x3,
@@ -41,32 +41,32 @@ public class BuddyHandler : GamePacketHandler<BuddyHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BuddyMode mode = (BuddyMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case BuddyMode.SendRequest:
+            case Mode.SendRequest:
                 HandleSendRequest(session, packet);
                 break;
-            case BuddyMode.Accept:
+            case Mode.Accept:
                 HandleAccept(session, packet);
                 break;
-            case BuddyMode.Decline:
+            case Mode.Decline:
                 HandleDecline(session, packet);
                 break;
-            case BuddyMode.Block:
+            case Mode.Block:
                 HandleBlock(session, packet);
                 break;
-            case BuddyMode.Unblock:
+            case Mode.Unblock:
                 HandleUnblock(session, packet);
                 break;
-            case BuddyMode.RemoveFriend:
+            case Mode.RemoveFriend:
                 HandleRemoveFriend(session, packet);
                 break;
-            case BuddyMode.EditBlockReason:
+            case Mode.EditBlockReason:
                 HandleEditBlockReason(session, packet);
                 break;
-            case BuddyMode.CancelRequest:
+            case Mode.CancelRequest:
                 HandleCancelRequest(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Enums;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
 using MapleServer2.Types;
@@ -11,29 +12,22 @@ public class BuildModeHandler : GamePacketHandler<BuildModeHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestSetBuildMode;
 
-    private enum BuildModeMode : byte
+    private enum Mode : byte
     {
         Stop = 0x0,
         Start = 0x1
     }
 
-    public enum BuildModeType : byte
-    {
-        Stop = 0x0,
-        House = 0x1,
-        Liftables = 0x2
-    }
-
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BuildModeMode mode = (BuildModeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case BuildModeMode.Stop:
+            case Mode.Stop:
                 HandleStop(session);
                 break;
-            case BuildModeMode.Start:
+            case Mode.Start:
                 HandleStart(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
@@ -12,7 +12,7 @@ public class CardReverseGameHandler : GamePacketHandler<CardReverseGameHandler>
 {
     public override RecvOp OpCode => RecvOp.CardReverseGame;
 
-    private enum CardReverseGameMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Mix = 0x1,
@@ -21,17 +21,17 @@ public class CardReverseGameHandler : GamePacketHandler<CardReverseGameHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        CardReverseGameMode mode = (CardReverseGameMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case CardReverseGameMode.Open:
+            case Mode.Open:
                 HandleOpen(session);
                 break;
-            case CardReverseGameMode.Mix:
+            case Mode.Mix:
                 HandleMix(session);
                 break;
-            case CardReverseGameMode.Select:
+            case Mode.Select:
                 HandleSelect(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
@@ -14,7 +14,7 @@ public class ChangeAttributesHandler : GamePacketHandler<ChangeAttributesHandler
 {
     public override RecvOp OpCode => RecvOp.ChangeAttribute;
 
-    private enum ChangeAttributesMode : byte
+    private enum Mode : byte
     {
         ChangeAttributes = 0,
         SelectNewAttributes = 2
@@ -22,14 +22,14 @@ public class ChangeAttributesHandler : GamePacketHandler<ChangeAttributesHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ChangeAttributesMode function = (ChangeAttributesMode) packet.ReadByte();
+        Mode function = (Mode) packet.ReadByte();
 
         switch (function)
         {
-            case ChangeAttributesMode.ChangeAttributes:
+            case Mode.ChangeAttributes:
                 HandleChangeAttributes(session, packet);
                 break;
-            case ChangeAttributesMode.SelectNewAttributes:
+            case Mode.SelectNewAttributes:
                 HandleSelectNewAttributes(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
@@ -12,7 +12,7 @@ public class ChangeAttributesScrollHandler : GamePacketHandler<ChangeAttributesS
 {
     public override RecvOp OpCode => RecvOp.ChangeAttributeScroll;
 
-    private enum ChangeAttributeMode : byte
+    private enum Mode : byte
     {
         ChangeAttributes = 1,
         SelectNewAttributes = 3
@@ -20,13 +20,13 @@ public class ChangeAttributesScrollHandler : GamePacketHandler<ChangeAttributesS
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ChangeAttributeMode mode = (ChangeAttributeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case ChangeAttributeMode.ChangeAttributes:
+            case Mode.ChangeAttributes:
                 HandleChangeAttributes(session, packet);
                 break;
-            case ChangeAttributeMode.SelectNewAttributes:
+            case Mode.SelectNewAttributes:
                 HandleSelectNewAttributes(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ChatStickerHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChatStickerHandler.cs
@@ -10,7 +10,7 @@ public class ChatStickerHandler : GamePacketHandler<ChatStickerHandler>
 {
     public override RecvOp OpCode => RecvOp.ChatSticker;
 
-    private enum ChatStickerMode : byte
+    private enum Mode : byte
     {
         OpenWindow = 0x1,
         UseSticker = 0x3,
@@ -21,23 +21,23 @@ public class ChatStickerHandler : GamePacketHandler<ChatStickerHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ChatStickerMode mode = (ChatStickerMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ChatStickerMode.OpenWindow:
+            case Mode.OpenWindow:
                 HandleOpenWindow();
                 break;
-            case ChatStickerMode.UseSticker:
+            case Mode.UseSticker:
                 HandleUseSticker(session, packet);
                 break;
-            case ChatStickerMode.GroupChatSticker:
+            case Mode.GroupChatSticker:
                 HandleGroupChatSticker(session, packet);
                 break;
-            case ChatStickerMode.Favorite:
+            case Mode.Favorite:
                 HandleFavorite(session, packet);
                 break;
-            case ChatStickerMode.Unfavorite:
+            case Mode.Unfavorite:
                 HandleUnfavorite(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ClubHandler.cs
@@ -12,7 +12,7 @@ public class ClubHandler : GamePacketHandler<ClubHandler>
 {
     public override RecvOp OpCode => RecvOp.Club;
 
-    private enum ClubMode : byte
+    private enum Mode : byte
     {
         Create = 0x1,
         NewClubInvite = 0x3,
@@ -45,29 +45,29 @@ public class ClubHandler : GamePacketHandler<ClubHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ClubMode mode = (ClubMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ClubMode.Create:
+            case Mode.Create:
                 HandleCreate(session, packet);
                 break;
-            case ClubMode.NewClubInvite:
+            case Mode.NewClubInvite:
                 HandleNewClubInvite(session, packet);
                 break;
-            case ClubMode.SendInvite:
+            case Mode.SendInvite:
                 HandleSendInvite(session, packet);
                 break;
-            case ClubMode.InviteResponse:
+            case Mode.InviteResponse:
                 HandleInviteResponse(session, packet);
                 break;
-            case ClubMode.Leave:
+            case Mode.Leave:
                 HandleLeave(session, packet);
                 break;
-            case ClubMode.Buff:
+            case Mode.Buff:
                 HandleBuff(packet);
                 break;
-            case ClubMode.Rename:
+            case Mode.Rename:
                 HandleRename(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -12,7 +12,7 @@ public class DungeonHandler : GamePacketHandler<DungeonHandler>
 {
     public override RecvOp OpCode => RecvOp.RoomDungeon;
 
-    private enum DungeonMode : byte
+    private enum Mode : byte
     {
         ResetDungeon = 0x01,
         CreateDungeon = 0x02,
@@ -26,29 +26,29 @@ public class DungeonHandler : GamePacketHandler<DungeonHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        DungeonMode mode = (DungeonMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case DungeonMode.EnterDungeonPortal:
+            case Mode.EnterDungeonPortal:
                 HandleEnterDungeonPortal(session);
                 break;
-            case DungeonMode.CreateDungeon:
+            case Mode.CreateDungeon:
                 HandleCreateDungeon(session, packet);
                 break;
-            case DungeonMode.EnterDungeonButton:
+            case Mode.EnterDungeonButton:
                 HandleEnterDungeonButton(session);
                 break;
-            case DungeonMode.AddRewards:
+            case Mode.AddRewards:
                 HandleAddRewards(session, packet);
                 break;
-            case DungeonMode.GetHelp:
+            case Mode.GetHelp:
                 HandleGetHelp(session, packet);
                 break;
-            case DungeonMode.Veteran:
+            case Mode.Veteran:
                 HandleVeteran(session, packet);
                 break;
-            case DungeonMode.Favorite:
+            case Mode.Favorite:
                 HandleFavorite(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
@@ -10,7 +10,7 @@ public class EmoteHandler : GamePacketHandler<EmoteHandler>
 {
     public override RecvOp OpCode => RecvOp.Emotion;
 
-    private enum EmoteMode : byte
+    private enum Mode : byte
     {
         LearnEmote = 0x1,
         UseEmote = 0x2
@@ -18,14 +18,14 @@ public class EmoteHandler : GamePacketHandler<EmoteHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        EmoteMode mode = (EmoteMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case EmoteMode.LearnEmote:
+            case Mode.LearnEmote:
                 HandleLearnEmote(session, packet);
                 break;
-            case EmoteMode.UseEmote:
+            case Mode.UseEmote:
                 HandleUseEmote(packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/EnchantScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EnchantScrollHandler.cs
@@ -16,7 +16,7 @@ public class EnchantScrollHandler : GamePacketHandler<EnchantScrollHandler>
 {
     public override RecvOp OpCode => RecvOp.EnchantScroll;
 
-    private enum EnchantScrollMode : byte
+    private enum Mode : byte
     {
         AddItem = 0x1,
         UseScroll = 0x2,
@@ -37,7 +37,7 @@ public class EnchantScrollHandler : GamePacketHandler<EnchantScrollHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        EnchantScrollMode mode = (EnchantScrollMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         long scrollUid = packet.ReadLong();
         long equipUid = packet.ReadLong();
@@ -87,10 +87,10 @@ public class EnchantScrollHandler : GamePacketHandler<EnchantScrollHandler>
 
         switch (mode)
         {
-            case EnchantScrollMode.AddItem:
+            case Mode.AddItem:
                 session.Send(EnchantScrollPacket.AddItem(equipUid, enchantStats));
                 break;
-            case EnchantScrollMode.UseScroll:
+            case Mode.UseScroll:
                 HandleUseScroll(session, equip, scroll, enchantStats, metadata.EnchantLevels[enchantLevelIndex], metadata.Id);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -68,9 +68,9 @@ public class FieldEnterHandler : GamePacketHandler<FieldEnterHandler>
         }
         session.Send(ChatStickerPacket.LoadChatSticker(player));
 
-        session.Send(ResponseCubePacket.DecorationScore(account.Home));
-        session.Send(ResponseCubePacket.LoadHome(player.FieldPlayer.ObjectId, player.Account.Home));
-        session.Send(ResponseCubePacket.ReturnMap(player.ReturnMapId));
+        session.Send(CubePacket.DecorationScore(account.Home));
+        session.Send(CubePacket.LoadHome(player.FieldPlayer.ObjectId, player.Account.Home));
+        session.Send(CubePacket.ReturnMap(player.ReturnMapId));
         session.Send(LapenshardPacket.Load(player.Inventory.LapenshardStorage));
 
         IEnumerable<Cube> cubes = session.FieldManager.State.Cubes.Values

--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -39,7 +39,7 @@ public class FieldEnterHandler : GamePacketHandler<FieldEnterHandler>
             {
                 player.FieldPlayer.ActivePet = pet;
 
-                session.Send(ResponsePetPacket.LoadPetSettings(pet));
+                session.Send(PetPacket.LoadPetSettings(pet));
                 session.Send(NoticePacket.Notice(SystemNotice.PetSummonOn, NoticeType.Chat | NoticeType.FastText));
             }
         }

--- a/MapleServer2/PacketHandlers/Game/FieldWarHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldWarHandler.cs
@@ -10,17 +10,17 @@ public class FieldWarHandler : GamePacketHandler<FieldWarHandler>
 {
     public override RecvOp OpCode => RecvOp.FieldWar;
 
-    private enum FieldWarMode : byte
+    private enum Mode : byte
     {
         LegionEnter = 0x01
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        FieldWarMode function = (FieldWarMode) packet.ReadByte();
+        Mode function = (Mode) packet.ReadByte();
         switch (function)
         {
-            case FieldWarMode.LegionEnter:
+            case Mode.LegionEnter:
                 HandleLegionEnter(session);
                 break;
         }

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -14,7 +14,7 @@ public class FishingHandler : GamePacketHandler<FishingHandler>
 {
     public override RecvOp OpCode => RecvOp.Fishing;
 
-    private enum FishingMode : byte
+    private enum Mode : byte
     {
         PrepareFishing = 0x0,
         Stop = 0x1,
@@ -35,23 +35,23 @@ public class FishingHandler : GamePacketHandler<FishingHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        FishingMode mode = (FishingMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case FishingMode.PrepareFishing:
+            case Mode.PrepareFishing:
                 HandlePrepareFishing(session, packet);
                 break;
-            case FishingMode.Stop:
+            case Mode.Stop:
                 HandleStop(session);
                 break;
-            case FishingMode.Catch:
+            case Mode.Catch:
                 HandleCatch(session, packet);
                 break;
-            case FishingMode.Start:
+            case Mode.Start:
                 HandleStart(session, packet);
                 break;
-            case FishingMode.FailMinigame:
+            case Mode.FailMinigame:
                 HandleFailMinigame();
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/FunctionCubeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FunctionCubeHandler.cs
@@ -15,17 +15,17 @@ public class FunctionCubeHandler : GamePacketHandler<FunctionCubeHandler>
 {
     public override RecvOp OpCode => RecvOp.FunctionCube;
 
-    private enum FunctionCubeMode : byte
+    private enum Mode : byte
     {
         Use = 0x04
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        FunctionCubeMode mode = (FunctionCubeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case FunctionCubeMode.Use:
+            case Mode.Use:
                 HandleUseCube(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/GemEquipmentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GemEquipmentHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestGemEquipmentHandler : GamePacketHandler<RequestGemEquipmentHandler>
+public class GemEquipmentHandler : GamePacketHandler<GemEquipmentHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestGemEquipment;
 
-    private enum RequestGemEquipmentMode : byte
+    private enum Mode : byte
     {
         EquipItem = 0x00,
         UnequipItem = 0x01,
@@ -19,17 +19,17 @@ public class RequestGemEquipmentHandler : GamePacketHandler<RequestGemEquipmentH
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestGemEquipmentMode mode = (RequestGemEquipmentMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case RequestGemEquipmentMode.EquipItem:
+            case Mode.EquipItem:
                 HandleEquipItem(session, packet);
                 break;
-            case RequestGemEquipmentMode.UnequipItem:
+            case Mode.UnequipItem:
                 HandleUnequipItem(session, packet);
                 break;
-            case RequestGemEquipmentMode.Transparency:
+            case Mode.Transparency:
                 HandleTransparency(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/GlobalPortalHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GlobalPortalHandler.cs
@@ -11,18 +11,18 @@ public class GlobalPortalHandler : GamePacketHandler<GlobalPortalHandler>
 {
     public override RecvOp OpCode => RecvOp.GlobalPortal;
 
-    private enum GlobalPortalMode : byte
+    private enum Mode : byte
     {
         Enter = 0x2
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        GlobalPortalMode mode = (GlobalPortalMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case GlobalPortalMode.Enter:
+            case Mode.Enter:
                 HandleEnter(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/GroupChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GroupChatHandler.cs
@@ -10,7 +10,7 @@ public class GroupChatHandler : GamePacketHandler<GroupChatHandler>
 {
     public override RecvOp OpCode => RecvOp.GroupChat;
 
-    private enum GroupChatMode : byte
+    private enum Mode : byte
     {
         Create = 0x1,
         Invite = 0x2,
@@ -20,20 +20,20 @@ public class GroupChatHandler : GamePacketHandler<GroupChatHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        GroupChatMode mode = (GroupChatMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case GroupChatMode.Create:
+            case Mode.Create:
                 HandleCreate(session);
                 break;
-            case GroupChatMode.Invite:
+            case Mode.Invite:
                 HandleInvite(session, packet);
                 break;
-            case GroupChatMode.Leave:
+            case Mode.Leave:
                 HandleLeave(session, packet);
                 break;
-            case GroupChatMode.Chat:
+            case Mode.Chat:
                 HandleChat(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -16,7 +16,7 @@ public class GuildHandler : GamePacketHandler<GuildHandler>
 {
     public override RecvOp OpCode => RecvOp.Guild;
 
-    private enum GuildMode : byte
+    private enum Mode : byte
     {
         Create = 0x1,
         Disband = 0x2,
@@ -85,88 +85,88 @@ public class GuildHandler : GamePacketHandler<GuildHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        GuildMode mode = (GuildMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case GuildMode.Create:
+            case Mode.Create:
                 HandleCreate(session, packet);
                 break;
-            case GuildMode.Disband:
+            case Mode.Disband:
                 HandleDisband(session);
                 break;
-            case GuildMode.Invite:
+            case Mode.Invite:
                 HandleInvite(session, packet);
                 break;
-            case GuildMode.InviteResponse:
+            case Mode.InviteResponse:
                 HandleInviteResponse(session, packet);
                 break;
-            case GuildMode.Leave:
+            case Mode.Leave:
                 HandleLeave(session);
                 break;
-            case GuildMode.Kick:
+            case Mode.Kick:
                 HandleKick(session, packet);
                 break;
-            case GuildMode.RankChange:
+            case Mode.RankChange:
                 HandleRankChange(session, packet);
                 break;
-            case GuildMode.PlayerMessage:
+            case Mode.PlayerMessage:
                 HandlePlayerMessage(session, packet);
                 break;
-            case GuildMode.CheckIn:
+            case Mode.CheckIn:
                 HandleCheckIn(session);
                 break;
-            case GuildMode.TransferLeader:
+            case Mode.TransferLeader:
                 HandleTransferLeader(session, packet);
                 break;
-            case GuildMode.GuildNotice:
+            case Mode.GuildNotice:
                 HandleGuildNotice(session, packet);
                 break;
-            case GuildMode.UpdateRank:
+            case Mode.UpdateRank:
                 HandleUpdateRank(session, packet);
                 break;
-            case GuildMode.ListGuild:
+            case Mode.ListGuild:
                 HandleListGuild(session, packet);
                 break;
-            case GuildMode.GuildMail:
+            case Mode.GuildMail:
                 HandleGuildMail(session, packet);
                 break;
-            case GuildMode.SubmitApplication:
+            case Mode.SubmitApplication:
                 HandleSubmitApplication(session, packet);
                 break;
-            case GuildMode.WithdrawApplication:
+            case Mode.WithdrawApplication:
                 HandleWithdrawApplication(session, packet);
                 break;
-            case GuildMode.ApplicationResponse:
+            case Mode.ApplicationResponse:
                 HandleApplicationResponse(session, packet);
                 break;
-            case GuildMode.LoadApplications:
+            case Mode.LoadApplications:
                 HandleLoadApplications(session);
                 break;
-            case GuildMode.LoadGuildList:
+            case Mode.LoadGuildList:
                 HandleLoadGuildList(session, packet);
                 break;
-            case GuildMode.SearchGuildByName:
+            case Mode.SearchGuildByName:
                 HandleSearchGuildByName(session, packet);
                 break;
-            case GuildMode.UseBuff:
+            case Mode.UseBuff:
                 HandleUseBuff(session, packet);
                 break;
-            case GuildMode.UpgradeBuff:
+            case Mode.UpgradeBuff:
                 HandleUpgradeBuff(session, packet);
                 break;
-            case GuildMode.UpgradeHome:
+            case Mode.UpgradeHome:
                 HandleUpgradeHome(session, packet);
                 break;
-            case GuildMode.ChangeHomeTheme:
+            case Mode.ChangeHomeTheme:
                 HandleChangeHomeTheme(session, packet);
                 break;
-            case GuildMode.EnterHouse:
+            case Mode.EnterHouse:
                 HandleEnterHouse(session);
                 break;
-            case GuildMode.GuildDonate:
+            case Mode.GuildDonate:
                 HandleGuildDonate(session, packet);
                 break;
-            case GuildMode.Services:
+            case Mode.Services:
                 HandleServices(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
@@ -15,7 +15,7 @@ public class HomeActionHandler : GamePacketHandler<HomeActionHandler>
 {
     public override RecvOp OpCode => RecvOp.HomeAction;
 
-    private enum HomeActionMode : byte
+    private enum Mode : byte
     {
         Smite = 0x01,
         Kick = 0x02,
@@ -27,23 +27,23 @@ public class HomeActionHandler : GamePacketHandler<HomeActionHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        HomeActionMode mode = (HomeActionMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case HomeActionMode.Kick:
+            case Mode.Kick:
                 HandleKick(packet);
                 break;
-            case HomeActionMode.Survey:
+            case Mode.Survey:
                 HandleRespondSurvey(session, packet);
                 break;
-            case HomeActionMode.ChangePortalSettings:
+            case Mode.ChangePortalSettings:
                 HandleChangePortalSettings(session, packet);
                 break;
-            case HomeActionMode.UpdateBallCoord:
+            case Mode.UpdateBallCoord:
                 HandleUpdateBallCoord(session, packet);
                 break;
-            case HomeActionMode.SendPortalSettings:
+            case Mode.SendPortalSettings:
                 HandleSendPortalSettings(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/HomeBankHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/HomeBankHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestHomeBankHandler : GamePacketHandler<RequestHomeBankHandler>
+public class HomeBankHandler : GamePacketHandler<HomeBankHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestHomeBank;
 
-    private enum BankMode : byte
+    private enum Mode : byte
     {
         House = 0x01,
         Inventory = 0x02
@@ -18,13 +18,13 @@ public class RequestHomeBankHandler : GamePacketHandler<RequestHomeBankHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BankMode mode = (BankMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case BankMode.House:
+            case Mode.House:
                 HandleOpen(session, TimeInfo.Now());
                 break;
-            case BankMode.Inventory:
+            case Mode.Inventory:
                 HandleOpen(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/HomeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/HomeHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestHomeHandler : GamePacketHandler<RequestHomeHandler>
+public class HomeHandler : GamePacketHandler<HomeHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestHome;
 
-    private enum RequestHomeMode : byte
+    private enum Mode : byte
     {
         InviteToHome = 0x01,
         MoveToHome = 0x03
@@ -18,13 +18,13 @@ public class RequestHomeHandler : GamePacketHandler<RequestHomeHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestHomeMode mode = (RequestHomeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case RequestHomeMode.InviteToHome:
+            case Mode.InviteToHome:
                 HandleInviteToHome(session, packet);
                 break;
-            case RequestHomeMode.MoveToHome:
+            case Mode.MoveToHome:
                 HandleMoveToHome(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -13,7 +13,7 @@ public class InstrumentHandler : GamePacketHandler<InstrumentHandler>
 {
     public override RecvOp OpCode => RecvOp.PlayInstrument;
 
-    private enum InstrumentMode : byte
+    private enum Mode : byte
     {
         StartImprovise = 0x0,
         PlayNote = 0x1,
@@ -29,38 +29,38 @@ public class InstrumentHandler : GamePacketHandler<InstrumentHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        InstrumentMode mode = (InstrumentMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case InstrumentMode.StartImprovise:
+            case Mode.StartImprovise:
                 HandleStartImprovise(session, packet);
                 break;
-            case InstrumentMode.PlayNote:
+            case Mode.PlayNote:
                 HandlePlayNote(session, packet);
                 break;
-            case InstrumentMode.StopImprovise:
+            case Mode.StopImprovise:
                 HandleStopImprovise(session);
                 break;
-            case InstrumentMode.PlayScore:
+            case Mode.PlayScore:
                 HandlePlayScore(session, packet);
                 break;
-            case InstrumentMode.StopScore:
+            case Mode.StopScore:
                 HandleStopScore(session);
                 break;
-            case InstrumentMode.StartEnsemble:
+            case Mode.StartEnsemble:
                 HandleStartEnsemble(session, packet);
                 break;
-            case InstrumentMode.LeaveEnsemble:
+            case Mode.LeaveEnsemble:
                 HandleLeaveEnsemble(session);
                 break;
-            case InstrumentMode.Compose:
+            case Mode.Compose:
                 HandleCompose(session, packet);
                 break;
-            case InstrumentMode.Fireworks:
+            case Mode.Fireworks:
                 HandleFireworks(session);
                 break;
-            case InstrumentMode.AudienceEmote:
+            case Mode.AudienceEmote:
                 HandleAudienceEmote(packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
@@ -16,7 +16,7 @@ internal class InteractObjectHandler : GamePacketHandler<InteractObjectHandler>
 {
     public override RecvOp OpCode => RecvOp.InteractObject;
 
-    private enum InteractObjectMode : byte
+    private enum Mode : byte
     {
         Cast = 0x0B,
         Interact = 0x0C
@@ -24,14 +24,14 @@ internal class InteractObjectHandler : GamePacketHandler<InteractObjectHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        InteractObjectMode mode = (InteractObjectMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case InteractObjectMode.Cast:
+            case Mode.Cast:
                 HandleCast(session, packet);
                 break;
-            case InteractObjectMode.Interact:
+            case Mode.Interact:
                 HandleInteract(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemBreakHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemBreakHandler.cs
@@ -5,11 +5,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemBreakHandler : GamePacketHandler<RequestItemBreakHandler>
+public class ItemBreakHandler : GamePacketHandler<ItemBreakHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemBreak;
 
-    private enum ItemBreakMode : byte
+    private enum Mode : byte
     {
         Open = 0x00,
         Add = 0x01,
@@ -20,23 +20,23 @@ public class RequestItemBreakHandler : GamePacketHandler<RequestItemBreakHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemBreakMode mode = (ItemBreakMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case ItemBreakMode.Open:
+            case Mode.Open:
                 session.Player.DismantleInventory.Slots = new (long, int)[100];
                 session.Player.DismantleInventory.Rewards = new();
                 break;
-            case ItemBreakMode.Add:
+            case Mode.Add:
                 HandleAdd(session, packet);
                 break;
-            case ItemBreakMode.Remove:
+            case Mode.Remove:
                 HandleRemove(session, packet);
                 break;
-            case ItemBreakMode.Dismantle:
+            case Mode.Dismantle:
                 HandleDismantle(session);
                 break;
-            case ItemBreakMode.AutoAdd:
+            case Mode.AutoAdd:
                 HandleAutoAdd(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
@@ -16,7 +16,7 @@ public class ItemEnchantHandler : GamePacketHandler<ItemEnchantHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemEnchant;
 
-    private enum ItemEnchantMode : byte
+    private enum Mode : byte
     {
         None = 0,
         BeginEnchant = 0x01,
@@ -35,25 +35,25 @@ public class ItemEnchantHandler : GamePacketHandler<ItemEnchantHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemEnchantMode mode = (ItemEnchantMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ItemEnchantMode.None: // Sent when opening up enchant ui
+            case Mode.None: // Sent when opening up enchant ui
                 break;
-            case ItemEnchantMode.BeginEnchant:
+            case Mode.BeginEnchant:
                 HandleBeginEnchant(session, packet);
                 break;
-            case ItemEnchantMode.UpdateCatalysts:
+            case Mode.UpdateCatalysts:
                 HandleUpdateCatalysts(session, packet);
                 break;
-            case ItemEnchantMode.UpdateCharges:
+            case Mode.UpdateCharges:
                 HandleUpdateCharges(session, packet);
                 break;
-            case ItemEnchantMode.Ophelia:
+            case Mode.Ophelia:
                 HandleOpheliaEnchant(session, packet);
                 break;
-            case ItemEnchantMode.Peachy:
+            case Mode.Peachy:
                 HandlePeachyEnchant(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantTransferHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantTransferHandler.cs
@@ -12,15 +12,6 @@ public class ItemEnchantTransferHandler : GamePacketHandler<ItemEnchantTransferH
 {
     public override RecvOp OpCode => RecvOp.ItemEnchantTransform;
 
-    private enum ItemEnchantTransferMode : byte
-    {
-        Convert = 0x1,
-        UseSticker = 0x3,
-        GroupChatSticker = 0x4,
-        Favorite = 0x5,
-        Unfavorite = 0x6
-    }
-
     public override void Handle(GameSession session, PacketReader packet)
     {
         long itemUid = packet.ReadLong();

--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -9,7 +9,7 @@ public class ItemEquipHandler : GamePacketHandler<ItemEquipHandler>
 {
     public override RecvOp OpCode => RecvOp.ItemEquip;
 
-    private enum ItemEquipMode : byte
+    private enum Mode : byte
     {
         Equip = 0,
         Unequip = 1
@@ -17,14 +17,14 @@ public class ItemEquipHandler : GamePacketHandler<ItemEquipHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemEquipMode function = (ItemEquipMode) packet.ReadByte();
+        Mode function = (Mode) packet.ReadByte();
 
         switch (function)
         {
-            case ItemEquipMode.Equip:
+            case Mode.Equip:
                 HandleEquipItem(session, packet);
                 break;
-            case ItemEquipMode.Unequip:
+            case Mode.Unequip:
                 HandleUnequipItem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
@@ -12,18 +12,18 @@ public class ItemExchangeHandler : GamePacketHandler<ItemExchangeHandler>
 {
     public override RecvOp OpCode => RecvOp.ItemExchange;
 
-    private enum ItemExchangeMode : byte
+    private enum Mode : byte
     {
         Use = 0x1
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemExchangeMode mode = (ItemExchangeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ItemExchangeMode.Use:
+            case Mode.Use:
                 HandleUse(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemInventoryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemInventoryHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemInventoryHandler : GamePacketHandler<RequestItemInventoryHandler>
+public class ItemInventoryHandler : GamePacketHandler<ItemInventoryHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemInventory;
 
-    private enum RequestItemInventoryMode : byte
+    private enum Mode : byte
     {
         Move = 0x3,
         Drop = 0x4,
@@ -21,23 +21,23 @@ public class RequestItemInventoryHandler : GamePacketHandler<RequestItemInventor
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestItemInventoryMode mode = (RequestItemInventoryMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case RequestItemInventoryMode.Move:
+            case Mode.Move:
                 HandleMove(session, packet);
                 break;
-            case RequestItemInventoryMode.Drop:
+            case Mode.Drop:
                 HandleDrop(session, packet);
                 break;
-            case RequestItemInventoryMode.DropBound:
+            case Mode.DropBound:
                 HandleDropBound(session, packet);
                 break;
-            case RequestItemInventoryMode.Sort:
+            case Mode.Sort:
                 HandleSort(session, packet);
                 break;
-            case RequestItemInventoryMode.Expand:
+            case Mode.Expand:
                 HandleExpand(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemLockHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemLockHandler.cs
@@ -4,11 +4,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemLockHandler : GamePacketHandler<RequestItemLockHandler>
+public class ItemLockHandler : GamePacketHandler<ItemLockHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemLock;
 
-    private enum ItemLockMode : byte
+    private enum Mode : byte
     {
         Open = 0x00,
         Add = 0x01,
@@ -18,19 +18,19 @@ public class RequestItemLockHandler : GamePacketHandler<RequestItemLockHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemLockMode mode = (ItemLockMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case ItemLockMode.Open:
+            case Mode.Open:
                 session.Player.LockInventory = new();
                 break;
-            case ItemLockMode.Add:
+            case Mode.Add:
                 HandleAdd(session, packet);
                 break;
-            case ItemLockMode.Remove:
+            case Mode.Remove:
                 HandleRemove(session, packet);
                 break;
-            case ItemLockMode.Update:
+            case Mode.Update:
                 HandleUpdateItem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemPickupHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemPickupHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemPickupHandler : GamePacketHandler<RequestItemPickupHandler>
+public class ItemPickupHandler : GamePacketHandler<ItemPickupHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemPickup;
 

--- a/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
@@ -11,7 +11,7 @@ public class ItemRepackageHandler : GamePacketHandler<ItemRepackageHandler>
 {
     public override RecvOp OpCode => RecvOp.ItemRepackage;
 
-    private enum ItemRepackageMode : byte
+    private enum Mode : byte
     {
         Repackage = 0x1
     }
@@ -27,11 +27,11 @@ public class ItemRepackageHandler : GamePacketHandler<ItemRepackageHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemRepackageMode mode = (ItemRepackageMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ItemRepackageMode.Repackage:
+            case Mode.Repackage:
                 HandleRepackage(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemSocketScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketScrollHandler.cs
@@ -13,7 +13,7 @@ public class ItemSocketScrollHandler : GamePacketHandler<ItemSocketScrollHandler
 {
     public override RecvOp OpCode => RecvOp.ItemSocketScroll;
 
-    private enum ItemSocketScrollMode : byte
+    private enum Mode : byte
     {
         UseScroll = 0x1
     }
@@ -32,11 +32,11 @@ public class ItemSocketScrollHandler : GamePacketHandler<ItemSocketScrollHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemSocketScrollMode mode = (ItemSocketScrollMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ItemSocketScrollMode.UseScroll:
+            case Mode.UseScroll:
                 HandleUseScroll(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -14,7 +14,7 @@ public class ItemSocketSystemHandler : GamePacketHandler<ItemSocketSystemHandler
 {
     public override RecvOp OpCode => RecvOp.ItemSocketSystem;
 
-    private enum ItemSocketSystemMode : byte
+    private enum Mode : byte
     {
         UnlockSocket = 0x0,
         SelectUnlockSocketEquip = 0x2,
@@ -34,26 +34,26 @@ public class ItemSocketSystemHandler : GamePacketHandler<ItemSocketSystemHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemSocketSystemMode mode = (ItemSocketSystemMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ItemSocketSystemMode.UnlockSocket:
+            case Mode.UnlockSocket:
                 HandleUnlockSocket(session, packet);
                 break;
-            case ItemSocketSystemMode.SelectUnlockSocketEquip:
+            case Mode.SelectUnlockSocketEquip:
                 HandleSelectUnlockSocketEquip(session, packet);
                 break;
-            case ItemSocketSystemMode.SelectGemUpgrade:
+            case Mode.SelectGemUpgrade:
                 HandleSelectGemUpgrade(session, packet);
                 break;
-            case ItemSocketSystemMode.UpgradeGem:
+            case Mode.UpgradeGem:
                 HandleUpgradeGem(session, packet);
                 break;
-            case ItemSocketSystemMode.MountGem:
+            case Mode.MountGem:
                 HandleMountGem(session, packet);
                 break;
-            case ItemSocketSystemMode.ExtractGem:
+            case Mode.ExtractGem:
                 HandleExtractGem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemStorageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemStorageHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemStorage : GamePacketHandler<RequestItemStorage>
+public class ItemStorageHandler : GamePacketHandler<ItemStorageHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemStorage;
 
-    private enum ItemStorageMode : byte
+    private enum Mode : byte
     {
         Add = 0x00,
         Remove = 0x01,
@@ -24,32 +24,32 @@ public class RequestItemStorage : GamePacketHandler<RequestItemStorage>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemStorageMode mode = (ItemStorageMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ItemStorageMode.Add:
+            case Mode.Add:
                 HandleAdd(session, packet);
                 break;
-            case ItemStorageMode.Remove:
+            case Mode.Remove:
                 HandleRemove(session, packet);
                 break;
-            case ItemStorageMode.Move:
+            case Mode.Move:
                 HandleMove(session, packet);
                 break;
-            case ItemStorageMode.Mesos:
+            case Mode.Mesos:
                 HandleMesos(session, packet);
                 break;
-            case ItemStorageMode.Expand:
+            case Mode.Expand:
                 HandleExpand(session);
                 break;
-            case ItemStorageMode.Sort:
+            case Mode.Sort:
                 HandleSort(session);
                 break;
-            case ItemStorageMode.LoadBank:
+            case Mode.LoadBank:
                 HandleLoadBank(session);
                 break;
-            case ItemStorageMode.Close:
+            case Mode.Close:
                 HandleClose(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/ItemUseHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemUseHandler.cs
@@ -15,7 +15,7 @@ using MoonSharp.Interpreter;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemUseHandler : GamePacketHandler<RequestItemUseHandler>
+public class ItemUseHandler : GamePacketHandler<ItemUseHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemUse;
 

--- a/MapleServer2/PacketHandlers/Game/ItemUseMultipleHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemUseMultipleHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemUseMultipleHandler : GamePacketHandler<RequestItemUseMultipleHandler>
+public class ItemUseMultipleHandler : GamePacketHandler<ItemUseMultipleHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestItemUseMultiple;
 

--- a/MapleServer2/PacketHandlers/Game/JobHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/JobHandler.cs
@@ -11,7 +11,7 @@ public class JobHandler : GamePacketHandler<JobHandler>
 {
     public override RecvOp OpCode => RecvOp.Job;
 
-    private enum JobMode : byte
+    private enum Mode : byte
     {
         Close = 0x08,
         Save = 0x09,
@@ -21,19 +21,19 @@ public class JobHandler : GamePacketHandler<JobHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        JobMode mode = (JobMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case JobMode.Close:
+            case Mode.Close:
                 HandleCloseSkillTree(session);
                 break;
-            case JobMode.Save:
+            case Mode.Save:
                 HandleSaveSkillTree(session, packet);
                 break;
-            case JobMode.Reset:
+            case Mode.Reset:
                 HandleResetSkillTree(session, packet);
                 break;
-            case JobMode.Preset:
+            case Mode.Preset:
                 HandlePresetSkillTree(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/KeyTableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/KeyTableHandler.cs
@@ -10,7 +10,7 @@ public class KeyTableHandler : GamePacketHandler<KeyTableHandler>
 {
     public override RecvOp OpCode => RecvOp.KeyTable;
 
-    private enum KeyTableEnum : byte
+    private enum Mode : byte
     {
         SetMacroKeybind = 0x01,
         SetKeyBind = 0x02,
@@ -22,24 +22,24 @@ public class KeyTableHandler : GamePacketHandler<KeyTableHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        KeyTableEnum requestType = (KeyTableEnum) packet.ReadByte();
+        Mode requestType = (Mode) packet.ReadByte();
 
         switch (requestType)
         {
-            case KeyTableEnum.SetMacroKeybind:
-            case KeyTableEnum.SetKeyBind:
+            case Mode.SetMacroKeybind:
+            case Mode.SetKeyBind:
                 SetKeyBinds(session, packet);
                 break;
-            case KeyTableEnum.MoveQuickSlot:
+            case Mode.MoveQuickSlot:
                 MoveQuickSlot(session, packet);
                 break;
-            case KeyTableEnum.AddToFirstSlot:
+            case Mode.AddToFirstSlot:
                 AddToQuickSlot(session, packet);
                 break;
-            case KeyTableEnum.RemoveQuickSlot:
+            case Mode.RemoveQuickSlot:
                 RemoveQuickSlot(session, packet);
                 break;
-            case KeyTableEnum.SetActiveHotbar:
+            case Mode.SetActiveHotbar:
                 SetActiveHotbar(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
@@ -12,7 +12,7 @@ public class LapenshardHandler : GamePacketHandler<LapenshardHandler>
 {
     public override RecvOp OpCode => RecvOp.ItemLapenshard;
 
-    private enum LapenshardMode : byte
+    private enum Mode : byte
     {
         Equip = 0x1,
         Unequip = 0x2,
@@ -30,22 +30,22 @@ public class LapenshardHandler : GamePacketHandler<LapenshardHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        LapenshardMode mode = (LapenshardMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case LapenshardMode.Equip:
+            case Mode.Equip:
                 HandleEquip(session, packet);
                 break;
-            case LapenshardMode.Unequip:
+            case Mode.Unequip:
                 HandleUnequip(session, packet);
                 break;
-            case LapenshardMode.AddFusion:
+            case Mode.AddFusion:
                 HandleAddFusion(session, packet);
                 break;
-            case LapenshardMode.AddCatalyst:
+            case Mode.AddCatalyst:
                 HandleAddCatalyst(session, packet);
                 break;
-            case LapenshardMode.Fusion:
+            case Mode.Fusion:
                 HandleFusion(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
@@ -10,7 +10,7 @@ namespace MapleServer2.PacketHandlers.Game;
 
 public class LiftableHandler : GamePacketHandler<LiftableHandler>
 {
-    private enum LiftableMode : byte
+    private enum Mode : byte
     {
         PickUp = 1
     }
@@ -19,11 +19,11 @@ public class LiftableHandler : GamePacketHandler<LiftableHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        LiftableMode mode = (LiftableMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case LiftableMode.PickUp:
+            case Mode.PickUp:
                 HandlePickUp(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Maple2Storage.Types;
 using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Enums;
 using MapleServer2.Managers.Actors;
 using MapleServer2.Packets;
 using MapleServer2.Servers.Game;
@@ -63,9 +64,9 @@ public class LiftableHandler : GamePacketHandler<LiftableHandler>
 
             fieldPlayer.CarryingLiftable = fieldLiftable;
 
-            session.FieldManager.BroadcastPacket(ResponseCubePacket.RemoveCube(fieldPlayer.ObjectId, fieldPlayer.ObjectId, fieldLiftable.Coord.ToByte()));
+            session.FieldManager.BroadcastPacket(CubePacket.RemoveCube(fieldPlayer.ObjectId, fieldPlayer.ObjectId, fieldLiftable.Coord.ToByte()));
             session.FieldManager.BroadcastPacket(LiftablePacket.RemoveCube(fieldLiftable));
-            session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeHandler.BuildModeType.Liftables, liftable.Metadata.ItemId));
+            session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeType.Liftables, liftable.Metadata.ItemId));
             return;
         }
 
@@ -82,7 +83,7 @@ public class LiftableHandler : GamePacketHandler<LiftableHandler>
         fieldPlayer.CarryingLiftable = fieldLiftable;
 
         session.FieldManager.BroadcastPacket(LiftablePacket.UpdateEntityById(liftable));
-        session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeHandler.BuildModeType.Liftables, liftable.Metadata.ItemId));
+        session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeType.Liftables, liftable.Metadata.ItemId));
         session.FieldManager.BroadcastPacket(LiftablePacket.UpdateEntityById(liftable));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/LimitBreakHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LimitBreakHandler.cs
@@ -14,7 +14,7 @@ public class LimitBreakHandler : GamePacketHandler<LimitBreakHandler>
 {
     public override RecvOp OpCode => RecvOp.LimitBreak;
 
-    private enum LimitBreakMode : byte
+    private enum Mode : byte
     {
         SelectItem = 0x00,
         LimitBreakItem = 0x01
@@ -29,14 +29,14 @@ public class LimitBreakHandler : GamePacketHandler<LimitBreakHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        LimitBreakMode mode = (LimitBreakMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case LimitBreakMode.SelectItem:
+            case Mode.SelectItem:
                 HandleSelectItem(session, packet);
                 break;
-            case LimitBreakMode.LimitBreakItem:
+            case Mode.LimitBreakItem:
                 HandleLimitBreakItem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/LoadUgcMapHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LoadUgcMapHandler.cs
@@ -29,7 +29,7 @@ public class LoadUgcMapHandler : GamePacketHandler<LoadUgcMapHandler>
             Home home = GameServer.HomeManager.GetHomeById(session.Player.VisitingHomeId);
             if (home == null)
             {
-                session.Send(ResponseLoadUgcMapPacket.LoadUgcMap());
+                session.Send(LoadUgcMapPacket.LoadUgcMap());
                 return;
             }
 
@@ -38,7 +38,7 @@ public class LoadUgcMapHandler : GamePacketHandler<LoadUgcMapHandler>
                 home
             };
 
-            session.Send(ResponseLoadUgcMapPacket.LoadUgcMap(home, session.Player.IsInDecorPlanner));
+            session.Send(LoadUgcMapPacket.LoadUgcMap(home, session.Player.IsInDecorPlanner));
 
             // Find spawning coords for home
             int cubePortalId = 50400190;
@@ -68,7 +68,7 @@ public class LoadUgcMapHandler : GamePacketHandler<LoadUgcMapHandler>
         else
         {
             homes = GameServer.HomeManager.GetPlots(session.Player.MapId);
-            session.Send(ResponseLoadUgcMapPacket.LoadUgcMap());
+            session.Send(LoadUgcMapPacket.LoadUgcMap());
         }
 
         List<Cube> cubes = new();

--- a/MapleServer2/PacketHandlers/Game/MacroHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MacroHandler.cs
@@ -11,7 +11,7 @@ public class MacroHandler : GamePacketHandler<MacroHandler>
 {
     public override RecvOp OpCode => RecvOp.Macro;
 
-    private enum MacroMode : byte
+    private enum Mode : byte
     {
         OpenSettings = 0x0,
         CloseSettings = 0x1,
@@ -19,14 +19,14 @@ public class MacroHandler : GamePacketHandler<MacroHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MacroMode mode = (MacroMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case MacroMode.OpenSettings:
+            case Mode.OpenSettings:
                 HandleOpenSettings(session);
                 break;
-            case MacroMode.CloseSettings:
+            case Mode.CloseSettings:
                 HandleCloseSettings(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MailHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MailHandler.cs
@@ -14,7 +14,7 @@ public class MailHandler : GamePacketHandler<MailHandler>
 {
     public override RecvOp OpCode => RecvOp.Mail;
 
-    private enum MailMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Send = 0x1,
@@ -48,29 +48,29 @@ public class MailHandler : GamePacketHandler<MailHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MailMode mode = (MailMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case MailMode.Open:
+            case Mode.Open:
                 HandleOpen(session);
                 break;
-            case MailMode.Send:
+            case Mode.Send:
                 HandleSend(session, packet);
                 break;
-            case MailMode.Read:
+            case Mode.Read:
                 HandleRead(session, packet);
                 break;
-            case MailMode.Collect:
+            case Mode.Collect:
                 HandleCollect(session, packet);
                 break;
-            case MailMode.Delete:
+            case Mode.Delete:
                 HandleDelete(session, packet);
                 break;
-            case MailMode.ReadBatch:
+            case Mode.ReadBatch:
                 HandleReadBatch(session, packet);
                 break;
-            case MailMode.CollectBatch:
+            case Mode.CollectBatch:
                 HandleCollectBatch(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
@@ -15,7 +15,7 @@ public class MapleopolyHandler : GamePacketHandler<MapleopolyHandler>
 {
     public override RecvOp OpCode => RecvOp.Mapleopoly;
 
-    private enum MapleopolyMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Roll = 0x1,
@@ -31,7 +31,7 @@ public class MapleopolyHandler : GamePacketHandler<MapleopolyHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MapleopolyMode mode = (MapleopolyMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         BlueMarble mapleopolyEvent = DatabaseManager.Events.FindMapleopolyEvent();
         if (mapleopolyEvent is null)
@@ -49,13 +49,13 @@ public class MapleopolyHandler : GamePacketHandler<MapleopolyHandler>
 
         switch (mode)
         {
-            case MapleopolyMode.Open:
+            case Mode.Open:
                 HandleOpen(session, totalTileValue, freeRollValue);
                 break;
-            case MapleopolyMode.Roll:
+            case Mode.Roll:
                 HandleRoll(session, totalTileValue, freeRollValue);
                 break;
-            case MapleopolyMode.ProcessTile:
+            case Mode.ProcessTile:
                 HandleProcessTile(session, totalTileValue, freeRollValue, totalTripValue);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
@@ -14,7 +14,7 @@ public class MasteryHandler : GamePacketHandler<MasteryHandler>
 {
     public override RecvOp OpCode => RecvOp.ConstructRecipe;
 
-    private enum MasteryMode : byte
+    private enum Mode : byte
     {
         RewardBox = 0x01,
         CraftItem = 0x02
@@ -31,13 +31,13 @@ public class MasteryHandler : GamePacketHandler<MasteryHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MasteryMode mode = (MasteryMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case MasteryMode.RewardBox:
+            case Mode.RewardBox:
                 HandleRewardBox(session, packet);
                 break;
-            case MasteryMode.CraftItem:
+            case Mode.CraftItem:
                 HandleCraftItem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
@@ -11,7 +11,7 @@ public class MatchPartyHandler : GamePacketHandler<MatchPartyHandler>
 {
     public override RecvOp OpCode => RecvOp.MatchParty;
 
-    private enum MatchPartyMode : byte
+    private enum Mode : byte
     {
         CreateListing = 0x0,
         RemoveListing = 0x1,
@@ -28,16 +28,16 @@ public class MatchPartyHandler : GamePacketHandler<MatchPartyHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MatchPartyMode mode = (MatchPartyMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case MatchPartyMode.CreateListing:
+            case Mode.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case MatchPartyMode.RemoveListing:
+            case Mode.RemoveListing:
                 HandleRemoveListing(session);
                 break;
-            case MatchPartyMode.Refresh:
+            case Mode.Refresh:
                 HandleRefresh(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
@@ -18,7 +18,7 @@ public class MeretMarketHandler : GamePacketHandler<MeretMarketHandler>
 {
     public override RecvOp OpCode => RecvOp.MeretMarket;
 
-    private enum MeretMarketMode : byte
+    private enum Mode : byte
     {
         LoadPersonalListings = 0xB,
         LoadSales = 0xC,
@@ -39,53 +39,53 @@ public class MeretMarketHandler : GamePacketHandler<MeretMarketHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MeretMarketMode mode = (MeretMarketMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case MeretMarketMode.LoadPersonalListings:
+            case Mode.LoadPersonalListings:
                 HandleLoadPersonalListings(session);
                 break;
-            case MeretMarketMode.LoadSales:
+            case Mode.LoadSales:
                 HandleLoadSales(session);
                 break;
-            case MeretMarketMode.ListItem:
+            case Mode.ListItem:
                 HandleListItem(session, packet);
                 break;
-            case MeretMarketMode.RemoveListing:
+            case Mode.RemoveListing:
                 HandleRemoveListing(session, packet);
                 break;
-            case MeretMarketMode.UnlistItem:
+            case Mode.UnlistItem:
                 HandleUnlistItem(session, packet);
                 break;
-            case MeretMarketMode.RelistItem:
+            case Mode.RelistItem:
                 HandleRelistItem(session, packet);
                 break;
-            case MeretMarketMode.CollectProfit:
+            case Mode.CollectProfit:
                 HandleCollectProfit(session, packet);
                 break;
-            case MeretMarketMode.Initialize:
+            case Mode.Initialize:
                 HandleInitialize(session);
                 break;
-            case MeretMarketMode.OpenShop:
+            case Mode.OpenShop:
                 HandleOpenShop(session, packet);
                 break;
-            case MeretMarketMode.Purchase:
+            case Mode.Purchase:
                 HandlePurchase(session, packet);
                 break;
-            case MeretMarketMode.OpenFeatured:
+            case Mode.OpenFeatured:
                 HandleOpenFeatured(session, packet);
                 break;
-            case MeretMarketMode.OpenDesignShop:
+            case Mode.OpenDesignShop:
                 HandleOpenDesignShop(session);
                 break;
-            case MeretMarketMode.Search:
+            case Mode.Search:
                 HandleSearch(session, packet);
                 break;
-            case MeretMarketMode.LoadCart:
+            case Mode.LoadCart:
                 HandleLoadCart(session);
                 break;
-            case MeretMarketMode.SendMarketRequest:
+            case Mode.SendMarketRequest:
                 HandleSendMarketRequest(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MesoMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MesoMarketHandler.cs
@@ -13,7 +13,7 @@ public class MesoMarketHandler : GamePacketHandler<MesoMarketHandler>
 {
     public override RecvOp OpCode => RecvOp.MesoMarket;
 
-    private enum MesoMarketMode : byte
+    private enum Mode : byte
     {
         Load = 0x3,
         CreateListing = 0x5,
@@ -41,23 +41,23 @@ public class MesoMarketHandler : GamePacketHandler<MesoMarketHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MesoMarketMode mode = (MesoMarketMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case MesoMarketMode.Load:
+            case Mode.Load:
                 HandleLoad(session);
                 break;
-            case MesoMarketMode.CreateListing:
+            case Mode.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case MesoMarketMode.CancelListing:
+            case Mode.CancelListing:
                 HandleCancelListing(session, packet);
                 break;
-            case MesoMarketMode.RefreshListings:
+            case Mode.RefreshListings:
                 HandleRefreshListings(session, packet);
                 break;
-            case MesoMarketMode.Purchase:
+            case Mode.Purchase:
                 HandlePurchase(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MoneyPickupHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoneyPickupHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestMoneyPickupHandler : GamePacketHandler<RequestMoneyPickupHandler>
+public class MoneyPickupHandler : GamePacketHandler<MoneyPickupHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestMoneyPickup;
 

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -16,7 +16,7 @@ public class MoveFieldHandler : GamePacketHandler<MoveFieldHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestMoveField;
 
-    private enum RequestMoveFieldMode : byte
+    private enum Mode : byte
     {
         Move = 0x0,
         LeaveInstance = 0x1,
@@ -27,23 +27,23 @@ public class MoveFieldHandler : GamePacketHandler<MoveFieldHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestMoveFieldMode mode = (RequestMoveFieldMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case RequestMoveFieldMode.Move:
+            case Mode.Move:
                 HandleMove(session, packet);
                 break;
-            case RequestMoveFieldMode.LeaveInstance:
+            case Mode.LeaveInstance:
                 HandleLeaveInstance(session);
                 break;
-            case RequestMoveFieldMode.VisitHouse:
+            case Mode.VisitHouse:
                 HandleVisitHouse(session, packet);
                 break;
-            case RequestMoveFieldMode.ReturnMap:
+            case Mode.ReturnMap:
                 HandleReturnMap(session);
                 break;
-            case RequestMoveFieldMode.EnterDecorPlaner:
+            case Mode.EnterDecorPlaner:
                 HandleEnterDecorPlaner(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -229,7 +229,7 @@ public class MoveFieldHandler : GamePacketHandler<MoveFieldHandler>
         }
 
         player.VisitingHomeId = home.Id;
-        session.Send(ResponseCubePacket.LoadHome(session.Player.FieldPlayer.ObjectId, home));
+        session.Send(CubePacket.LoadHome(session.Player.FieldPlayer.ObjectId, home));
 
         player.WarpGameToGame(home.MapId, home.InstanceId, session.Player.FieldPlayer.Coord, session.Player.FieldPlayer.Rotation);
     }

--- a/MapleServer2/PacketHandlers/Game/MushkingRoyaleSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MushkingRoyaleSystemHandler.cs
@@ -15,7 +15,7 @@ public class MushkingRoyaleSystemHandler : GamePacketHandler<MushkingRoyaleSyste
 {
     public override RecvOp OpCode => RecvOp.MushkingRoyale;
 
-    private enum MushkingRoyaleSystemMode : byte
+    private enum Mode : byte
     {
         JoinSoloQueue = 0x0,
         LeaveSoloQueue = 0x1,
@@ -27,26 +27,26 @@ public class MushkingRoyaleSystemHandler : GamePacketHandler<MushkingRoyaleSyste
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MushkingRoyaleSystemMode mode = (MushkingRoyaleSystemMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case MushkingRoyaleSystemMode.JoinSoloQueue:
+            case Mode.JoinSoloQueue:
                 HandleJoinSoloQueue(session);
                 break;
-            case MushkingRoyaleSystemMode.LeaveSoloQueue:
+            case Mode.LeaveSoloQueue:
                 HandleLeaveSoloQueue(session);
                 break;
-            case MushkingRoyaleSystemMode.EnterMatch:
+            case Mode.EnterMatch:
                 HandleEnterMatch(session);
                 break;
-            case MushkingRoyaleSystemMode.EquipMedal:
+            case Mode.EquipMedal:
                 HandleEquipMedal(session, packet);
                 break;
-            case MushkingRoyaleSystemMode.PurchaseGoldPass:
+            case Mode.PurchaseGoldPass:
                 HandlePurchaseGoldPass(session, packet);
                 break;
-            case MushkingRoyaleSystemMode.ClaimRewards:
+            case Mode.ClaimRewards:
                 HandleClaimRewards(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/NewsNotificationHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NewsNotificationHandler.cs
@@ -9,7 +9,7 @@ public class NewsNotificationHandler : GamePacketHandler<NewsNotificationHandler
 {
     public override RecvOp OpCode => RecvOp.NewsNotification;
 
-    private enum NewsNotificationMode : byte
+    private enum Mode : byte
     {
         OpenBrowser = 0x0,
         OpenSidebar = 0x2
@@ -18,14 +18,14 @@ public class NewsNotificationHandler : GamePacketHandler<NewsNotificationHandler
     public override void Handle(GameSession session, PacketReader packet)
     {
         short unk = packet.ReadShort();
-        NewsNotificationMode mode = (NewsNotificationMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case NewsNotificationMode.OpenBrowser:
+            case Mode.OpenBrowser:
                 HandleOpenBrowser(session);
                 break;
-            case NewsNotificationMode.OpenSidebar:
+            case Mode.OpenSidebar:
                 HandleOpenSidebar(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
@@ -19,7 +19,7 @@ public class NpcTalkHandler : GamePacketHandler<NpcTalkHandler>
 {
     public override RecvOp OpCode => RecvOp.NpcTalk;
 
-    private enum NpcTalkMode : byte
+    private enum Mode : byte
     {
         Close = 0,
         Begin = 1,
@@ -37,21 +37,21 @@ public class NpcTalkHandler : GamePacketHandler<NpcTalkHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        NpcTalkMode function = (NpcTalkMode) packet.ReadByte();
+        Mode function = (Mode) packet.ReadByte();
         switch (function)
         {
-            case NpcTalkMode.Close:
+            case Mode.Close:
                 return;
-            case NpcTalkMode.Begin:
+            case Mode.Begin:
                 HandleBegin(session, packet);
                 break;
-            case NpcTalkMode.Continue:
+            case Mode.Continue:
                 HandleContinue(session, packet.ReadInt());
                 break;
-            case NpcTalkMode.Enchant:
+            case Mode.Enchant:
                 HandleEnchant(session, packet);
                 break;
-            case NpcTalkMode.NextQuest:
+            case Mode.NextQuest:
                 HandleNextQuest(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/PCCafeBonusHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PCCafeBonusHandler.cs
@@ -9,7 +9,7 @@ public class PCCafeBonusHandler : GamePacketHandler<PCCafeBonusHandler>
 {
     public override RecvOp OpCode => RecvOp.PCCafeBonus;
 
-    private enum PCCafeBonusMode : byte
+    private enum Mode : byte
     {
         ClaimLoginTimeReward = 0x1,
         ClaimPCCafeItem = 0x2
@@ -17,14 +17,14 @@ public class PCCafeBonusHandler : GamePacketHandler<PCCafeBonusHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PCCafeBonusMode mode = (PCCafeBonusMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case PCCafeBonusMode.ClaimLoginTimeReward:
+            case Mode.ClaimLoginTimeReward:
                 HandleClaimLoginTimeReward(session, packet);
                 break;
-            case PCCafeBonusMode.ClaimPCCafeItem:
+            case Mode.ClaimPCCafeItem:
                 HandleClaimPCCafeItem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -11,7 +11,7 @@ public class PartyHandler : GamePacketHandler<PartyHandler>
 {
     public override RecvOp OpCode => RecvOp.Party;
 
-    private enum PartyMode : byte
+    private enum Mode : byte
     {
         Invite = 0x1,
         Join = 0x2,
@@ -29,41 +29,41 @@ public class PartyHandler : GamePacketHandler<PartyHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PartyMode mode = (PartyMode) packet.ReadByte(); //Mode
+        Mode mode = (Mode) packet.ReadByte(); //Mode
 
         switch (mode)
         {
-            case PartyMode.Invite:
+            case Mode.Invite:
                 HandleInvite(session, packet);
                 break;
-            case PartyMode.Join:
+            case Mode.Join:
                 HandleJoin(session, packet);
                 break;
-            case PartyMode.Leave:
+            case Mode.Leave:
                 HandleLeave(session);
                 break;
-            case PartyMode.Kick:
+            case Mode.Kick:
                 HandleKick(session, packet);
                 break;
-            case PartyMode.SetLeader:
+            case Mode.SetLeader:
                 HandleSetLeader(session, packet);
                 break;
-            case PartyMode.FinderJoin:
+            case Mode.FinderJoin:
                 HandleFinderJoin(session, packet);
                 break;
-            case PartyMode.SummonParty:
+            case Mode.SummonParty:
                 HandleSummonParty();
                 break;
-            case PartyMode.VoteKick:
+            case Mode.VoteKick:
                 HandleVoteKick(session, packet);
                 break;
-            case PartyMode.ReadyCheck:
+            case Mode.ReadyCheck:
                 HandleStartReadyCheck(session);
                 break;
-            case PartyMode.FindDungeonParty:
+            case Mode.FindDungeonParty:
                 HandleFindDungeonParty(session, packet);
                 break;
-            case PartyMode.ReadyCheckUpdate:
+            case Mode.ReadyCheckUpdate:
                 HandleReadyCheckUpdate(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/PetHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PetHandler.cs
@@ -10,11 +10,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestPetHandler : GamePacketHandler<RequestPetHandler>
+public class PetHandler : GamePacketHandler<PetHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestPet;
 
-    private enum RequestPetMode : byte
+    private enum Mode : byte
     {
         Summon = 0x0,
         Dismiss = 0x1,
@@ -26,26 +26,26 @@ public class RequestPetHandler : GamePacketHandler<RequestPetHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestPetMode mode = (RequestPetMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case RequestPetMode.Summon:
+            case Mode.Summon:
                 HandlePetSummon(session, packet);
                 break;
-            case RequestPetMode.Dismiss:
+            case Mode.Dismiss:
                 HandlePetDismiss(session, packet);
                 break;
-            case RequestPetMode.Replace:
+            case Mode.Replace:
                 HandlePetReplace(session, packet);
                 break;
-            case RequestPetMode.Rename:
+            case Mode.Rename:
                 HandlePetRename(session, packet);
                 break;
-            case RequestPetMode.PotionSettings:
+            case Mode.PotionSettings:
                 HandlePetPotionSettings(session, packet);
                 break;
-            case RequestPetMode.LootSettings:
+            case Mode.LootSettings:
                 HandlePetLootSettings(session, packet);
                 break;
             default:
@@ -87,7 +87,7 @@ public class RequestPetHandler : GamePacketHandler<RequestPetHandler>
 
         player.ActivePet.PetInfo.Name = name;
         fieldPlayer.ActivePet.Item = player.ActivePet;
-        session.Send(ResponsePetPacket.UpdateName(fieldPlayer.ActivePet));
+        session.Send(PetPacket.UpdateName(fieldPlayer.ActivePet));
 
         DatabaseManager.Pets.Update(fieldPlayer.ActivePet.Item.PetInfo);
     }
@@ -120,7 +120,7 @@ public class RequestPetHandler : GamePacketHandler<RequestPetHandler>
 
         player.ActivePet.PetInfo.PotionSettings = settings;
         fieldPlayer.ActivePet.Item = player.ActivePet;
-        session.Send(ResponsePetPacket.UpdatePotions(fieldPlayer.ActivePet));
+        session.Send(PetPacket.UpdatePotions(fieldPlayer.ActivePet));
 
         DatabaseManager.Pets.Update(fieldPlayer.ActivePet.Item.PetInfo);
     }
@@ -138,7 +138,7 @@ public class RequestPetHandler : GamePacketHandler<RequestPetHandler>
 
         player.ActivePet.PetInfo.LootSettings = settings;
         fieldPlayer.ActivePet.Item = player.ActivePet;
-        session.Send(ResponsePetPacket.UpdateLoot(fieldPlayer.ActivePet));
+        session.Send(PetPacket.UpdateLoot(fieldPlayer.ActivePet));
 
         DatabaseManager.Pets.Update(fieldPlayer.ActivePet.Item.PetInfo);
     }
@@ -166,7 +166,7 @@ public class RequestPetHandler : GamePacketHandler<RequestPetHandler>
         player.ActivePet = pet.Item;
         player.FieldPlayer.ActivePet = pet;
 
-        session.Send(ResponsePetPacket.LoadPetSettings(pet));
+        session.Send(PetPacket.LoadPetSettings(pet));
         session.Send(NoticePacket.Notice(SystemNotice.PetSummonOn, NoticeType.Chat | NoticeType.FastText));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/PlayerHostHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PlayerHostHandler.cs
@@ -10,18 +10,18 @@ public class PlayerHostHandler : GamePacketHandler<PlayerHostHandler>
 {
     public override RecvOp OpCode => RecvOp.PlayerHost;
 
-    private enum PlayerHostMode : byte
+    private enum Mode : byte
     {
         Claim = 0x1
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PlayerHostMode mode = (PlayerHostMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case PlayerHostMode.Claim:
+            case Mode.Claim:
                 HandleClaim(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/PremiumClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PremiumClubHandler.cs
@@ -13,7 +13,7 @@ public class PremiumClubHandler : GamePacketHandler<PremiumClubHandler>
 {
     public override RecvOp OpCode => RecvOp.PremiumClub;
 
-    private enum PremiumClubMode : byte
+    private enum Mode : byte
     {
         Open = 0x1,
         ClaimItems = 0x2,
@@ -23,20 +23,20 @@ public class PremiumClubHandler : GamePacketHandler<PremiumClubHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PremiumClubMode mode = (PremiumClubMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case PremiumClubMode.Open:
+            case Mode.Open:
                 HandleOpen(session);
                 break;
-            case PremiumClubMode.ClaimItems:
+            case Mode.ClaimItems:
                 HandleClaimItems(session, packet);
                 break;
-            case PremiumClubMode.OpenPurchaseWindow:
+            case Mode.OpenPurchaseWindow:
                 HandleOpenPurchaseWindow(session);
                 break;
-            case PremiumClubMode.PurchaseMembership:
+            case Mode.PurchaseMembership:
                 HandlePurchaseMembership(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/PrestigeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PrestigeHandler.cs
@@ -13,7 +13,7 @@ public class PrestigeHandler : GamePacketHandler<PrestigeHandler>
 {
     public override RecvOp OpCode => RecvOp.Prestige;
 
-    private enum PrestigeMode : byte
+    private enum Mode : byte
     {
         ClaimPerk = 0x03,
         ClaimMissionReward = 0x05
@@ -21,13 +21,13 @@ public class PrestigeHandler : GamePacketHandler<PrestigeHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PrestigeMode mode = (PrestigeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case PrestigeMode.ClaimPerk:
+            case Mode.ClaimPerk:
                 HandleClaimPerk(session, packet);
                 break;
-            case PrestigeMode.ClaimMissionReward:
+            case Mode.ClaimMissionReward:
                 HandleClaimMissionReward(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/QuestHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/QuestHandler.cs
@@ -15,7 +15,7 @@ public class QuestHandler : GamePacketHandler<QuestHandler>
 {
     public override RecvOp OpCode => RecvOp.Quest;
 
-    private enum QuestMode : byte
+    private enum Mode : byte
     {
         AcceptQuest = 0x02,
         CompleteQuest = 0x04,
@@ -29,32 +29,32 @@ public class QuestHandler : GamePacketHandler<QuestHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        QuestMode mode = (QuestMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case QuestMode.AcceptQuest:
+            case Mode.AcceptQuest:
                 HandleAcceptQuest(session, packet);
                 break;
-            case QuestMode.CompleteQuest:
+            case Mode.CompleteQuest:
                 HandleCompleteQuest(session, packet);
                 break;
-            case QuestMode.ExplorationQuests:
+            case Mode.ExplorationQuests:
                 HandleAddExplorationQuests(session, packet);
                 break;
-            case QuestMode.CompleteNavigator:
+            case Mode.CompleteNavigator:
                 HandleCompleteNavigator(session, packet);
                 break;
-            case QuestMode.ResumeDungeon:
+            case Mode.ResumeDungeon:
                 HandleResumeDungeon(session, packet);
                 break;
-            case QuestMode.DispatchMode:
+            case Mode.DispatchMode:
                 HandleDispatchMode(session, packet);
                 break;
-            case QuestMode.ToggleTracking:
+            case Mode.ToggleTracking:
                 HandleToggleTracking(session, packet);
                 break;
-            case QuestMode.SkyFortress:
+            case Mode.SkyFortress:
                 HandleSkyFortressTeleport(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/RequestCubeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestCubeHandler.cs
@@ -18,7 +18,7 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestCube;
 
-    private enum RequestCubeMode : byte
+    private enum Mode : byte
     {
         LoadFurnishingItem = 0x1,
         BuyPlot = 0x2,
@@ -57,97 +57,97 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestCubeMode mode = (RequestCubeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case RequestCubeMode.LoadFurnishingItem:
+            case Mode.LoadFurnishingItem:
                 HandleLoadFurnishingItem(session, packet);
                 break;
-            case RequestCubeMode.BuyPlot:
+            case Mode.BuyPlot:
                 HandleBuyPlot(session, packet);
                 break;
-            case RequestCubeMode.ForfeitPlot:
+            case Mode.ForfeitPlot:
                 HandleForfeitPlot(session);
                 break;
-            case RequestCubeMode.AddCube:
+            case Mode.AddCube:
                 HandleAddCube(session, packet);
                 break;
-            case RequestCubeMode.RemoveCube:
+            case Mode.RemoveCube:
                 HandleRemoveCube(session, packet);
                 break;
-            case RequestCubeMode.RotateCube:
+            case Mode.RotateCube:
                 HandleRotateCube(session, packet);
                 break;
-            case RequestCubeMode.ReplaceCube:
+            case Mode.ReplaceCube:
                 HandleReplaceCube(session, packet);
                 break;
-            case RequestCubeMode.Pickup:
+            case Mode.Pickup:
                 HandlePickup(session, packet);
                 break;
-            case RequestCubeMode.Drop:
+            case Mode.Drop:
                 HandleDrop(session);
                 break;
-            case RequestCubeMode.HomeName:
+            case Mode.HomeName:
                 HandleHomeName(session, packet);
                 break;
-            case RequestCubeMode.HomePassword:
+            case Mode.HomePassword:
                 HandleHomePassword(session, packet);
                 break;
-            case RequestCubeMode.NominateHouse:
+            case Mode.NominateHouse:
                 HandleNominateHouse(session);
                 break;
-            case RequestCubeMode.HomeDescription:
+            case Mode.HomeDescription:
                 HandleHomeDescription(session, packet);
                 break;
-            case RequestCubeMode.ClearInterior:
+            case Mode.ClearInterior:
                 HandleClearInterior(session);
                 break;
-            case RequestCubeMode.RequestLayout:
+            case Mode.RequestLayout:
                 HandleRequestLayout(session, packet);
                 break;
-            case RequestCubeMode.IncreaseSize:
-            case RequestCubeMode.DecreaseSize:
-            case RequestCubeMode.IncreaseHeight:
-            case RequestCubeMode.DecreaseHeight:
+            case Mode.IncreaseSize:
+            case Mode.DecreaseSize:
+            case Mode.IncreaseHeight:
+            case Mode.DecreaseHeight:
                 HandleModifySize(session, mode);
                 break;
-            case RequestCubeMode.DecorationReward:
+            case Mode.DecorationReward:
                 HandleDecorationReward(session);
                 break;
-            case RequestCubeMode.InteriorDesignReward:
+            case Mode.InteriorDesignReward:
                 HandleInteriorDesignReward(session, packet);
                 break;
-            case RequestCubeMode.SaveLayout:
+            case Mode.SaveLayout:
                 HandleSaveLayout(session, packet);
                 break;
-            case RequestCubeMode.DecorPlannerLoadLayout:
+            case Mode.DecorPlannerLoadLayout:
                 HandleDecorPlannerLoadLayout(session, packet);
                 break;
-            case RequestCubeMode.LoadLayout:
+            case Mode.LoadLayout:
                 HandleLoadLayout(session, packet);
                 break;
-            case RequestCubeMode.KickEveryone:
+            case Mode.KickEveryone:
                 HandleKickEveryone(session);
                 break;
-            case RequestCubeMode.ChangeLighting:
-            case RequestCubeMode.ChangeBackground:
-            case RequestCubeMode.ChangeCamera:
+            case Mode.ChangeLighting:
+            case Mode.ChangeBackground:
+            case Mode.ChangeCamera:
                 HandleModifyInteriorSettings(session, mode, packet);
                 break;
-            case RequestCubeMode.EnablePermission:
+            case Mode.EnablePermission:
                 HandleEnablePermission(session, packet);
                 break;
-            case RequestCubeMode.SetPermission:
+            case Mode.SetPermission:
                 HandleSetPermission(session, packet);
                 break;
-            case RequestCubeMode.UpdateBudget:
+            case Mode.UpdateBudget:
                 HandleUpdateBudget(session, packet);
                 break;
-            case RequestCubeMode.GiveBuildingPermission:
+            case Mode.GiveBuildingPermission:
                 HandleGiveBuildingPermission(session, packet);
                 break;
-            case RequestCubeMode.RemoveBuildingPermission:
+            case Mode.RemoveBuildingPermission:
                 HandleRemoveBuildingPermission(session, packet);
                 break;
             default:
@@ -873,7 +873,7 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
         session.Send(ChatPacket.Error(session.Player, SystemNotice.UgcMapPackageAutomaticCreationCompleted, ChatType.NoticeAlert));
     }
 
-    private static void HandleModifySize(GameSession session, RequestCubeMode mode)
+    private static void HandleModifySize(GameSession session, Mode mode)
     {
         Home home = GameServer.HomeManager.GetHomeById(session.Player.VisitingHomeId);
         if (session.Player.AccountId != home.AccountId)
@@ -883,10 +883,10 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
 
         switch (mode)
         {
-            case RequestCubeMode.IncreaseSize when home.Size + 1 > 25:
-            case RequestCubeMode.IncreaseHeight when home.Height + 1 > 15:
-            case RequestCubeMode.DecreaseSize when home.Size - 1 < 4:
-            case RequestCubeMode.DecreaseHeight when home.Height - 1 < 3:
+            case Mode.IncreaseSize when home.Size + 1 > 25:
+            case Mode.IncreaseHeight when home.Height + 1 > 15:
+            case Mode.DecreaseSize when home.Size - 1 < 4:
+            case Mode.DecreaseHeight when home.Height - 1 < 3:
                 return;
         }
 
@@ -896,16 +896,16 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
         {
             switch (mode)
             {
-                case RequestCubeMode.IncreaseSize:
+                case Mode.IncreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseSize(++home.DecorPlannerSize));
                     break;
-                case RequestCubeMode.DecreaseSize:
+                case Mode.DecreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseSize(--home.DecorPlannerSize));
                     break;
-                case RequestCubeMode.IncreaseHeight:
+                case Mode.IncreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseHeight(++home.DecorPlannerHeight));
                     break;
-                case RequestCubeMode.DecreaseHeight:
+                case Mode.DecreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseHeight(--home.DecorPlannerHeight));
                     break;
             }
@@ -914,22 +914,22 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
         {
             switch (mode)
             {
-                case RequestCubeMode.IncreaseSize:
+                case Mode.IncreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseSize(++home.Size));
                     break;
-                case RequestCubeMode.DecreaseSize:
+                case Mode.DecreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseSize(--home.Size));
                     break;
-                case RequestCubeMode.IncreaseHeight:
+                case Mode.IncreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseHeight(++home.Height));
                     break;
-                case RequestCubeMode.DecreaseHeight:
+                case Mode.DecreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseHeight(--home.Height));
                     break;
             }
         }
 
-        if (mode is not (RequestCubeMode.DecreaseHeight or RequestCubeMode.DecreaseSize))
+        if (mode is not (Mode.DecreaseHeight or Mode.DecreaseSize))
         {
             return;
         }
@@ -1220,7 +1220,7 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
         session.FieldManager.BroadcastPacket(ResponseCubePacket.UpdateBudget(home));
     }
 
-    private static void HandleModifyInteriorSettings(GameSession session, RequestCubeMode mode, PacketReader packet)
+    private static void HandleModifyInteriorSettings(GameSession session, Mode mode, PacketReader packet)
     {
         byte value = packet.ReadByte();
 
@@ -1232,15 +1232,15 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
 
         switch (mode)
         {
-            case RequestCubeMode.ChangeBackground:
+            case Mode.ChangeBackground:
                 home.Background = value;
                 session.FieldManager.BroadcastPacket(ResponseCubePacket.ChangeLighting(value));
                 break;
-            case RequestCubeMode.ChangeLighting:
+            case Mode.ChangeLighting:
                 home.Lighting = value;
                 session.FieldManager.BroadcastPacket(ResponseCubePacket.ChangeBackground(value));
                 break;
-            case RequestCubeMode.ChangeCamera:
+            case Mode.ChangeCamera:
                 home.Camera = value;
                 session.FieldManager.BroadcastPacket(ResponseCubePacket.ChangeCamera(value));
                 break;
@@ -1410,9 +1410,9 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
         return null;
     }
 
-    private static void RemoveBlocks(GameSession session, RequestCubeMode mode, Home home)
+    private static void RemoveBlocks(GameSession session, Mode mode, Home home)
     {
-        if (mode is RequestCubeMode.DecreaseSize)
+        if (mode is Mode.DecreaseSize)
         {
             int maxSize = (home.Size - 1) * Block.BLOCK_SIZE * -1;
             for (int i = 0; i < home.Size; i++)
@@ -1442,7 +1442,7 @@ public class RequestCubeHandler : GamePacketHandler<RequestCubeHandler>
             }
         }
 
-        if (mode is RequestCubeMode.DecreaseHeight)
+        if (mode is Mode.DecreaseHeight)
         {
             for (int i = 0; i < home.Size; i++)
             {

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -16,7 +16,7 @@ public class RideHandler : GamePacketHandler<RideHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestRide;
 
-    private enum RideMode : byte
+    private enum Mode : byte
     {
         StartRide = 0x0,
         StopRide = 0x1,
@@ -27,23 +27,23 @@ public class RideHandler : GamePacketHandler<RideHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RideMode mode = (RideMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case RideMode.StartRide:
+            case Mode.StartRide:
                 HandleStartRide(session, packet);
                 break;
-            case RideMode.StopRide:
+            case Mode.StopRide:
                 HandleStopRide(session, packet);
                 break;
-            case RideMode.ChangeRide:
+            case Mode.ChangeRide:
                 HandleChangeRide(session, packet);
                 break;
-            case RideMode.StartMultiPersonRide:
+            case Mode.StartMultiPersonRide:
                 HandleStartMultiPersonRide(session, packet);
                 break;
-            case RideMode.StopMultiPersonRide:
+            case Mode.StopMultiPersonRide:
                 HandleStopMultiPersonRide(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/RockPaperScissorsHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RockPaperScissorsHandler.cs
@@ -14,7 +14,7 @@ public class RockPaperScissorsHandler : GamePacketHandler<RockPaperScissorsHandl
 {
     public override RecvOp OpCode => RecvOp.RockPaperScissors;
 
-    private enum RpsMode : short
+    private enum Mode : short
     {
         OpenMatch = 0x00,
         RequestMatch = 0x01,
@@ -35,32 +35,32 @@ public class RockPaperScissorsHandler : GamePacketHandler<RockPaperScissorsHandl
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RpsMode mode = (RpsMode) packet.ReadShort();
+        Mode mode = (Mode) packet.ReadShort();
 
         switch (mode)
         {
-            case RpsMode.OpenMatch:
+            case Mode.OpenMatch:
                 HandleOpenMatch(session);
                 break;
-            case RpsMode.RequestMatch:
+            case Mode.RequestMatch:
                 HandleRequestMatch(session, packet);
                 break;
-            case RpsMode.ConfirmMatch:
+            case Mode.ConfirmMatch:
                 HandleConfirmMatch(session, packet);
                 break;
-            case RpsMode.DenyMatch:
+            case Mode.DenyMatch:
                 HandleDenyMatch(session, packet);
                 break;
-            case RpsMode.CancelRequestMatch:
+            case Mode.CancelRequestMatch:
                 HandleCancelRequestMatch(session, packet);
                 break;
-            case RpsMode.SelectRpsChoice:
+            case Mode.SelectRpsChoice:
                 HandleSelectRpsChoice(session, packet);
                 break;
-            case RpsMode.ClaimReward:
+            case Mode.ClaimReward:
                 HandleClaimReward(session, packet);
                 break;
-            case RpsMode.ConfirmMatch2:
+            case Mode.ConfirmMatch2:
                 HandleConfirmMatch2(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/RouletteGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RouletteGameHandler.cs
@@ -14,7 +14,7 @@ public class RouletteGameHandler : GamePacketHandler<RouletteGameHandler>
 {
     public override RecvOp OpCode => RecvOp.RouletteGame;
 
-    private enum RouletteGameType : byte
+    private enum Mode : byte
     {
         Open = 0x00,
         Spin = 0x02,
@@ -23,16 +23,16 @@ public class RouletteGameHandler : GamePacketHandler<RouletteGameHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RouletteGameType mode = (RouletteGameType) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case RouletteGameType.Open:
+            case Mode.Open:
                 HandleOpen(session, packet);
                 break;
-            case RouletteGameType.Spin:
+            case Mode.Spin:
                 HandleSpin(session);
                 break;
-            case RouletteGameType.Close:
+            case Mode.Close:
                 break;
             default:
                 LogUnknownMode(mode);

--- a/MapleServer2/PacketHandlers/Game/ShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ShopHandler.cs
@@ -15,7 +15,7 @@ public class ShopHandler : GamePacketHandler<ShopHandler>
 {
     public override RecvOp OpCode => RecvOp.Shop;
 
-    private enum ShopMode : byte
+    private enum Mode : byte
     {
         Buy = 0x4,
         Sell = 0x5,
@@ -25,20 +25,20 @@ public class ShopHandler : GamePacketHandler<ShopHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ShopMode mode = (ShopMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ShopMode.Close:
+            case Mode.Close:
                 HandleClose(session);
                 break;
-            case ShopMode.Buy:
+            case Mode.Buy:
                 HandleBuy(session, packet);
                 break;
-            case ShopMode.Sell:
+            case Mode.Sell:
                 HandleSell(session, packet);
                 break;
-            case ShopMode.OpenViaItem:
+            case Mode.OpenViaItem:
                 HandleOpenViaItem(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/SkillBookTreeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillBookTreeHandler.cs
@@ -11,7 +11,7 @@ public class SkillBookTreeHandler : GamePacketHandler<SkillBookTreeHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestSkillBookTree;
 
-    private enum SkillBookMode : byte
+    private enum Mode : byte
     {
         Open = 0x00,
         Save = 0x01,
@@ -21,19 +21,19 @@ public class SkillBookTreeHandler : GamePacketHandler<SkillBookTreeHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        SkillBookMode mode = (SkillBookMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case SkillBookMode.Open:
+            case Mode.Open:
                 HandleOpen(session);
                 break;
-            case SkillBookMode.Save:
+            case Mode.Save:
                 HandleSave(session, packet);
                 break;
-            case SkillBookMode.Rename:
+            case Mode.Rename:
                 HandleRename(session, packet);
                 break;
-            case SkillBookMode.AddTab:
+            case Mode.AddTab:
                 HandleAddTab(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -14,7 +14,7 @@ public class SkillHandler : GamePacketHandler<SkillHandler>
 {
     public override RecvOp OpCode => RecvOp.Skill;
 
-    private enum SkillHandlerMode : byte
+    private enum Mode : byte
     {
         Cast = 0x0,
         Damage = 0x1,
@@ -25,22 +25,22 @@ public class SkillHandler : GamePacketHandler<SkillHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        SkillHandlerMode mode = (SkillHandlerMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case SkillHandlerMode.Cast:
+            case Mode.Cast:
                 HandleCast(session, packet);
                 break;
-            case SkillHandlerMode.Damage:
+            case Mode.Damage:
                 HandleDamageMode(session, packet);
                 break;
-            case SkillHandlerMode.Sync:
+            case Mode.Sync:
                 HandleSyncSkills(session, packet);
                 break;
-            case SkillHandlerMode.SyncTick:
+            case Mode.SyncTick:
                 HandleSyncTick(packet);
                 break;
-            case SkillHandlerMode.Cancel:
+            case Mode.Cancel:
                 HandleCancelSkill(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -10,7 +10,7 @@ public class StatPointHandler : GamePacketHandler<StatPointHandler>
 {
     public override RecvOp OpCode => RecvOp.StatPoint;
 
-    private enum StatPointMode : byte
+    private enum Mode : byte
     {
         Increment = 0x2,
         Reset = 0x3
@@ -18,14 +18,14 @@ public class StatPointHandler : GamePacketHandler<StatPointHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        StatPointMode mode = (StatPointMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case StatPointMode.Increment:
+            case Mode.Increment:
                 HandleStatIncrement(session, packet);
                 break;
-            case StatPointMode.Reset:
+            case Mode.Reset:
                 HandleResetStatDistribution(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/StateHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StateHandler.cs
@@ -9,7 +9,7 @@ public class StateHandler : GamePacketHandler<StateHandler>
 {
     public override RecvOp OpCode => RecvOp.State;
 
-    private enum StateHandlerMode : byte
+    private enum Mode : byte
     {
         Jump = 0x0,
         Land = 0x1
@@ -17,14 +17,14 @@ public class StateHandler : GamePacketHandler<StateHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        StateHandlerMode mode = (StateHandlerMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case StateHandlerMode.Jump:
+            case Mode.Jump:
                 HandleJump(session);
                 break;
-            case StateHandlerMode.Land:
+            case Mode.Land:
                 break;
             default:
                 LogUnknownMode(mode);

--- a/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
@@ -10,7 +10,7 @@ public class SuperChatHandler : GamePacketHandler<SuperChatHandler>
 {
     public override RecvOp OpCode => RecvOp.SuperWorldChat;
 
-    private enum SuperChatMode : byte
+    private enum Mode : byte
     {
         Select = 0x0,
         Deselect = 0x1
@@ -18,14 +18,14 @@ public class SuperChatHandler : GamePacketHandler<SuperChatHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        SuperChatMode mode = (SuperChatMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case SuperChatMode.Select:
+            case Mode.Select:
                 HandleSelect(session, packet);
                 break;
-            case SuperChatMode.Deselect:
+            case Mode.Deselect:
                 HandleDeselect(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
@@ -14,7 +14,7 @@ public class SystemShopHandler : GamePacketHandler<SystemShopHandler>
 {
     public override RecvOp OpCode => RecvOp.SystemShop;
 
-    private enum ShopMode : byte
+    private enum Mode : byte
     {
         Arena = 0x03,
         Fishing = 0x04,
@@ -23,17 +23,17 @@ public class SystemShopHandler : GamePacketHandler<SystemShopHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ShopMode mode = (ShopMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case ShopMode.ViaItem:
+            case Mode.ViaItem:
                 HandleViaItem(session, packet);
                 break;
-            case ShopMode.Fishing:
+            case Mode.Fishing:
                 HandleFishingShop(session, packet);
                 break;
-            case ShopMode.Arena:
+            case Mode.Arena:
                 HandleMapleArenaShop(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/TaxiHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TaxiHandler.cs
@@ -11,11 +11,11 @@ using MoonSharp.Interpreter;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-internal class RequestTaxiHandler : GamePacketHandler<RequestTaxiHandler>
+internal class TaxiHandler : GamePacketHandler<TaxiHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestTaxi;
 
-    private enum RequestTaxiMode : byte
+    private enum Mode : byte
     {
         Car = 0x1,
         RotorsMeso = 0x3,
@@ -25,12 +25,12 @@ internal class RequestTaxiHandler : GamePacketHandler<RequestTaxiHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestTaxiMode mode = (RequestTaxiMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         int mapId = 0;
         long meretPrice = 15;
 
-        if (mode != RequestTaxiMode.DiscoverTaxi)
+        if (mode != Mode.DiscoverTaxi)
         {
             mapId = packet.ReadInt();
 
@@ -51,16 +51,16 @@ internal class RequestTaxiHandler : GamePacketHandler<RequestTaxiHandler>
 
         switch (mode)
         {
-            case RequestTaxiMode.Car:
+            case Mode.Car:
                 HandleCarTaxi(session, mapId);
                 break;
-            case RequestTaxiMode.RotorsMeso:
+            case Mode.RotorsMeso:
                 HandleRotorMeso(session, mapId);
                 break;
-            case RequestTaxiMode.RotorsMeret:
+            case Mode.RotorsMeret:
                 HandleRotorMeret(session, mapId, meretPrice);
                 break;
-            case RequestTaxiMode.DiscoverTaxi:
+            case Mode.DiscoverTaxi:
                 HandleDiscoverTaxi(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/TimeSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TimeSyncHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestTimeSyncHandler : GamePacketHandler<RequestTimeSyncHandler>
+public class TimeSyncHandler : GamePacketHandler<TimeSyncHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestTimeSync;
 

--- a/MapleServer2/PacketHandlers/Game/TradeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TradeHandler.cs
@@ -11,7 +11,7 @@ public class TradeHandler : GamePacketHandler<TradeHandler>
 {
     public override RecvOp OpCode => RecvOp.Trade;
 
-    private enum TradeModeType : byte
+    private enum Mode : byte
     {
         SendRequest = 0x00,
         RequestRespond = 0x02,
@@ -27,37 +27,37 @@ public class TradeHandler : GamePacketHandler<TradeHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        TradeModeType mode = (TradeModeType) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case TradeModeType.SendRequest:
+            case Mode.SendRequest:
                 HandleSendRequest(session, packet);
                 break;
-            case TradeModeType.RequestRespond:
+            case Mode.RequestRespond:
                 HandleRequestRespond(packet);
                 break;
-            case TradeModeType.AcceptRequest:
+            case Mode.AcceptRequest:
                 HandleAcceptRequest(session, packet);
                 break;
-            case TradeModeType.DeclineRequest:
+            case Mode.DeclineRequest:
                 HandleDeclineRequest(session, packet);
                 break;
-            case TradeModeType.CloseTrade:
+            case Mode.CloseTrade:
                 HandleCloseTrade(session);
                 break;
-            case TradeModeType.AddItemToTrade:
+            case Mode.AddItemToTrade:
                 HandleAddItemToTrade(session, packet);
                 break;
-            case TradeModeType.RemoveItemToTrade:
+            case Mode.RemoveItemToTrade:
                 HandleRemoveItemToTrade(session, packet);
                 break;
-            case TradeModeType.ModifyMesosToTrade:
+            case Mode.ModifyMesosToTrade:
                 HandleModifyMesosToTrade(session, packet);
                 break;
-            case TradeModeType.LockOffer:
+            case Mode.LockOffer:
                 HandleLockOffer(session);
                 break;
-            case TradeModeType.FinalizeTrade:
+            case Mode.FinalizeTrade:
                 HandleFinalizeTrade(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/TriggerHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TriggerHandler.cs
@@ -12,7 +12,7 @@ public class TriggerHandler : GamePacketHandler<TriggerHandler>
 {
     public override RecvOp OpCode => RecvOp.Trigger;
 
-    private enum TriggerMode : byte
+    private enum Mode : byte
     {
         SkipCutscene = 0x7,
         UpdateWidget = 0x8
@@ -20,14 +20,14 @@ public class TriggerHandler : GamePacketHandler<TriggerHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        TriggerMode mode = (TriggerMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case TriggerMode.SkipCutscene:
+            case Mode.SkipCutscene:
                 HandleSkipCutscene(session);
                 break;
-            case TriggerMode.UpdateWidget:
+            case Mode.UpdateWidget:
                 HandleUpdateWidget(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/TrophyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TrophyHandler.cs
@@ -14,7 +14,7 @@ public class TrophyHandler : GamePacketHandler<TrophyHandler>
 {
     public override RecvOp OpCode => RecvOp.Trophy;
 
-    private enum TrophyHandlerMode : byte
+    private enum Mode : byte
     {
         ClaimReward = 0x03,
         Favorite = 0x04
@@ -22,14 +22,14 @@ public class TrophyHandler : GamePacketHandler<TrophyHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        TrophyHandlerMode mode = (TrophyHandlerMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case TrophyHandlerMode.ClaimReward:
+            case Mode.ClaimReward:
                 HandleClaimReward(session, packet);
                 break;
-            case TrophyHandlerMode.Favorite:
+            case Mode.Favorite:
                 HandleFavorite(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/TutorialItemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TutorialItemHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestTutorialItemHandler : GamePacketHandler<RequestTutorialItemHandler>
+public class TutorialItemHandler : GamePacketHandler<TutorialItemHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestTutorialItem;
 

--- a/MapleServer2/PacketHandlers/Game/UGCHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UGCHandler.cs
@@ -14,7 +14,7 @@ public class UgcHandler : GamePacketHandler<UgcHandler>
 {
     public override RecvOp OpCode => RecvOp.UGC;
 
-    private enum UgcMode : byte
+    private enum Mode : byte
     {
         Upload = 0x01,
         ConfirmationPacket = 0x03,
@@ -25,22 +25,22 @@ public class UgcHandler : GamePacketHandler<UgcHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        UgcMode function = (UgcMode) packet.ReadByte();
+        Mode function = (Mode) packet.ReadByte();
         switch (function)
         {
-            case UgcMode.Upload:
+            case Mode.Upload:
                 HandleUpload(session, packet);
                 break;
-            case UgcMode.ConfirmationPacket:
+            case Mode.ConfirmationPacket:
                 HandleConfirmationPacket(session, packet);
                 break;
-            case UgcMode.ProfilePicture:
+            case Mode.ProfilePicture:
                 HandleProfilePicture(session, packet);
                 break;
-            case UgcMode.LoadBanner:
+            case Mode.LoadBanner:
                 HandleLoadBanner(session, packet);
                 break;
-            case UgcMode.UpdateBanner:
+            case Mode.UpdateBanner:
                 HandleUpdateBanner(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/UserEnvHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserEnvHandler.cs
@@ -5,11 +5,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestUserEnvHandler : GamePacketHandler<RequestUserEnvHandler>
+public class UserEnvHandler : GamePacketHandler<UserEnvHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestUserEnvironment;
 
-    private enum UserEnvMode : byte
+    private enum Mode : byte
     {
         Change = 0x1,
         Trophy = 0x3
@@ -17,14 +17,14 @@ public class RequestUserEnvHandler : GamePacketHandler<RequestUserEnvHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        UserEnvMode mode = (UserEnvMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case UserEnvMode.Change:
+            case Mode.Change:
                 HandleTitleChange(session, packet);
                 break;
-            case UserEnvMode.Trophy:
+            case Mode.Trophy:
                 HandleTrophy(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/WardrobeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/WardrobeHandler.cs
@@ -16,7 +16,7 @@ public class WardrobeHandler : GamePacketHandler<WardrobeHandler>
 {
     public override RecvOp OpCode => RecvOp.Wardrobe;
 
-    private enum WardrobeMode : byte
+    private enum Mode : byte
     {
         Save = 0,
         Equip = 1,
@@ -27,23 +27,23 @@ public class WardrobeHandler : GamePacketHandler<WardrobeHandler>
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        WardrobeMode mode = (WardrobeMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
 
         switch (mode)
         {
-            case WardrobeMode.Save:
+            case Mode.Save:
                 HandleSave(session, packet);
                 break;
-            case WardrobeMode.Equip:
+            case Mode.Equip:
                 HandleEquip(session, packet);
                 break;
-            case WardrobeMode.Reset:
+            case Mode.Reset:
                 HandleReset(session, packet);
                 break;
-            case WardrobeMode.SetShortcut:
+            case Mode.SetShortcut:
                 HandleSetShortcut(session, packet);
                 break;
-            case WardrobeMode.Rename:
+            case Mode.Rename:
                 HandleRename(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/WorldMapHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/WorldMapHandler.cs
@@ -5,21 +5,21 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestWorldMapHandler : GamePacketHandler<RequestWorldMapHandler>
+public class WorldMapHandler : GamePacketHandler<WorldMapHandler>
 {
     public override RecvOp OpCode => RecvOp.RequestWorldMap;
 
-    private enum WorldMapMode : byte
+    private enum Mode : byte
     {
         Open = 0x00
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        WorldMapMode mode = (WorldMapMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case WorldMapMode.Open: // open
+            case Mode.Open: // open
                 HandleOpen(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
@@ -17,7 +17,7 @@ public class CharacterManagementHandler : LoginPacketHandler<CharacterManagement
 {
     public override RecvOp OpCode => RecvOp.CharManagement;
 
-    private enum CharacterManagementMode : byte
+    private enum Mode : byte
     {
         Login = 0x0,
         Create = 0x1,
@@ -26,16 +26,16 @@ public class CharacterManagementHandler : LoginPacketHandler<CharacterManagement
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        CharacterManagementMode mode = (CharacterManagementMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         switch (mode)
         {
-            case CharacterManagementMode.Login:
+            case Mode.Login:
                 HandleSelect(session, packet);
                 break;
-            case CharacterManagementMode.Create:
+            case Mode.Create:
                 HandleCreate(session, packet);
                 break;
-            case CharacterManagementMode.Delete:
+            case Mode.Delete:
                 HandleDelete(session, packet);
                 break;
             default:
@@ -93,22 +93,22 @@ public class CharacterManagementHandler : LoginPacketHandler<CharacterManagement
         switch (name.Length)
         {
             case <= 1:
-                session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.CharacterCreatePacketMode.NameNeeds2LettersMinimum));
+                session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.Mode.NameNeeds2LettersMinimum));
                 return;
             case > 13:
-                session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.CharacterCreatePacketMode.MaxCharactersReached));
+                session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.Mode.MaxCharactersReached));
                 return;
         }
 
         if (DatabaseManager.Characters.NameExists(name))
         {
-            session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.CharacterCreatePacketMode.NameIsTaken));
+            session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.Mode.NameIsTaken));
             return;
         }
 
         if (CharacterCreateMetadataStorage.JobIsDisabled((int) job))
         {
-            session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.CharacterCreatePacketMode.JobRestriction));
+            session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.Mode.JobRestriction));
             return;
         }
 
@@ -122,7 +122,7 @@ public class CharacterManagementHandler : LoginPacketHandler<CharacterManagement
             string typeStr = packet.ReadUnicodeString();
             if (!Enum.TryParse(typeStr, out ItemSlot type) || !DefaultItemsMetadataStorage.IsValid((int) job, id))
             {
-                session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.CharacterCreatePacketMode.IncorrectGear));
+                session.Send(ResponseCharCreatePacket.Error(ResponseCharCreatePacket.Mode.IncorrectGear));
                 return;
             }
 

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -23,7 +23,7 @@ public class LoginHandler : LoginPacketHandler<LoginHandler>
     private readonly string ServerName;
     private readonly short ChannelCount;
 
-    private enum LoginMode : byte
+    private enum Mode : byte
     {
         Banners = 0x01,
         SendCharacters = 0x02
@@ -43,7 +43,7 @@ public class LoginHandler : LoginPacketHandler<LoginHandler>
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        LoginMode mode = (LoginMode) packet.ReadByte();
+        Mode mode = (Mode) packet.ReadByte();
         string username = packet.ReadUnicodeString();
         string password = packet.ReadUnicodeString();
 
@@ -90,10 +90,10 @@ public class LoginHandler : LoginPacketHandler<LoginHandler>
 
         switch (mode)
         {
-            case LoginMode.Banners:
+            case Mode.Banners:
                 SendBanners(session, account);
                 break;
-            case LoginMode.SendCharacters:
+            case Mode.SendCharacters:
                 SendCharacters(session, account);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Login/LoginUgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginUgcHandler.cs
@@ -10,17 +10,17 @@ public class LoginUgcHandler : LoginPacketHandler<LoginUgcHandler>
 {
     public override RecvOp OpCode => RecvOp.UGC;
 
-    private enum UgcMode : byte
+    private enum Mode : byte
     {
         ProfilePicture = 0x0B
     }
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        UgcMode function = (UgcMode) packet.ReadByte();
+        Mode function = (Mode) packet.ReadByte();
         switch (function)
         {
-            case UgcMode.ProfilePicture:
+            case Mode.ProfilePicture:
                 HandleProfilePicture(session, packet);
                 break;
             default:

--- a/MapleServer2/Packets/AttendancePacket.cs
+++ b/MapleServer2/Packets/AttendancePacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class AttendancePacket
 {
-    private enum AttendancePacketMode : byte
+    private enum Mode : byte
     {
         Notice = 0x9
     }
@@ -13,7 +13,7 @@ public static class AttendancePacket
     public static PacketWriter Notice(byte noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Attendance);
-        pWriter.Write(AttendancePacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteByte(noticeId);
         return pWriter;
     }

--- a/MapleServer2/Packets/BeautyPacket.cs
+++ b/MapleServer2/Packets/BeautyPacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class BeautyPacket
 {
-    private enum BeautyPacketMode : byte
+    private enum Mode : byte
     {
         LoadBeautyShop = 0x0,
         LoadDyeShop = 0x1,
@@ -28,7 +28,7 @@ public static class BeautyPacket
     public static PacketWriter LoadBeautyShop(BeautyShop beautyShop)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadBeautyShop);
+        pWriter.Write(Mode.LoadBeautyShop);
         WriteBeautyShop(pWriter, beautyShop);
         pWriter.WriteByte();
         pWriter.WriteByte();
@@ -39,7 +39,7 @@ public static class BeautyPacket
     public static PacketWriter LoadBeautyShop(BeautyShop beautyShop, List<BeautyShopItem> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadBeautyShop);
+        pWriter.Write(Mode.LoadBeautyShop);
         WriteBeautyShop(pWriter, beautyShop);
         pWriter.WriteByte(30);
         pWriter.WriteByte(6);
@@ -62,7 +62,7 @@ public static class BeautyPacket
     public static PacketWriter LoadDyeShop(BeautyShop beautyShop)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadDyeShop);
+        pWriter.Write(Mode.LoadDyeShop);
         WriteBeautyShop(pWriter, beautyShop);
         return pWriter;
     }
@@ -70,7 +70,7 @@ public static class BeautyPacket
     public static PacketWriter LoadSaveShop(BeautyShop beautyShop)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadSaveShop);
+        pWriter.Write(Mode.LoadSaveShop);
         WriteBeautyShop(pWriter, beautyShop);
         pWriter.WriteByte(30);
         pWriter.WriteByte(6);
@@ -81,7 +81,7 @@ public static class BeautyPacket
     public static PacketWriter UseVoucher(int voucherId, int quantity)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.UseVoucher);
+        pWriter.Write(Mode.UseVoucher);
         pWriter.WriteInt(voucherId);
         pWriter.WriteInt(quantity);
         return pWriter;
@@ -90,7 +90,7 @@ public static class BeautyPacket
     public static PacketWriter RandomHairOption(Item previousHair, Item newHair)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.RandomHairOption);
+        pWriter.Write(Mode.RandomHairOption);
         pWriter.WriteInt(previousHair.Id);
         pWriter.WriteInt(newHair.Id);
         return pWriter;
@@ -99,7 +99,7 @@ public static class BeautyPacket
     public static PacketWriter ChooseRandomHair(int voucherId = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.ChooseRandomHair);
+        pWriter.Write(Mode.ChooseRandomHair);
         pWriter.WriteInt(voucherId);
         pWriter.WriteByte();
         return pWriter;
@@ -108,14 +108,14 @@ public static class BeautyPacket
     public static PacketWriter InitializeSaves()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.InitializeSaves);
+        pWriter.Write(Mode.InitializeSaves);
         return pWriter;
     }
 
     public static PacketWriter LoadSavedHairCount(short hairCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadSavedHairCount);
+        pWriter.Write(Mode.LoadSavedHairCount);
         pWriter.WriteShort(hairCount);
         return pWriter;
     }
@@ -123,7 +123,7 @@ public static class BeautyPacket
     public static PacketWriter LoadSavedHairs(List<Item> savedHairs)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadSavedHairs);
+        pWriter.Write(Mode.LoadSavedHairs);
         pWriter.WriteShort((short) savedHairs.Count);
         foreach (Item hair in savedHairs)
         {
@@ -146,7 +146,7 @@ public static class BeautyPacket
     public static PacketWriter SaveHair(Item playerHair, Item hairCopy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.SaveHair);
+        pWriter.Write(Mode.SaveHair);
         pWriter.WriteLong(playerHair.Uid);
         pWriter.WriteLong(hairCopy.Uid);
         pWriter.WriteByte();
@@ -157,7 +157,7 @@ public static class BeautyPacket
     public static PacketWriter DeleteSavedHair(long itemUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.DeleteSavedHair);
+        pWriter.Write(Mode.DeleteSavedHair);
         pWriter.WriteLong(itemUid);
         return pWriter;
     }
@@ -165,7 +165,7 @@ public static class BeautyPacket
     public static PacketWriter LoadSaveWindow()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.LoadSaveWindow);
+        pWriter.Write(Mode.LoadSaveWindow);
         pWriter.WriteByte();
         pWriter.WriteShort();
         return pWriter;
@@ -174,7 +174,7 @@ public static class BeautyPacket
     public static PacketWriter ChangetoSavedHair()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Beauty);
-        pWriter.Write(BeautyPacketMode.ChangeToSavedHair);
+        pWriter.Write(Mode.ChangeToSavedHair);
         return pWriter;
     }
 

--- a/MapleServer2/Packets/BirthdayPacket.cs
+++ b/MapleServer2/Packets/BirthdayPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public class BirthdayPacket
 {
-    private enum BirthdayPacketMode : byte
+    private enum Mode : byte
     {
         SetBirthday = 0x1
     }
@@ -13,7 +13,7 @@ public class BirthdayPacket
     public static PacketWriter SetBirthday(int playerObjectId, long birthdate)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Birthday);
-        pWriter.Write(BirthdayPacketMode.SetBirthday);
+        pWriter.Write(Mode.SetBirthday);
         pWriter.WriteInt(playerObjectId);
         pWriter.WriteLong(birthdate);
         return pWriter;

--- a/MapleServer2/Packets/BlackMarketPacket.cs
+++ b/MapleServer2/Packets/BlackMarketPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class BlackMarketPacket
 {
-    private enum BlackMarketPacketMode : byte
+    private enum Mode : byte
     {
         Error = 0x0,
         Open = 0x1,
@@ -21,7 +21,7 @@ public static class BlackMarketPacket
     public static PacketWriter Error(int errorCode, int itemId = 0, int itemLevel = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.Error);
+        pWriter.Write(Mode.Error);
         pWriter.WriteByte();
         pWriter.WriteInt(errorCode);
         pWriter.WriteLong();
@@ -33,7 +33,7 @@ public static class BlackMarketPacket
     public static PacketWriter Open(List<BlackMarketListing> listings)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt(listings.Count);
         foreach (BlackMarketListing listing in listings)
         {
@@ -45,7 +45,7 @@ public static class BlackMarketPacket
     public static PacketWriter CreateListing(BlackMarketListing listing)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.CreateListing);
+        pWriter.Write(Mode.CreateListing);
         WriteListing(pWriter, listing);
         return pWriter;
     }
@@ -53,7 +53,7 @@ public static class BlackMarketPacket
     public static PacketWriter CancelListing(BlackMarketListing listing, bool isSold)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.CancelListing);
+        pWriter.Write(Mode.CancelListing);
         pWriter.WriteLong(listing.Id);
         pWriter.WriteBool(isSold);
         return pWriter;
@@ -62,7 +62,7 @@ public static class BlackMarketPacket
     public static PacketWriter SearchResults(List<BlackMarketListing> listings)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.SearchResults);
+        pWriter.Write(Mode.SearchResults);
         pWriter.WriteInt(listings.Count);
         foreach (BlackMarketListing listing in listings)
         {
@@ -74,7 +74,7 @@ public static class BlackMarketPacket
     public static PacketWriter Purchase(long listingId, int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.Purchase);
+        pWriter.Write(Mode.Purchase);
         pWriter.WriteLong(listingId);
         pWriter.WriteInt(amount);
         return pWriter;
@@ -83,7 +83,7 @@ public static class BlackMarketPacket
     public static PacketWriter PrepareListing(int itemId, int rarity, int npcShopPrice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BlackMarket);
-        pWriter.Write(BlackMarketPacketMode.PrepareListing);
+        pWriter.Write(Mode.PrepareListing);
         pWriter.WriteInt(itemId);
         pWriter.WriteInt(rarity);
         pWriter.WriteLong(npcShopPrice);

--- a/MapleServer2/Packets/BreakablePacket.cs
+++ b/MapleServer2/Packets/BreakablePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class BreakablePacket
 {
-    private enum BreakablePacketMode : byte
+    private enum Mode : byte
     {
         LoadBreakables = 0x0,
         Interact = 0x1
@@ -15,7 +15,7 @@ public static class BreakablePacket
     public static PacketWriter LoadBreakables(List<BreakableObject> breakables)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Breakable);
-        pWriter.Write(BreakablePacketMode.LoadBreakables);
+        pWriter.Write(Mode.LoadBreakables);
         pWriter.WriteInt(breakables.Count);
         foreach (BreakableObject breakable in breakables)
         {
@@ -27,7 +27,7 @@ public static class BreakablePacket
     public static PacketWriter Interact(BreakableObject breakable)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Breakable);
-        pWriter.Write(BreakablePacketMode.Interact);
+        pWriter.Write(Mode.Interact);
         WriteBreakable(pWriter, breakable);
         return pWriter;
     }

--- a/MapleServer2/Packets/BuddyEmotePacket.cs
+++ b/MapleServer2/Packets/BuddyEmotePacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class BuddyEmotePacket
 {
-    private enum BuddyEmotePacketMode : byte
+    private enum Mode : byte
     {
         SendRequest = 0x0,
         ConfirmSendRequest = 0x1,
@@ -21,7 +21,7 @@ public static class BuddyEmotePacket
     public static PacketWriter SendRequest(int buddyEmoteId, Player sender)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.SendRequest);
+        pWriter.Write(Mode.SendRequest);
         pWriter.WriteInt(buddyEmoteId);
         pWriter.WriteLong(sender.CharacterId);
         pWriter.WriteUnicodeString(sender.Name);
@@ -31,7 +31,7 @@ public static class BuddyEmotePacket
     public static PacketWriter ConfirmSendRequest(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.ConfirmSendRequest);
+        pWriter.Write(Mode.ConfirmSendRequest);
         pWriter.WriteLong(player.CharacterId);
         return pWriter;
     }
@@ -39,7 +39,7 @@ public static class BuddyEmotePacket
     public static PacketWriter LearnEmote()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.LearnEmote);
+        pWriter.Write(Mode.LearnEmote);
         pWriter.WriteInt(); // emoteID
         pWriter.WriteInt(1); // quantity
         pWriter.WriteLong();
@@ -49,7 +49,7 @@ public static class BuddyEmotePacket
     public static PacketWriter SendAccept(int buddyEmoteId, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.AcceptEmote);
+        pWriter.Write(Mode.AcceptEmote);
         pWriter.WriteInt(buddyEmoteId);
         pWriter.WriteLong(player.CharacterId);
         return pWriter;
@@ -58,7 +58,7 @@ public static class BuddyEmotePacket
     public static PacketWriter DeclineEmote(int buddyEmoteId, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.DeclineEmote);
+        pWriter.Write(Mode.DeclineEmote);
         pWriter.WriteInt(buddyEmoteId);
         pWriter.WriteLong(player.CharacterId);
         return pWriter;
@@ -67,7 +67,7 @@ public static class BuddyEmotePacket
     public static PacketWriter StartEmote(int buddyEmoteId, Player player1, Player player2, CoordF coords, int rotation)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.StartEmote);
+        pWriter.Write(Mode.StartEmote);
         pWriter.WriteInt(buddyEmoteId);
         pWriter.WriteLong(player1.CharacterId);
         pWriter.WriteLong(player2.CharacterId);
@@ -82,7 +82,7 @@ public static class BuddyEmotePacket
     public static PacketWriter StopEmote(int buddyEmoteId, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.BuddyEmote);
-        pWriter.Write(BuddyEmotePacketMode.StopEmote);
+        pWriter.Write(Mode.StopEmote);
         pWriter.WriteInt(buddyEmoteId);
         pWriter.WriteLong(player.CharacterId);
         return pWriter;

--- a/MapleServer2/Packets/BuddyPacket.cs
+++ b/MapleServer2/Packets/BuddyPacket.cs
@@ -4,9 +4,9 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public class BuddyPacket
+public static class BuddyPacket
 {
-    private enum BuddyPacketMode : byte
+    private enum Mode : byte
     {
         LoadList = 0x1,
         Notice = 0x2,
@@ -29,7 +29,7 @@ public class BuddyPacket
     public static PacketWriter LoadList(List<Buddy> buddyList)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.LoadList);
+        pWriter.Write(Mode.LoadList);
         pWriter.WriteInt(buddyList.Count);
         foreach (Buddy buddy in buddyList)
         {
@@ -41,7 +41,7 @@ public class BuddyPacket
     public static PacketWriter Notice(byte notice, string playerName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteByte(notice);
         pWriter.WriteUnicodeString(playerName);
         pWriter.WriteUnicodeString();
@@ -51,7 +51,7 @@ public class BuddyPacket
     public static PacketWriter AcceptRequest(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.AcceptRequest);
+        pWriter.Write(Mode.AcceptRequest);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         pWriter.WriteLong(buddy.Friend.CharacterId);
@@ -63,7 +63,7 @@ public class BuddyPacket
     public static PacketWriter DeclineRequest(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.DeclineRequest);
+        pWriter.Write(Mode.DeclineRequest);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         return pWriter;
@@ -72,7 +72,7 @@ public class BuddyPacket
     public static PacketWriter Block(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.Block);
+        pWriter.Write(Mode.Block);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         pWriter.WriteUnicodeString(buddy.Friend.Name);
@@ -83,7 +83,7 @@ public class BuddyPacket
     public static PacketWriter Unblock(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.Unblock);
+        pWriter.Write(Mode.Unblock);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         return pWriter;
@@ -92,7 +92,7 @@ public class BuddyPacket
     public static PacketWriter RemoveFromList(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.RemoveFromList);
+        pWriter.Write(Mode.RemoveFromList);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         pWriter.WriteLong(buddy.Friend.AccountId);
@@ -104,7 +104,7 @@ public class BuddyPacket
     public static PacketWriter UpdateBuddy(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.UpdateBuddy);
+        pWriter.Write(Mode.UpdateBuddy);
         WriteBuddy(buddy, pWriter);
         return pWriter;
     }
@@ -112,7 +112,7 @@ public class BuddyPacket
     public static PacketWriter AddToList(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.AddToList);
+        pWriter.Write(Mode.AddToList);
         WriteBuddy(buddy, pWriter);
         return pWriter;
     }
@@ -120,7 +120,7 @@ public class BuddyPacket
     public static PacketWriter EditBlockReason(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.EditBlockReason);
+        pWriter.Write(Mode.EditBlockReason);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         pWriter.WriteUnicodeString(buddy.Friend.Name);
@@ -133,7 +133,7 @@ public class BuddyPacket
     public static PacketWriter AcceptNotification(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.AcceptNotification);
+        pWriter.Write(Mode.AcceptNotification);
         pWriter.WriteLong(buddy.SharedId);
         return pWriter;
     }
@@ -141,7 +141,7 @@ public class BuddyPacket
     public static PacketWriter BlockNotification(string playerName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.BlockNotification);
+        pWriter.Write(Mode.BlockNotification);
         pWriter.WriteByte();
         pWriter.WriteUnicodeString(playerName);
         return pWriter;
@@ -150,7 +150,7 @@ public class BuddyPacket
     public static PacketWriter LoginLogoutNotification(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.LoginLogoutNotification);
+        pWriter.Write(Mode.LoginLogoutNotification);
         pWriter.WriteBool(!buddy.Friend?.Session?.Connected() ?? true);
         pWriter.WriteLong(buddy.SharedId);
         pWriter.WriteUnicodeString(buddy.Friend.Name);
@@ -160,14 +160,14 @@ public class BuddyPacket
     public static PacketWriter Initialize()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.Initialize);
+        pWriter.Write(Mode.Initialize);
         return pWriter;
     }
 
     public static PacketWriter CancelRequest(Buddy buddy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.CancelRequest);
+        pWriter.Write(Mode.CancelRequest);
         pWriter.WriteByte();
         pWriter.WriteLong(buddy.SharedId);
         return pWriter;
@@ -176,7 +176,7 @@ public class BuddyPacket
     public static PacketWriter EndList(int buddyCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buddy);
-        pWriter.Write(BuddyPacketMode.EndList);
+        pWriter.Write(Mode.EndList);
         pWriter.WriteInt(buddyCount);
         return pWriter;
     }

--- a/MapleServer2/Packets/BuffPacket.cs
+++ b/MapleServer2/Packets/BuffPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class BuffPacket
 {
-    private enum StatusMode : byte
+    private enum Mode : byte
     {
         Add = 0,
         Remove = 1,
@@ -16,7 +16,7 @@ public static class BuffPacket
     public static PacketWriter AddBuff(Status status)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buff);
-        pWriter.Write(StatusMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteBuffOwner(status.Target, status.UniqueId, status.Source);
 
         pWriter.WriteBuff(status.Start, status.End, status.SkillId, status.Level, status.Stacks);
@@ -29,7 +29,7 @@ public static class BuffPacket
     public static PacketWriter UpdateBuff(Status status)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buff);
-        pWriter.Write(StatusMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteBuffOwner(status.Target, status.UniqueId, status.Source);
 
         pWriter.WriteInt(status.Target);
@@ -43,7 +43,7 @@ public static class BuffPacket
     public static PacketWriter RemoveBuff(Status status)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buff);
-        pWriter.Write(StatusMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteBuffOwner(status.Target, status.UniqueId, status.Source);
 
         return pWriter;
@@ -52,7 +52,7 @@ public static class BuffPacket
     public static PacketWriter AddBuff(AdditionalEffect status, int target)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buff);
-        pWriter.Write(StatusMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteBuffOwner(target, status.BuffId, status.SourceId);
 
         pWriter.WriteBuff(status.Start, status.End, status.Id, status.Level, status.Stacks);
@@ -65,7 +65,7 @@ public static class BuffPacket
     public static PacketWriter UpdateBuff(AdditionalEffect status, int target)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buff);
-        pWriter.Write(StatusMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteBuffOwner(target, status.BuffId, status.SourceId);
 
         pWriter.WriteInt(target);
@@ -79,7 +79,7 @@ public static class BuffPacket
     public static PacketWriter RemoveBuff(AdditionalEffect status, int target)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Buff);
-        pWriter.Write(StatusMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteBuffOwner(target, status.BuffId, status.SourceId);
 
         return pWriter;

--- a/MapleServer2/Packets/BuildModePacket.cs
+++ b/MapleServer2/Packets/BuildModePacket.cs
@@ -1,5 +1,6 @@
 ﻿using MaplePacketLib2.Tools;
 using MapleServer2.Constants;
+using MapleServer2.Enums;
 using MapleServer2.PacketHandlers.Game;
 using MapleServer2.Types;
 
@@ -7,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class BuildModePacket
 {
-    public static PacketWriter Use(IFieldObject<Player> fieldPlayer, BuildModeHandler.BuildModeType type, int itemId = 0, long itemUid = 0)
+    public static PacketWriter Use(IFieldObject<Player> fieldPlayer, BuildModeType type, int itemId = 0, long itemUid = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SetBuildMode);
         pWriter.WriteInt(fieldPlayer.ObjectId);
@@ -15,14 +16,14 @@ public static class BuildModePacket
 
         switch (type)
         {
-            case BuildModeHandler.BuildModeType.House:
+            case BuildModeType.House:
                 pWriter.WriteInt(itemId);
                 pWriter.WriteLong(itemUid);
                 pWriter.WriteLong();
                 pWriter.WriteByte();
                 pWriter.WriteInt();
                 break;
-            case BuildModeHandler.BuildModeType.Liftables:
+            case BuildModeType.Liftables:
                 pWriter.WriteInt(itemId);
                 pWriter.WriteLong();
                 pWriter.WriteLong();

--- a/MapleServer2/Packets/CardReverseGamePacket.cs
+++ b/MapleServer2/Packets/CardReverseGamePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class CardReverseGamePacket
 {
-    private enum CardReverseGamePacketMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Mix = 0x1,
@@ -17,7 +17,7 @@ public static class CardReverseGamePacket
     public static PacketWriter Open(List<CardReverseGame> cards)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CardReverseGame);
-        pWriter.Write(CardReverseGamePacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt(CardReverseGame.TOKEN_ITEM_ID);
         pWriter.WriteInt(CardReverseGame.TOKEN_COST);
         pWriter.WriteInt(cards.Count);
@@ -33,14 +33,14 @@ public static class CardReverseGamePacket
     public static PacketWriter Mix()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CardReverseGame);
-        pWriter.Write(CardReverseGamePacketMode.Mix);
+        pWriter.Write(Mode.Mix);
         return pWriter;
     }
 
     public static PacketWriter Select(int index)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CardReverseGame);
-        pWriter.Write(CardReverseGamePacketMode.Select);
+        pWriter.Write(Mode.Select);
         pWriter.WriteInt(index);
         return pWriter;
     }
@@ -48,7 +48,7 @@ public static class CardReverseGamePacket
     public static PacketWriter Notice()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CardReverseGame);
-        pWriter.Write(CardReverseGamePacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteByte();
         return pWriter;
     }

--- a/MapleServer2/Packets/CashPacket.cs
+++ b/MapleServer2/Packets/CashPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class CashPacket
 {
-    private enum CashMode : byte
+    private enum Mode : byte
     {
         Mode09 = 0x09
     }
@@ -13,7 +13,7 @@ public static class CashPacket
     public static PacketWriter Unknown09()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cash);
-        pWriter.Write(CashMode.Mode09);
+        pWriter.Write(Mode.Mode09);
         pWriter.WriteByte();
 
         return pWriter;

--- a/MapleServer2/Packets/ChangeAttributesScrollPacket.cs
+++ b/MapleServer2/Packets/ChangeAttributesScrollPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public class ChangeAttributesScrollPacket
 {
-    private enum ChangeAttributesScrollMode : byte
+    private enum Mode : byte
     {
         Open = 0,
         Preview = 2,
@@ -17,7 +17,7 @@ public class ChangeAttributesScrollPacket
     public static PacketWriter Open(long uid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChangeAttributesScroll);
-        pWriter.Write(ChangeAttributesScrollMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteLong(uid);
 
         return pWriter;
@@ -26,7 +26,7 @@ public class ChangeAttributesScrollPacket
     public static PacketWriter PreviewNewItem(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChangeAttributesScroll);
-        pWriter.Write(ChangeAttributesScrollMode.Preview);
+        pWriter.Write(Mode.Preview);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
 
@@ -36,7 +36,7 @@ public class ChangeAttributesScrollPacket
     public static PacketWriter AddNewItem(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChangeAttributesScroll);
-        pWriter.Write(ChangeAttributesScrollMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
 

--- a/MapleServer2/Packets/CharacterCreatePacket.cs
+++ b/MapleServer2/Packets/CharacterCreatePacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class ResponseCharCreatePacket
 {
-    public enum CharacterCreatePacketMode : byte
+    public enum Mode : byte
     {
         SystemError = 0x00, // s_char_err_system
         NameNeeds2LettersMinimum = 0x01, //s_char_err_name
@@ -18,7 +18,7 @@ public static class ResponseCharCreatePacket
         AbnormalActivityDetected = 0x0E // s_char_err_creation_restriction
     }
 
-    public static PacketWriter Error(CharacterCreatePacketMode mode, string message = "")
+    public static PacketWriter Error(Mode mode, string message = "")
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharCreate);
         pWriter.Write(mode);

--- a/MapleServer2/Packets/CharacterInfoPacket.cs
+++ b/MapleServer2/Packets/CharacterInfoPacket.cs
@@ -4,7 +4,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public class CharacterInfoPacket
+public static class CharacterInfoPacket
 {
     public static PacketWriter WriteCharacterInfo(long characterId, Player player)
     {

--- a/MapleServer2/Packets/CharacterListPacket.cs
+++ b/MapleServer2/Packets/CharacterListPacket.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Packets;
 
 public static class CharacterListPacket
 {
-    private enum ListMode : byte
+    private enum Mode : byte
     {
         AddEntries = 0x00,
         AppendEntry = 0x01,
@@ -24,7 +24,7 @@ public static class CharacterListPacket
     public static PacketWriter AddEntries(List<Player> players)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.AddEntries);
+        pWriter.Write(Mode.AddEntries);
         pWriter.WriteByte((byte) players.Count);
         foreach (Player player in players)
         {
@@ -38,7 +38,7 @@ public static class CharacterListPacket
     public static PacketWriter AppendEntry(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.AppendEntry);
+        pWriter.Write(Mode.AppendEntry);
         WriteCharacterEntry(pWriter, player);
 
         return pWriter;
@@ -47,7 +47,7 @@ public static class CharacterListPacket
     public static PacketWriter DeleteCharacter(long playerId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.DeleteCharacter);
+        pWriter.Write(Mode.DeleteCharacter);
         pWriter.WriteInt(); // unk
         pWriter.WriteLong(playerId);
 
@@ -57,7 +57,7 @@ public static class CharacterListPacket
     public static PacketWriter DeletePending(long playerId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.DeletePending);
+        pWriter.Write(Mode.DeletePending);
         pWriter.WriteLong(playerId);
         pWriter.WriteInt(); // unk
         pWriter.WriteLong(); // delete timestamp
@@ -68,7 +68,7 @@ public static class CharacterListPacket
     public static PacketWriter DeleteCancel(long playerId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.DeleteCancel);
+        pWriter.Write(Mode.DeleteCancel);
         pWriter.WriteLong(playerId);
         pWriter.WriteInt(); // unk
 
@@ -253,7 +253,7 @@ public static class CharacterListPacket
     public static PacketWriter StartList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.StartList);
+        pWriter.Write(Mode.StartList);
 
         return pWriter;
     }
@@ -262,7 +262,7 @@ public static class CharacterListPacket
     public static PacketWriter EndList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.EndList);
+        pWriter.Write(Mode.EndList);
         pWriter.WriteBool(false);
 
         return pWriter;
@@ -271,7 +271,7 @@ public static class CharacterListPacket
     public static PacketWriter NameChanged(long characterId, string characterName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CharList);
-        pWriter.Write(ListMode.NameChange);
+        pWriter.Write(Mode.NameChange);
         pWriter.WriteInt(1);
         pWriter.WriteLong(characterId);
         pWriter.WriteUnicodeString(characterName);

--- a/MapleServer2/Packets/ChatStickerPacket.cs
+++ b/MapleServer2/Packets/ChatStickerPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class ChatStickerPacket
 {
-    private enum ChatStickerMode : byte
+    private enum Mode : byte
     {
         LoadChatSticker = 0x0,
         ExpiredStickerNotification = 0x1,
@@ -20,7 +20,7 @@ public static class ChatStickerPacket
     public static PacketWriter LoadChatSticker(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.LoadChatSticker);
+        pWriter.Write(Mode.LoadChatSticker);
         pWriter.WriteShort((short) player.FavoriteStickers.Count);
         foreach (int favorite in player.FavoriteStickers)
         {
@@ -38,7 +38,7 @@ public static class ChatStickerPacket
     public static PacketWriter ExpiredStickerNotification(List<ChatSticker> stickers)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.ExpiredStickerNotification);
+        pWriter.Write(Mode.ExpiredStickerNotification);
         pWriter.WriteInt();
         pWriter.WriteInt(stickers.Count);
         foreach (ChatSticker sticker in stickers)
@@ -51,7 +51,7 @@ public static class ChatStickerPacket
     public static PacketWriter AddSticker(int itemId, int stickerGroupId, long expiration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.AddSticker);
+        pWriter.Write(Mode.AddSticker);
         pWriter.WriteInt(itemId);
         pWriter.WriteInt(1);
         pWriter.WriteInt(stickerGroupId);
@@ -62,7 +62,7 @@ public static class ChatStickerPacket
     public static PacketWriter UseSticker(int stickerId, string script)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.UseSticker);
+        pWriter.Write(Mode.UseSticker);
         pWriter.WriteInt(stickerId);
         pWriter.WriteUnicodeString(script);
         pWriter.WriteByte();
@@ -72,7 +72,7 @@ public static class ChatStickerPacket
     public static PacketWriter GroupChatSticker(int stickerId, string groupChatName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.GroupChatSticker);
+        pWriter.Write(Mode.GroupChatSticker);
         pWriter.WriteInt(stickerId);
         pWriter.WriteUnicodeString(groupChatName);
         return pWriter;
@@ -81,7 +81,7 @@ public static class ChatStickerPacket
     public static PacketWriter Favorite(int stickerId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.Favorite);
+        pWriter.Write(Mode.Favorite);
         pWriter.WriteInt(stickerId);
         return pWriter;
     }
@@ -89,7 +89,7 @@ public static class ChatStickerPacket
     public static PacketWriter Unfavorite(int stickerId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ChatSticker);
-        pWriter.Write(ChatStickerMode.Unfavorite);
+        pWriter.Write(Mode.Unfavorite);
         pWriter.WriteInt(stickerId);
         return pWriter;
     }

--- a/MapleServer2/Packets/CinematicPacket.cs
+++ b/MapleServer2/Packets/CinematicPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class CinematicPacket
 {
-    private enum CinematicPacketMode : byte
+    private enum Mode : byte
     {
         HideUi = 0x1,
         Mode02 = 0x2,
@@ -22,7 +22,7 @@ public static class CinematicPacket
     public static PacketWriter HideUi(bool hide)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.HideUi);
+        pWriter.Write(Mode.HideUi);
         pWriter.WriteBool(hide);
         return pWriter;
     }
@@ -30,14 +30,14 @@ public static class CinematicPacket
     public static PacketWriter Mode02()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.Mode02);
+        pWriter.Write(Mode.Mode02);
         return pWriter;
     }
 
     public static PacketWriter View(int type)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.View);
+        pWriter.Write(Mode.View);
         pWriter.WriteInt(type);
         pWriter.WriteUnicodeString();
         pWriter.WriteUnicodeString();
@@ -47,7 +47,7 @@ public static class CinematicPacket
     public static PacketWriter SetSceneSkip(string skipState = "")
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.SetSceneSkip);
+        pWriter.Write(Mode.SetSceneSkip);
         pWriter.WriteBool(skipState.Length != 0);
         pWriter.WriteString(skipState);
         return pWriter;
@@ -56,14 +56,14 @@ public static class CinematicPacket
     public static PacketWriter StartSceneSkip()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.StartSceneSkip);
+        pWriter.Write(Mode.StartSceneSkip);
         return pWriter;
     }
 
     public static PacketWriter Conversation(int npcId, string illustrationId, string stringId, int delay, Align align)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.Conversation);
+        pWriter.Write(Mode.Conversation);
         pWriter.WriteInt(npcId);
         pWriter.WriteString(illustrationId);
         pWriter.WriteUnicodeString(stringId);
@@ -75,7 +75,7 @@ public static class CinematicPacket
     public static PacketWriter BalloonTalk(int objectId, bool isNpcId, string msg, int duration, int delayTick)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.BalloonTalk);
+        pWriter.Write(Mode.BalloonTalk);
         pWriter.WriteBool(isNpcId);
         pWriter.WriteInt(objectId);
         pWriter.WriteUnicodeString(msg);
@@ -88,7 +88,7 @@ public static class CinematicPacket
         float scale)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.Caption);
+        pWriter.Write(Mode.Caption);
         pWriter.WriteUnicodeString(type + "Caption");
         pWriter.WriteUnicodeString(title);
         pWriter.WriteUnicodeString(script);
@@ -103,7 +103,7 @@ public static class CinematicPacket
     public static PacketWriter SystemMessage(string script)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cinematic);
-        pWriter.Write(CinematicPacketMode.SystemMsg);
+        pWriter.Write(Mode.SystemMsg);
         pWriter.WriteUnicodeString(script);
         pWriter.WriteByte();
 

--- a/MapleServer2/Packets/ClubPacket.cs
+++ b/MapleServer2/Packets/ClubPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class ClubPacket
 {
-    private enum ClubPacketMode : byte
+    private enum Mode : byte
     {
         UpdateClub = 0x0,
         Establish = 0x1,
@@ -37,7 +37,7 @@ public static class ClubPacket
     public static PacketWriter UpdateClub(Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.UpdateClub);
+        pWriter.Write(Mode.UpdateClub);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.Name);
         pWriter.WriteLong(club.LeaderAccountId);
@@ -64,7 +64,7 @@ public static class ClubPacket
     public static PacketWriter Establish(Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.Establish);
+        pWriter.Write(Mode.Establish);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.Name);
         return pWriter;
@@ -73,7 +73,7 @@ public static class ClubPacket
     public static PacketWriter Create(Party party, Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.Create);
+        pWriter.Write(Mode.Create);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.Name);
         pWriter.WriteLong(party.Leader.AccountId);
@@ -99,7 +99,7 @@ public static class ClubPacket
     public static PacketWriter DeleteUnestablishedClub(long clubId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.DeleteUnestablishedClub);
+        pWriter.Write(Mode.DeleteUnestablishedClub);
         pWriter.WriteLong(clubId);
         pWriter.WriteInt(0x4D); // unk
         return pWriter;
@@ -108,7 +108,7 @@ public static class ClubPacket
     public static PacketWriter InviteSentReceipt(long clubId, Player other)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.InviteSentReceipt);
+        pWriter.Write(Mode.InviteSentReceipt);
         pWriter.WriteLong(clubId);
         pWriter.WriteUnicodeString(other.Name);
         return pWriter;
@@ -117,7 +117,7 @@ public static class ClubPacket
     public static PacketWriter Invite(Club club, Player other)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.Invite);
+        pWriter.Write(Mode.Invite);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.Name);
         pWriter.WriteUnicodeString(club.LeaderName);
@@ -128,7 +128,7 @@ public static class ClubPacket
     public static PacketWriter InviteResponse(Club club, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.InviteResponse);
+        pWriter.Write(Mode.InviteResponse);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.Name);
         pWriter.WriteUnicodeString(club.LeaderName);
@@ -140,7 +140,7 @@ public static class ClubPacket
     public static PacketWriter LeaderInviteResponse(Club club, string invitee, bool response)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.LeaderInviteResponse);
+        pWriter.Write(Mode.LeaderInviteResponse);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(invitee);
         pWriter.WriteBool(response);
@@ -151,7 +151,7 @@ public static class ClubPacket
     public static PacketWriter LeaveClub(Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.LeaveClub);
+        pWriter.Write(Mode.LeaveClub);
         pWriter.WriteLong(club.Id);
         return pWriter;
     }
@@ -159,7 +159,7 @@ public static class ClubPacket
     public static PacketWriter ChangeBuffReceipt(Club club, int buffId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.ChangeBuffReceipt);
+        pWriter.Write(Mode.ChangeBuffReceipt);
         pWriter.WriteLong(club.Id);
         pWriter.WriteInt(buffId);
         pWriter.WriteInt(0x1);
@@ -169,7 +169,7 @@ public static class ClubPacket
     public static PacketWriter ClubProposalInviteResponse(long clubId, ClubInviteResponse response, string characterName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.ClubProposalInviteResponse);
+        pWriter.Write(Mode.ClubProposalInviteResponse);
         pWriter.WriteLong(clubId);
         pWriter.Write(response);
         pWriter.WriteUnicodeString(characterName);
@@ -179,7 +179,7 @@ public static class ClubPacket
     public static PacketWriter Disband(Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.Disband);
+        pWriter.Write(Mode.Disband);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.LeaderName);
         pWriter.WriteInt(0xCF); //unk
@@ -189,7 +189,7 @@ public static class ClubPacket
     public static PacketWriter ConfirmInvite(Club club, ClubMember member /*, byte response*/)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.ConfirmInvite);
+        pWriter.Write(Mode.ConfirmInvite);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.LeaderName);
         pWriter.WriteByte(0x2); //unk
@@ -202,7 +202,7 @@ public static class ClubPacket
     public static PacketWriter LeaveNotice(Club club, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.LeaveNotice);
+        pWriter.Write(Mode.LeaveNotice);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
@@ -211,7 +211,7 @@ public static class ClubPacket
     public static PacketWriter LogoutNotice(Player player, Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.LogoutNotice);
+        pWriter.Write(Mode.LogoutNotice);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteLong(player.LastLogTime);
@@ -221,7 +221,7 @@ public static class ClubPacket
     public static PacketWriter AssignNewLeader(Player oldLeader, Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.AssignNewLeader);
+        pWriter.Write(Mode.AssignNewLeader);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(oldLeader.Name);
         pWriter.WriteUnicodeString(club.LeaderName);
@@ -232,7 +232,7 @@ public static class ClubPacket
     public static PacketWriter ChangeBuff(Club club, int buffId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.ChangeBuff);
+        pWriter.Write(Mode.ChangeBuff);
         pWriter.WriteLong(club.Id);
         pWriter.WriteInt(buffId);
         pWriter.WriteInt(0x1); // buff level
@@ -242,7 +242,7 @@ public static class ClubPacket
     public static PacketWriter UpdateMemberLocation(long clubId, string memberName, int mapId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.UpdateMemberLocation);
+        pWriter.Write(Mode.UpdateMemberLocation);
         pWriter.WriteLong(clubId);
         pWriter.WriteUnicodeString(memberName);
         pWriter.WriteInt(mapId);
@@ -252,7 +252,7 @@ public static class ClubPacket
     public static PacketWriter UpdatePlayer(ClubMember member, Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.UpdatePlayer);
+        pWriter.Write(Mode.UpdatePlayer);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(member.Player.Name);
         WriteClubMember(pWriter, member);
@@ -262,7 +262,7 @@ public static class ClubPacket
     public static PacketWriter LoginNotice(Player player, Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.LoginNotice);
+        pWriter.Write(Mode.LoginNotice);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
@@ -271,7 +271,7 @@ public static class ClubPacket
     public static PacketWriter Rename(Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.Rename);
+        pWriter.Write(Mode.Rename);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(club.Name);
         pWriter.WriteLong(club.LastNameChangeTimestamp);
@@ -281,7 +281,7 @@ public static class ClubPacket
     public static PacketWriter UpdateMemberName(string oldName, string newName, long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.UpdateMemberName);
+        pWriter.Write(Mode.UpdateMemberName);
         pWriter.WriteLong(characterId);
         pWriter.WriteUnicodeString(oldName);
         pWriter.WriteUnicodeString(newName);
@@ -291,7 +291,7 @@ public static class ClubPacket
     public static PacketWriter ErrorNotice(int errorId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.ErrorNotice);
+        pWriter.Write(Mode.ErrorNotice);
         pWriter.WriteByte(1);
         pWriter.WriteInt(errorId);
         return pWriter;
@@ -300,7 +300,7 @@ public static class ClubPacket
     public static PacketWriter Join(string memberName, Club club)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Club);
-        pWriter.Write(ClubPacketMode.Join);
+        pWriter.Write(Mode.Join);
         pWriter.WriteLong(club.Id);
         pWriter.WriteUnicodeString(memberName);
         pWriter.WriteUnicodeString(club.Name);

--- a/MapleServer2/Packets/CouponUsePacket.cs
+++ b/MapleServer2/Packets/CouponUsePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class CouponUsePacket
 {
-    private enum CouponUsePacketMode : byte
+    private enum Mode : byte
     {
         InventoryExpanded = 0x0,
         MaxInventorySize = 0x1,
@@ -18,21 +18,21 @@ public static class CouponUsePacket
     public static PacketWriter CharacterSlotAdded()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CouponUse);
-        pWriter.Write(CouponUsePacketMode.CharacterSlotAdded);
+        pWriter.Write(Mode.CharacterSlotAdded);
         return pWriter;
     }
 
     public static PacketWriter MaxCharacterSlots()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CouponUse);
-        pWriter.Write(CouponUsePacketMode.MaxCharacterSlots);
+        pWriter.Write(Mode.MaxCharacterSlots);
         return pWriter;
     }
 
     public static PacketWriter BeautyCoupon(IFieldObject<Player> player, long itemUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.CouponUse);
-        pWriter.Write(CouponUsePacketMode.BeautyCoupon);
+        pWriter.Write(Mode.BeautyCoupon);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteLong(itemUid);
         return pWriter;

--- a/MapleServer2/Packets/CubePacket.cs
+++ b/MapleServer2/Packets/CubePacket.cs
@@ -7,9 +7,9 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public static class ResponseCubePacket
+public static class CubePacket
 {
-    private enum ResponseCubePacketMode : byte
+    private enum Mode : byte
     {
         LoadFurnishingItem = 0x1,
         EnablePlotFurnishing = 0x2,
@@ -55,7 +55,7 @@ public static class ResponseCubePacket
     public static PacketWriter LoadFurnishingItem(IFieldObject<Player> player, int itemId, long itemUid, Item item = null)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.LoadFurnishingItem);
+        pWriter.Write(Mode.LoadFurnishingItem);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteInt(itemId);
         pWriter.WriteLong(itemUid);
@@ -72,7 +72,7 @@ public static class ResponseCubePacket
     public static PacketWriter EnablePlotFurnishing(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.EnablePlotFurnishing);
+        pWriter.Write(Mode.EnablePlotFurnishing);
         pWriter.WriteByte(); // disable bool
         pWriter.WriteInt(player.Account.Home.PlotNumber);
         pWriter.WriteInt(player.Account.Home.ApartmentNumber);
@@ -86,7 +86,7 @@ public static class ResponseCubePacket
     public static PacketWriter CompletePurchase()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.CompletePurchase);
+        pWriter.Write(Mode.CompletePurchase);
 
         return pWriter;
     }
@@ -94,7 +94,7 @@ public static class ResponseCubePacket
     public static PacketWriter RemovePlot(int plotNumber, int apartmentNumber)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ForfeitPlot);
+        pWriter.Write(Mode.ForfeitPlot);
         pWriter.WriteByte();
         pWriter.WriteInt(plotNumber);
         pWriter.WriteInt(apartmentNumber);
@@ -106,7 +106,7 @@ public static class ResponseCubePacket
     public static PacketWriter RemovePlot2(int plotId, int plotNumber)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ForfeitPlot2);
+        pWriter.Write(Mode.ForfeitPlot2);
         pWriter.WriteByte(72); // unknown
         pWriter.WriteShort();
         pWriter.WriteInt(plotId);
@@ -118,7 +118,7 @@ public static class ResponseCubePacket
     public static PacketWriter PlaceFurnishing(IFieldObject<Cube> cube, int ownerObjectId, int fieldPlayerObjectId, bool sendOnlyObjectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.PlaceFurnishing);
+        pWriter.Write(Mode.PlaceFurnishing);
         pWriter.WriteBool(sendOnlyObjectId);
         pWriter.WriteInt(ownerObjectId);
         pWriter.WriteInt(fieldPlayerObjectId);
@@ -153,7 +153,7 @@ public static class ResponseCubePacket
     public static PacketWriter PlaceLiftable(IFieldObject<LiftableObject> fieldLiftableObject, int ownerObjectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.PlaceFurnishing);
+        pWriter.Write(Mode.PlaceFurnishing);
         pWriter.WriteBool(false);
         pWriter.WriteInt(ownerObjectId);
         pWriter.WriteInt(ownerObjectId);
@@ -177,7 +177,7 @@ public static class ResponseCubePacket
     public static PacketWriter CantPlaceHere(int fieldPlayerObjectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.PlaceFurnishing);
+        pWriter.Write(Mode.PlaceFurnishing);
         pWriter.WriteByte(44);
         pWriter.WriteInt(fieldPlayerObjectId);
         pWriter.WriteInt(fieldPlayerObjectId);
@@ -188,7 +188,7 @@ public static class ResponseCubePacket
     public static PacketWriter RemoveCube(int ownerObjectId, int fieldPlayerObjectId, CoordB coord)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.RemoveCube);
+        pWriter.Write(Mode.RemoveCube);
         pWriter.WriteByte();
         pWriter.WriteInt(ownerObjectId);
         pWriter.WriteInt(fieldPlayerObjectId);
@@ -202,7 +202,7 @@ public static class ResponseCubePacket
     public static PacketWriter RotateCube(IFieldObject<Player> player, IFieldObject<Cube> cube)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.RotateCube);
+        pWriter.Write(Mode.RotateCube);
         pWriter.WriteByte();
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteInt(player.ObjectId);
@@ -216,7 +216,7 @@ public static class ResponseCubePacket
     public static PacketWriter ReplaceCube(int homeOwnerObjectId, int fieldPlayerObjectId, IFieldObject<Cube> newCube, bool sendOnlyObjectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ReplaceCube);
+        pWriter.Write(Mode.ReplaceCube);
         pWriter.WriteBool(sendOnlyObjectId);
         pWriter.WriteInt(homeOwnerObjectId);
         pWriter.WriteInt(fieldPlayerObjectId);
@@ -248,7 +248,7 @@ public static class ResponseCubePacket
     public static PacketWriter Pickup(IFieldActor<Player> fieldPlayer, int weaponId, CoordB coords)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.Pickup);
+        pWriter.Write(Mode.Pickup);
         pWriter.WriteZero(1);
         pWriter.WriteInt(fieldPlayer.ObjectId);
         pWriter.Write(coords);
@@ -262,7 +262,7 @@ public static class ResponseCubePacket
     public static PacketWriter Drop(IFieldObject<Player> player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.Drop);
+        pWriter.Write(Mode.Drop);
         pWriter.WriteZero(1);
         pWriter.WriteInt(player.ObjectId);
 
@@ -272,7 +272,7 @@ public static class ResponseCubePacket
     public static PacketWriter LoadHome(int playerObjectId, Home home)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.LoadHome);
+        pWriter.Write(Mode.LoadHome);
         pWriter.WriteInt(playerObjectId);
         pWriter.WriteInt(home?.MapId ?? 0);
         pWriter.WriteInt(home?.PlotMapId ?? 0);
@@ -289,7 +289,7 @@ public static class ResponseCubePacket
     public static PacketWriter HomeName(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.HomeName);
+        pWriter.Write(Mode.HomeName);
         pWriter.WriteByte();
         pWriter.WriteLong(player.AccountId);
         pWriter.WriteInt(player.Account.Home.PlotNumber);
@@ -302,7 +302,7 @@ public static class ResponseCubePacket
     public static PacketWriter PurchasePlot(int plotNumber, int apartmentNumber, long expiration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.PurchasePlot);
+        pWriter.Write(Mode.PurchasePlot);
         pWriter.WriteInt(plotNumber);
         pWriter.WriteInt(apartmentNumber);
         pWriter.WriteByte(1);
@@ -314,7 +314,7 @@ public static class ResponseCubePacket
     public static PacketWriter ForfeitPlot(int plotNumber, int apartmentNumber, long expiration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.PurchasePlot);
+        pWriter.Write(Mode.PurchasePlot);
         pWriter.WriteInt(plotNumber);
         pWriter.WriteInt(apartmentNumber);
         pWriter.WriteByte(4);
@@ -326,7 +326,7 @@ public static class ResponseCubePacket
     public static PacketWriter ChangePassword()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ChangePassword);
+        pWriter.Write(Mode.ChangePassword);
         pWriter.WriteByte();
 
         return pWriter;
@@ -335,7 +335,7 @@ public static class ResponseCubePacket
     public static PacketWriter ArchitectScoreExpiration(long accountId, long now)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ArchitectScoreExpiration);
+        pWriter.Write(Mode.ArchitectScoreExpiration);
         pWriter.WriteByte();
         pWriter.WriteLong(accountId);
         pWriter.WriteLong(now);
@@ -346,7 +346,7 @@ public static class ResponseCubePacket
     public static PacketWriter KickEveryone()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.KickEveryone);
+        pWriter.Write(Mode.KickEveryone);
 
         return pWriter;
     }
@@ -354,7 +354,7 @@ public static class ResponseCubePacket
     public static PacketWriter UpdateArchitectScore(int current, int total)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.UpdateArchitectScore);
+        pWriter.Write(Mode.UpdateArchitectScore);
         pWriter.WriteInt(current);
         pWriter.WriteInt(total);
 
@@ -364,7 +364,7 @@ public static class ResponseCubePacket
     public static PacketWriter HomeDescription(string description)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.HomeDescription);
+        pWriter.Write(Mode.HomeDescription);
         pWriter.WriteByte();
         pWriter.WriteUnicodeString(description);
 
@@ -374,7 +374,7 @@ public static class ResponseCubePacket
     public static PacketWriter ReturnMap(int mapId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ReturnMap);
+        pWriter.Write(Mode.ReturnMap);
         pWriter.WriteInt(mapId);
 
         return pWriter;
@@ -383,7 +383,7 @@ public static class ResponseCubePacket
     public static PacketWriter BillPopup(Dictionary<byte, long> cubeCosts, int cubeCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.LoadLayout);
+        pWriter.Write(Mode.LoadLayout);
         pWriter.WriteByte((byte) cubeCosts.Keys.Count);
         pWriter.WriteInt(cubeCount);
         foreach ((byte key, long value) in cubeCosts)
@@ -398,7 +398,7 @@ public static class ResponseCubePacket
     public static PacketWriter IncreaseSize(byte size)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.IncreaseSize);
+        pWriter.Write(Mode.IncreaseSize);
         pWriter.WriteByte();
         pWriter.WriteByte(size);
 
@@ -408,7 +408,7 @@ public static class ResponseCubePacket
     public static PacketWriter DecreaseSize(byte size)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.DecreaseSize);
+        pWriter.Write(Mode.DecreaseSize);
         pWriter.WriteByte();
         pWriter.WriteByte(size);
 
@@ -418,7 +418,7 @@ public static class ResponseCubePacket
     public static PacketWriter DecorationScore(Home home)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.Rewards);
+        pWriter.Write(Mode.Rewards);
         pWriter.WriteLong(home?.AccountId ?? 0);
         pWriter.WriteLong(home?.DecorationRewardTimestamp ?? 0);
         pWriter.WriteLong(home?.DecorationLevel ?? 1);
@@ -438,7 +438,7 @@ public static class ResponseCubePacket
     public static PacketWriter EnablePermission(HomePermission permission, bool enabled)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.EnablePermission);
+        pWriter.Write(Mode.EnablePermission);
         pWriter.Write(permission);
         pWriter.WriteBool(enabled);
 
@@ -448,7 +448,7 @@ public static class ResponseCubePacket
     public static PacketWriter SetPermission(HomePermission permission, byte setting)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.SetPermission);
+        pWriter.Write(Mode.SetPermission);
         pWriter.Write(permission);
         pWriter.WriteByte(setting);
 
@@ -458,7 +458,7 @@ public static class ResponseCubePacket
     public static PacketWriter IncreaseHeight(byte height)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.IncreaseHeight);
+        pWriter.Write(Mode.IncreaseHeight);
         pWriter.WriteByte();
         pWriter.WriteByte(height);
 
@@ -468,7 +468,7 @@ public static class ResponseCubePacket
     public static PacketWriter DecreaseHeight(byte height)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.DecreaseHeight);
+        pWriter.Write(Mode.DecreaseHeight);
         pWriter.WriteByte();
         pWriter.WriteByte(height);
 
@@ -478,7 +478,7 @@ public static class ResponseCubePacket
     public static PacketWriter SaveLayout(long accountId, int layoutId, string layoutName, long timestamp)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.SaveLayout);
+        pWriter.Write(Mode.SaveLayout);
         pWriter.WriteByte();
         pWriter.WriteLong(accountId);
         pWriter.WriteInt(layoutId);
@@ -491,7 +491,7 @@ public static class ResponseCubePacket
     public static PacketWriter ChangeBackground(byte lighthing)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ChangeLighting);
+        pWriter.Write(Mode.ChangeLighting);
         pWriter.WriteByte();
         pWriter.WriteByte(lighthing);
 
@@ -501,7 +501,7 @@ public static class ResponseCubePacket
     public static PacketWriter ChangeLighting(byte background)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ChangeBackground);
+        pWriter.Write(Mode.ChangeBackground);
         pWriter.WriteByte();
         pWriter.WriteByte(background);
 
@@ -511,7 +511,7 @@ public static class ResponseCubePacket
     public static PacketWriter UpdateBuildingPermissions(long targetAccountId, long ownerAccountId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.GiveBuildingPermission);
+        pWriter.Write(Mode.GiveBuildingPermission);
         pWriter.WriteLong(targetAccountId);
         pWriter.WriteLong(ownerAccountId);
         pWriter.WriteLong();
@@ -523,7 +523,7 @@ public static class ResponseCubePacket
     public static PacketWriter ChangeCamera(byte camera)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.ChangeCamera);
+        pWriter.Write(Mode.ChangeCamera);
         pWriter.WriteByte();
         pWriter.WriteByte(camera);
 
@@ -533,7 +533,7 @@ public static class ResponseCubePacket
     public static PacketWriter SendWarehouseItems(List<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.LoadWarehouseItems);
+        pWriter.Write(Mode.LoadWarehouseItems);
         pWriter.WriteShort(3);
         pWriter.WriteInt(items.Count);
         foreach (Item item in items)
@@ -548,7 +548,7 @@ public static class ResponseCubePacket
     public static PacketWriter UpdateBudget(Home home)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.UpdateBudget);
+        pWriter.Write(Mode.UpdateBudget);
         pWriter.WriteByte();
         pWriter.WriteLong(home.Mesos);
         pWriter.WriteLong(home.Merets);
@@ -559,7 +559,7 @@ public static class ResponseCubePacket
     public static PacketWriter AddBuildingPermission(long accountId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.AddBuildingPermission);
+        pWriter.Write(Mode.AddBuildingPermission);
         pWriter.WriteByte();
         pWriter.WriteLong(accountId);
 
@@ -569,7 +569,7 @@ public static class ResponseCubePacket
     public static PacketWriter RemoveBuildingPermission(long accountId, string characterName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.RemoveBuildingPermission);
+        pWriter.Write(Mode.RemoveBuildingPermission);
         pWriter.WriteByte();
         pWriter.WriteLong(accountId);
         pWriter.WriteUnicodeString(characterName);
@@ -580,7 +580,7 @@ public static class ResponseCubePacket
     public static PacketWriter UpdateHomeSizeAndHeight(byte size, byte height)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseCube);
-        pWriter.Write(ResponseCubePacketMode.UpdateSizeHeight);
+        pWriter.Write(Mode.UpdateSizeHeight);
         pWriter.WriteByte();
         pWriter.WriteByte(size);
         pWriter.WriteByte(height);

--- a/MapleServer2/Packets/DungeonHelperPacket.cs
+++ b/MapleServer2/Packets/DungeonHelperPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class DungeonHelperPacket
 {
-    private enum DungeonHelperPacketMode : byte
+    private enum Mode : byte
     {
         BroadcastAssist = 0x0,
         DisplayVetAndRookie = 0x1
@@ -15,7 +15,7 @@ public static class DungeonHelperPacket
     public static PacketWriter BroadcastAssist(Party party, int dungeonId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.DungeonHelper);
-        pWriter.Write(DungeonHelperPacketMode.BroadcastAssist);
+        pWriter.Write(Mode.BroadcastAssist);
         WriteDungeonHelperParty(pWriter, party, dungeonId);
         return pWriter;
     }
@@ -23,7 +23,7 @@ public static class DungeonHelperPacket
     public static PacketWriter DisplayVetAndRookie(Party party, int dungeonId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.DungeonHelper);
-        pWriter.Write(DungeonHelperPacketMode.DisplayVetAndRookie);
+        pWriter.Write(Mode.DisplayVetAndRookie);
         pWriter.WriteByte(); // rookie count
         pWriter.WriteByte(); // veteran count
         WriteDungeonHelperParty(pWriter, party, dungeonId);

--- a/MapleServer2/Packets/DungeonPacket.cs
+++ b/MapleServer2/Packets/DungeonPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class DungeonPacket
 {
-    private enum DungeonPacketMode : byte
+    private enum Mode : byte
     {
         DungeonInfo = 0x6,
         UpdateDungeonInfo = 0x7
@@ -14,7 +14,7 @@ public static class DungeonPacket
     public static PacketWriter DungeonInfo(int dungeonId, byte weeklyClearCountMax, byte addRewards, int clearCount, short lifetimeRecord, byte toggle)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.DungeonRoom);
-        pWriter.Write(DungeonPacketMode.DungeonInfo);
+        pWriter.Write(Mode.DungeonInfo);
         pWriter.WriteInt(dungeonId);
         pWriter.WriteLong(); //timestamp
         pWriter.WriteByte(weeklyClearCountMax);
@@ -34,7 +34,7 @@ public static class DungeonPacket
     public static PacketWriter UpdateDungeonInfo(byte mode, int dungeonId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.DungeonRoom);
-        pWriter.Write(DungeonPacketMode.UpdateDungeonInfo);
+        pWriter.Write(Mode.UpdateDungeonInfo);
         pWriter.WriteByte(mode); //05 = favorite, 04 = become veteran
         pWriter.WriteInt(dungeonId);
         return pWriter;

--- a/MapleServer2/Packets/EmotePacket.cs
+++ b/MapleServer2/Packets/EmotePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class EmotePacket
 {
-    private enum EmotePacketMode : byte
+    private enum Mode : byte
     {
         LoadEmotes = 0x0,
         LearnEmote = 0x1
@@ -15,7 +15,7 @@ public static class EmotePacket
     public static PacketWriter LoadEmotes(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Emotion);
-        pWriter.Write(EmotePacketMode.LoadEmotes);
+        pWriter.Write(Mode.LoadEmotes);
         pWriter.WriteInt(player.Emotes.Count);
         foreach (int emoteId in player.Emotes)
         {
@@ -29,7 +29,7 @@ public static class EmotePacket
     public static PacketWriter LearnEmote(int emoteId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Emotion);
-        pWriter.Write(EmotePacketMode.LearnEmote);
+        pWriter.Write(Mode.LearnEmote);
         pWriter.WriteInt(emoteId);
         pWriter.WriteInt(1); // quantity
         pWriter.WriteLong();

--- a/MapleServer2/Packets/EnchantScrollPacket.cs
+++ b/MapleServer2/Packets/EnchantScrollPacket.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Packets;
 
 public static class EnchantScrollPacket
 {
-    private enum EnchantScrollMode : byte
+    private enum Mode : byte
     {
         OpenWindow = 0x0,
         AddItem = 0x1,
@@ -19,7 +19,7 @@ public static class EnchantScrollPacket
     public static PacketWriter OpenWindow(long itemUid, EnchantScrollMetadata metadata, float successRate)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.EnchantScroll);
-        pWriter.Write(EnchantScrollMode.OpenWindow);
+        pWriter.Write(Mode.OpenWindow);
         pWriter.WriteLong(itemUid);
         pWriter.Write(metadata.ScrollType);
         pWriter.WriteBool(false); // untradeable reminder
@@ -49,7 +49,7 @@ public static class EnchantScrollPacket
     public static PacketWriter AddItem(long itemUid, Dictionary<StatAttribute, ItemStat> enchantStats)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.EnchantScroll);
-        pWriter.Write(EnchantScrollMode.AddItem);
+        pWriter.Write(Mode.AddItem);
         pWriter.WriteLong(itemUid);
         pWriter.WriteShort(1);
         List<BasicStat> stats = enchantStats.Values.OfType<BasicStat>().ToList();
@@ -66,7 +66,7 @@ public static class EnchantScrollPacket
     public static PacketWriter UseScroll(short errorId, Item item = null)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.EnchantScroll);
-        pWriter.Write(EnchantScrollMode.UseScroll);
+        pWriter.Write(Mode.UseScroll);
         pWriter.WriteShort(errorId);
         if (item is not null)
         {

--- a/MapleServer2/Packets/EnterUgcMapPacket.cs
+++ b/MapleServer2/Packets/EnterUgcMapPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class EnterUgcMapPacket
 {
-    private enum EnterUgcMapMode : byte
+    private enum Mode : byte
     {
         RequestPassword = 0x03,
         WrongPassword = 0x04
@@ -14,7 +14,7 @@ public static class EnterUgcMapPacket
     public static PacketWriter RequestPassword(long accountId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.EnterUGCMap);
-        pWriter.Write(EnterUgcMapMode.RequestPassword);
+        pWriter.Write(Mode.RequestPassword);
         pWriter.WriteInt();
         pWriter.WriteLong();
         pWriter.WriteLong(accountId);
@@ -27,7 +27,7 @@ public static class EnterUgcMapPacket
     public static PacketWriter WrongPassword(long accountId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.EnterUGCMap);
-        pWriter.Write(EnterUgcMapMode.WrongPassword);
+        pWriter.Write(Mode.WrongPassword);
         pWriter.WriteInt();
         pWriter.WriteLong();
         pWriter.WriteLong(accountId);

--- a/MapleServer2/Packets/FieldEnterPacket.cs
+++ b/MapleServer2/Packets/FieldEnterPacket.cs
@@ -4,7 +4,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public static class RequestFieldEnterPacket
+public static class FieldEnterPacket
 {
     public static PacketWriter RequestEnter(IFieldActor<Player> fieldPlayer)
     {

--- a/MapleServer2/Packets/FieldObjectPacket.cs
+++ b/MapleServer2/Packets/FieldObjectPacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class FieldObjectPacket
 {
-    private enum FieldObjectMode : byte
+    private enum Mode : byte
     {
         LoadPlayer = 0x03,
         RemovePlayer = 0x04,
@@ -23,7 +23,7 @@ public static class FieldObjectPacket
     {
         Player player = fieldPlayer.Value;
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.LoadPlayer);
+        pWriter.Write(Mode.LoadPlayer);
         pWriter.WriteInt(fieldPlayer.ObjectId);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteLong(player.AccountId);
@@ -52,7 +52,7 @@ public static class FieldObjectPacket
     public static PacketWriter RemovePlayer(IFieldObject<Player> fieldPlayer)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.RemovePlayer);
+        pWriter.Write(Mode.RemovePlayer);
         pWriter.WriteInt(fieldPlayer.ObjectId);
 
         return pWriter;
@@ -62,7 +62,7 @@ public static class FieldObjectPacket
     {
         FieldObjectUpdate flag = FieldObjectUpdate.Move | FieldObjectUpdate.Animate;
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.UpdateEntity);
+        pWriter.Write(Mode.UpdateEntity);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteByte((byte) flag);
 
@@ -110,7 +110,7 @@ public static class FieldObjectPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
 
-        pWriter.Write(FieldObjectMode.UpdateEntity);
+        pWriter.Write(Mode.UpdateEntity);
         pWriter.WriteInt(player.FieldPlayer.ObjectId);
         pWriter.Write(FieldObjectUpdate.Level);
         pWriter.WriteShort(player.Levels.Level);
@@ -121,7 +121,7 @@ public static class FieldObjectPacket
     public static PacketWriter LoadNpc(IFieldObject<NpcMetadata> npc)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.LoadNpc);
+        pWriter.Write(Mode.LoadNpc);
         pWriter.WriteInt(npc.ObjectId);
         pWriter.WriteInt(npc.Value.Id);
         pWriter.WriteByte();
@@ -159,7 +159,7 @@ public static class FieldObjectPacket
     public static PacketWriter UpdateEntity(int objectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.UpdateEntity);
+        pWriter.Write(Mode.UpdateEntity);
         pWriter.WriteInt(objectId);
         pWriter.WriteByte();
         pWriter.WriteShort();
@@ -169,7 +169,7 @@ public static class FieldObjectPacket
     public static PacketWriter RemoveNpc(IFieldObject<NpcMetadata> npc)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.RemoveNpc);
+        pWriter.Write(Mode.RemoveNpc);
         pWriter.WriteInt(npc.ObjectId);
         return pWriter;
     }
@@ -177,7 +177,7 @@ public static class FieldObjectPacket
     public static PacketWriter MoveNpc(IFieldObject<NpcMetadata> npc)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldObject);
-        pWriter.Write(FieldObjectMode.MoveNpc);
+        pWriter.Write(Mode.MoveNpc);
         pWriter.WriteInt(npc.ObjectId);
         pWriter.WriteByte();
         pWriter.Write(npc.Coord);

--- a/MapleServer2/Packets/FieldPortalPacket.cs
+++ b/MapleServer2/Packets/FieldPortalPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class FieldPortalPacket
 {
-    private enum PortalType : byte
+    private enum Mode : byte
     {
         AddPortal = 0x00,
         RemovePortal = 0x01,
@@ -21,7 +21,7 @@ public static class FieldPortalPacket
         coord.Z -= 75; // Looks like every portal coord is offset by 75
 
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldPortal);
-        pWriter.Write(PortalType.AddPortal);
+        pWriter.Write(Mode.AddPortal);
         pWriter.WriteInt(portal.Id);
         pWriter.WriteBool(portal.IsVisible);
         pWriter.WriteBool(portal.IsEnabled);
@@ -49,7 +49,7 @@ public static class FieldPortalPacket
     public static PacketWriter RemovePortal(Portal portal)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldPortal);
-        pWriter.Write(PortalType.RemovePortal);
+        pWriter.Write(Mode.RemovePortal);
         pWriter.WriteInt(portal.Id);
 
         return pWriter;
@@ -58,7 +58,7 @@ public static class FieldPortalPacket
     public static PacketWriter UpdatePortal(IFieldObject<Portal> portal)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldPortal);
-        pWriter.Write(PortalType.UpdatePortal);
+        pWriter.Write(Mode.UpdatePortal);
         pWriter.WriteInt(portal.Value.Id);
         pWriter.WriteBool(portal.Value.IsVisible);
         pWriter.WriteBool(portal.Value.IsEnabled);

--- a/MapleServer2/Packets/FieldPropertyPacket.cs
+++ b/MapleServer2/Packets/FieldPropertyPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class FieldPropertyPacket
 {
-    private enum FieldPropertyMode : byte
+    private enum Mode : byte
     {
         Gravity = 0x01,
         SightRange = 0x06,
@@ -21,7 +21,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.Gravity);
+        pWriter.Write(Mode.Gravity);
         pWriter.WriteFloat(value);
 
         return pWriter;
@@ -31,7 +31,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.Weather);
+        pWriter.Write(Mode.Weather);
         pWriter.WriteByte((byte) weather);
 
         return pWriter;
@@ -41,7 +41,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.AmbientLight);
+        pWriter.Write(Mode.AmbientLight);
         pWriter.WriteByte(r);
         pWriter.WriteByte(g);
         pWriter.WriteByte(b);
@@ -53,7 +53,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.DirectionalLight);
+        pWriter.Write(Mode.DirectionalLight);
         pWriter.WriteByte(r);
         pWriter.WriteByte(g);
         pWriter.WriteByte(b);
@@ -68,7 +68,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.FreeCamera);
+        pWriter.Write(Mode.FreeCamera);
         pWriter.WriteBool(enable);
 
         return pWriter;
@@ -78,7 +78,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.SightRange);
+        pWriter.Write(Mode.SightRange);
         pWriter.WriteFloat(900); // radius
         pWriter.WriteFloat(); // these 3 floats control some kind of fade in/out
         pWriter.WriteFloat();
@@ -94,7 +94,7 @@ public static class FieldPropertyPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldProperty);
         pWriter.WriteByte(1);
-        pWriter.Write(FieldPropertyMode.SightRange);
+        pWriter.Write(Mode.SightRange);
         pWriter.WriteFloat(); // radius
         pWriter.WriteFloat(); // these 3 floats control some kind of fade in/out
         pWriter.WriteFloat();

--- a/MapleServer2/Packets/FieldWarPacket.cs
+++ b/MapleServer2/Packets/FieldWarPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class FieldWarPacket
 {
-    private enum FieldWarMode : byte
+    private enum Mode : byte
     {
         LegionPopup = 0x0
     }
@@ -13,7 +13,7 @@ public static class FieldWarPacket
     public static PacketWriter LegionPopup(int fieldWarId, long epochTime)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FieldWar);
-        pWriter.Write(FieldWarMode.LegionPopup);
+        pWriter.Write(Mode.LegionPopup);
         pWriter.WriteInt(fieldWarId);
         pWriter.WriteLong(epochTime);
         return pWriter;

--- a/MapleServer2/Packets/FireworksPacket.cs
+++ b/MapleServer2/Packets/FireworksPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class FireWorksPacket
 {
-    private enum FireworksPacketMode : byte
+    private enum Mode : byte
     {
         TreasureChest = 0x4,
         Gacha = 0x5
@@ -15,7 +15,7 @@ public static class FireWorksPacket
     public static PacketWriter TreasureChest(int itemId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fireworks);
-        pWriter.Write(FireworksPacketMode.TreasureChest);
+        pWriter.Write(Mode.TreasureChest);
         pWriter.WriteInt(itemId);
         return pWriter;
     }
@@ -23,7 +23,7 @@ public static class FireWorksPacket
     public static PacketWriter Gacha(List<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fireworks);
-        pWriter.Write(FireworksPacketMode.Gacha);
+        pWriter.Write(Mode.Gacha);
         pWriter.WriteInt(items.Count);
         foreach (Item item in items)
         {

--- a/MapleServer2/Packets/FishingPacket.cs
+++ b/MapleServer2/Packets/FishingPacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class FishingPacket
 {
-    private enum FishingPacketMode : byte
+    private enum Mode : byte
     {
         PrepareFishing = 0x0,
         Stop = 0x1,
@@ -24,7 +24,7 @@ public static class FishingPacket
     public static PacketWriter PrepareFishing(long rodItemUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.PrepareFishing);
+        pWriter.Write(Mode.PrepareFishing);
         pWriter.WriteLong(rodItemUid);
         return pWriter;
     }
@@ -32,14 +32,14 @@ public static class FishingPacket
     public static PacketWriter Stop()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.Stop);
+        pWriter.Write(Mode.Stop);
         return pWriter;
     }
 
     public static PacketWriter Notice(short notice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteShort(notice);
         return pWriter;
     }
@@ -47,7 +47,7 @@ public static class FishingPacket
     public static PacketWriter IncreaseMastery(MasteryType type, int fishId, int exp)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.IncreaseMastery);
+        pWriter.Write(Mode.IncreaseMastery);
         pWriter.WriteInt(fishId);
         pWriter.WriteInt(exp);
         pWriter.WriteInt((int) type);
@@ -57,7 +57,7 @@ public static class FishingPacket
     public static PacketWriter LoadFishTiles(List<MapBlock> tiles, int reduceTime)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.LoadFishTiles);
+        pWriter.Write(Mode.LoadFishTiles);
         pWriter.WriteByte();
         pWriter.WriteInt(tiles.Count);
         foreach (MapBlock tile in tiles)
@@ -75,7 +75,7 @@ public static class FishingPacket
     public static PacketWriter CatchItem(List<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.CatchItem);
+        pWriter.Write(Mode.CatchItem);
         pWriter.WriteInt(items.Count);
 
         foreach (Item item in items)
@@ -90,7 +90,7 @@ public static class FishingPacket
     public static PacketWriter LoadAlbum(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.LoadAlbum);
+        pWriter.Write(Mode.LoadAlbum);
         pWriter.WriteInt(player.FishAlbum.Count);
         foreach ((int _, Fishing fishing) in player.FishAlbum)
         {
@@ -104,7 +104,7 @@ public static class FishingPacket
     public static PacketWriter CatchFish(Player player, FishMetadata fish, int fishSize, bool success)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.CatchFish);
+        pWriter.Write(Mode.CatchFish);
         pWriter.WriteInt(fish.Id);
         pWriter.WriteInt(fishSize);
         pWriter.WriteBool(success);
@@ -124,7 +124,7 @@ public static class FishingPacket
     public static PacketWriter Start(int fishingTick, bool minigame)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Fishing);
-        pWriter.Write(FishingPacketMode.Start);
+        pWriter.Write(Mode.Start);
         pWriter.WriteBool(minigame);
         pWriter.WriteInt(fishingTick);
         return pWriter;

--- a/MapleServer2/Packets/FunctionCubePacket.cs
+++ b/MapleServer2/Packets/FunctionCubePacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public class FunctionCubePacket
 {
-    private enum FunctionCubeMode : byte
+    private enum Mode : byte
     {
         SendCubes = 0x02,
         Add = 0x03,
@@ -21,7 +21,7 @@ public class FunctionCubePacket
     {
         PacketWriter packetWriter = PacketWriter.Of(SendOp.FunctionCube);
 
-        packetWriter.Write(FunctionCubeMode.SendCubes);
+        packetWriter.Write(Mode.SendCubes);
         packetWriter.WriteInt(cubes.Count);
         foreach (Cube cube in cubes)
         {
@@ -47,7 +47,7 @@ public class FunctionCubePacket
     {
         PacketWriter packetWriter = PacketWriter.Of(SendOp.FunctionCube);
 
-        packetWriter.Write(FunctionCubeMode.Add);
+        packetWriter.Write(Mode.Add);
         packetWriter.WriteUnicodeString($"4_{coordB.AsHexadecimal()}");
         packetWriter.WriteInt(status);
         packetWriter.WriteByte(unkByte);
@@ -59,7 +59,7 @@ public class FunctionCubePacket
     {
         PacketWriter packetWriter = PacketWriter.Of(SendOp.FunctionCube);
 
-        packetWriter.Write(FunctionCubeMode.Furniture);
+        packetWriter.Write(Mode.Furniture);
         packetWriter.WriteLong(characterId);
         packetWriter.WriteUnicodeString($"4_{coordB.AsHexadecimal()}");
         packetWriter.WriteBool(inUse);
@@ -71,7 +71,7 @@ public class FunctionCubePacket
     {
         PacketWriter packetWriter = PacketWriter.Of(SendOp.FunctionCube);
 
-        packetWriter.Write(FunctionCubeMode.SuccessLifeSkill);
+        packetWriter.Write(Mode.SuccessLifeSkill);
         packetWriter.WriteLong(characterId);
         packetWriter.WriteUnicodeString($"4_{coordB.AsHexadecimal()}");
         packetWriter.WriteLong(TimeInfo.Now());
@@ -84,7 +84,7 @@ public class FunctionCubePacket
     {
         PacketWriter packetWriter = PacketWriter.Of(SendOp.FunctionCube);
 
-        packetWriter.Write(FunctionCubeMode.FailLifeSkill);
+        packetWriter.Write(Mode.FailLifeSkill);
         packetWriter.WriteLong(characterId);
         packetWriter.WriteUnicodeString($"4_{coordB.AsHexadecimal()}");
         packetWriter.WriteLong(TimeInfo.Now());

--- a/MapleServer2/Packets/FurnishingInventoryPacket.cs
+++ b/MapleServer2/Packets/FurnishingInventoryPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class FurnishingInventoryPacket
 {
-    private enum FurnishingInventoryPacketMode : byte
+    private enum Mode : byte
     {
         StartList = 0x0,
         Load = 0x1,
@@ -17,7 +17,7 @@ public static class FurnishingInventoryPacket
     public static PacketWriter StartList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FurnishingInventory);
-        pWriter.Write(FurnishingInventoryPacketMode.StartList);
+        pWriter.Write(Mode.StartList);
 
         return pWriter;
     }
@@ -25,7 +25,7 @@ public static class FurnishingInventoryPacket
     public static PacketWriter Load(Cube cube)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FurnishingInventory);
-        pWriter.Write(FurnishingInventoryPacketMode.Load);
+        pWriter.Write(Mode.Load);
         pWriter.WriteInt(cube.Item.Id);
         pWriter.WriteLong(cube.Uid);
         pWriter.WriteLong(); // expire timestamp for ugc items
@@ -41,7 +41,7 @@ public static class FurnishingInventoryPacket
     public static PacketWriter Remove(Cube cube)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FurnishingInventory);
-        pWriter.Write(FurnishingInventoryPacketMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong(cube.Uid);
 
         return pWriter;
@@ -50,7 +50,7 @@ public static class FurnishingInventoryPacket
     public static PacketWriter EndList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.FurnishingInventory);
-        pWriter.Write(FurnishingInventoryPacketMode.EndList);
+        pWriter.Write(Mode.EndList);
 
         return pWriter;
     }

--- a/MapleServer2/Packets/GameEventUserValuePacket.cs
+++ b/MapleServer2/Packets/GameEventUserValuePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class GameEventUserValuePacket
 {
-    private enum GameEventUserValuePacketMode : byte
+    private enum Mode : byte
     {
         LoadValues = 0x0,
         UpdateValue = 0x1,
@@ -16,7 +16,7 @@ public static class GameEventUserValuePacket
     public static PacketWriter LoadValues(List<GameEventUserValue> userValues)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GameEventUserValue);
-        pWriter.Write(GameEventUserValuePacketMode.LoadValues);
+        pWriter.Write(Mode.LoadValues);
         pWriter.WriteByte();
         pWriter.WriteInt(userValues.Count);
 
@@ -30,7 +30,7 @@ public static class GameEventUserValuePacket
     public static PacketWriter UpdateValue(GameEventUserValue userValue)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GameEventUserValue);
-        pWriter.Write(GameEventUserValuePacketMode.UpdateValue);
+        pWriter.Write(Mode.UpdateValue);
         pWriter.WriteByte();
         WriteUserValue(pWriter, userValue);
         return pWriter;

--- a/MapleServer2/Packets/GemPacket.cs
+++ b/MapleServer2/Packets/GemPacket.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Packets;
 
 public static class GemPacket
 {
-    private enum GemMode : byte
+    private enum Mode : byte
     {
         EquipItem = 0x00,
         UnequipItem = 0x01,
@@ -30,7 +30,7 @@ public static class GemPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Gem);
 
-        pWriter.Write(GemMode.EquipItem);
+        pWriter.Write(Mode.EquipItem);
         pWriter.WriteInt(session.Player.FieldPlayer.ObjectId);
         pWriter.WriteInt(item.Id);
         pWriter.WriteLong(item.Uid);
@@ -45,7 +45,7 @@ public static class GemPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Gem);
 
-        pWriter.Write(GemMode.UnequipItem);
+        pWriter.Write(Mode.UnequipItem);
         pWriter.WriteInt(session.Player.FieldPlayer.ObjectId);
         pWriter.Write(gemSlot);
 
@@ -56,7 +56,7 @@ public static class GemPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Gem);
 
-        pWriter.Write(GemMode.EquipError);
+        pWriter.Write(Mode.EquipError);
         pWriter.WriteShort((short) type);
 
         return pWriter;

--- a/MapleServer2/Packets/GlobalPortalPacket.cs
+++ b/MapleServer2/Packets/GlobalPortalPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class GlobalPortalPacket
 {
-    private enum GlobalPortalPacketMode : byte
+    private enum Mode : byte
     {
         Notice = 0x0,
         Clear = 0x1
@@ -15,7 +15,7 @@ public static class GlobalPortalPacket
     public static PacketWriter Notice(GlobalEvent globalEvent)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GlobalPortal);
-        pWriter.Write(GlobalPortalPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteInt(globalEvent.Id);
         pWriter.WriteInt(144); // unk. seems to either be 144 or 145
         pWriter.WriteUnicodeString("s_massive_event_message");
@@ -30,7 +30,7 @@ public static class GlobalPortalPacket
     public static PacketWriter Clear(GlobalEvent globalEvent)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GlobalPortal);
-        pWriter.Write(GlobalPortalPacketMode.Clear);
+        pWriter.Write(Mode.Clear);
         pWriter.WriteInt(globalEvent.Id);
         return pWriter;
     }

--- a/MapleServer2/Packets/GroupChatPacket.cs
+++ b/MapleServer2/Packets/GroupChatPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class GroupChatPacket
 {
-    private enum GroupChatPacketMode : byte
+    private enum Mode : byte
     {
         Update = 0x0,
         Create = 0x1,
@@ -24,7 +24,7 @@ public static class GroupChatPacket
     public static PacketWriter Update(GroupChat groupChat)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteInt(groupChat.Id);
         pWriter.WriteByte((byte) groupChat.Members.Count);
         foreach (Player member in groupChat.Members)
@@ -38,7 +38,7 @@ public static class GroupChatPacket
     public static PacketWriter Create(GroupChat groupChat)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Create);
+        pWriter.Write(Mode.Create);
         pWriter.WriteInt(groupChat.Id);
         return pWriter;
     }
@@ -46,7 +46,7 @@ public static class GroupChatPacket
     public static PacketWriter Invite(Player member, Player invitee, GroupChat groupChat)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Invite);
+        pWriter.Write(Mode.Invite);
         pWriter.WriteUnicodeString(member.Name);
         pWriter.WriteUnicodeString(invitee.Name);
         pWriter.WriteInt(groupChat.Id);
@@ -56,7 +56,7 @@ public static class GroupChatPacket
     public static PacketWriter Join(Player member, Player invitee, GroupChat groupChat)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Join);
+        pWriter.Write(Mode.Join);
         pWriter.WriteUnicodeString(member.Name);
         pWriter.WriteUnicodeString(invitee.Name);
         pWriter.WriteInt(groupChat.Id);
@@ -66,7 +66,7 @@ public static class GroupChatPacket
     public static PacketWriter Leave(GroupChat groupChat)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Leave);
+        pWriter.Write(Mode.Leave);
         pWriter.WriteInt(groupChat.Id);
         return pWriter;
     }
@@ -74,7 +74,7 @@ public static class GroupChatPacket
     public static PacketWriter UpdateGroupMembers(Player member, Player invitee, GroupChat groupChat)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.UpdateGroupMembers);
+        pWriter.Write(Mode.UpdateGroupMembers);
         pWriter.WriteInt(groupChat.Id);
         pWriter.WriteUnicodeString(member.Name);
         pWriter.WriteByte(0x1);
@@ -85,7 +85,7 @@ public static class GroupChatPacket
     public static PacketWriter LeaveNotice(GroupChat groupChat, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.LeaveNotice);
+        pWriter.Write(Mode.LeaveNotice);
         pWriter.WriteInt(groupChat.Id);
         pWriter.WriteByte();
         pWriter.WriteUnicodeString(player.Name);
@@ -95,7 +95,7 @@ public static class GroupChatPacket
     public static PacketWriter LoginNotice(GroupChat groupChat, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.LoginNotice);
+        pWriter.Write(Mode.LoginNotice);
         pWriter.WriteInt(groupChat.Id);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
@@ -104,7 +104,7 @@ public static class GroupChatPacket
     public static PacketWriter LogoutNotice(GroupChat groupChat, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.LogoutNotice);
+        pWriter.Write(Mode.LogoutNotice);
         pWriter.WriteInt(groupChat.Id);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
@@ -113,7 +113,7 @@ public static class GroupChatPacket
     public static PacketWriter Chat(GroupChat groupChat, Player player, string message)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Chat);
+        pWriter.Write(Mode.Chat);
         pWriter.WriteInt(groupChat.Id);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteUnicodeString(message);
@@ -123,7 +123,7 @@ public static class GroupChatPacket
     public static PacketWriter Error(Player player, string other, int error)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GroupChat);
-        pWriter.Write(GroupChatPacketMode.Error);
+        pWriter.Write(Mode.Error);
         pWriter.WriteByte(0x2);
         pWriter.WriteInt(error);
         pWriter.WriteUnicodeString(player.Name);

--- a/MapleServer2/Packets/GuideObjectPacket.cs
+++ b/MapleServer2/Packets/GuideObjectPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class GuideObjectPacket
 {
-    private enum GuideObjectPacketMode : byte
+    private enum Mode : byte
     {
         Add = 0x0,
         Remove = 0x1,
@@ -17,7 +17,7 @@ public static class GuideObjectPacket
     public static PacketWriter Add(IFieldObject<GuideObject> guide)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GuideObject);
-        pWriter.Write(GuideObjectPacketMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteShort(guide.Value.Type);
         pWriter.WriteInt(guide.ObjectId);
         pWriter.WriteLong(guide.Value.BoundCharacterId);
@@ -34,7 +34,7 @@ public static class GuideObjectPacket
     public static PacketWriter Remove(IFieldObject<GuideObject> guide)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GuideObject);
-        pWriter.Write(GuideObjectPacketMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteInt(guide.ObjectId);
         pWriter.WriteLong(guide.Value.BoundCharacterId);
 
@@ -44,7 +44,7 @@ public static class GuideObjectPacket
     public static PacketWriter Sync(IFieldObject<GuideObject> guide, byte unk2, byte unk3, byte unk4, byte unk5, CoordS unkCoord, short unk6, int unk7)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.GuideObject);
-        pWriter.Write(GuideObjectPacketMode.Sync);
+        pWriter.Write(Mode.Sync);
         pWriter.WriteInt(guide.ObjectId);
         pWriter.WriteByte(unk2);
         pWriter.WriteByte(unk3);

--- a/MapleServer2/Packets/GuildPacket.cs
+++ b/MapleServer2/Packets/GuildPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class GuildPacket
 {
-    private enum GuildPacketMode : byte
+    private enum Mode : byte
     {
         UpdateGuild = 0x0,
         Create = 0x1,
@@ -80,7 +80,7 @@ public static class GuildPacket
     public static PacketWriter UpdateGuild(Guild guild)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateGuild);
+        pWriter.Write(Mode.UpdateGuild);
         pWriter.WriteLong(guild.Id);
         pWriter.WriteUnicodeString(guild.Name);
         pWriter.WriteUnicodeString(guild.Emblem);
@@ -232,7 +232,7 @@ public static class GuildPacket
     public static PacketWriter Create(string guildName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.Create);
+        pWriter.Write(Mode.Create);
         pWriter.WriteByte();
         pWriter.WriteUnicodeString(guildName);
         return pWriter;
@@ -241,7 +241,7 @@ public static class GuildPacket
     public static PacketWriter DisbandConfirm()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.DisbandConfirm);
+        pWriter.Write(Mode.DisbandConfirm);
         pWriter.WriteByte();
         return pWriter;
     }
@@ -249,7 +249,7 @@ public static class GuildPacket
     public static PacketWriter InviteConfirm(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.InviteConfirm);
+        pWriter.Write(Mode.InviteConfirm);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
     }
@@ -257,7 +257,7 @@ public static class GuildPacket
     public static PacketWriter SendInvite(Player inviter, Player invitee, Guild guild)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.SendInvite);
+        pWriter.Write(Mode.SendInvite);
         pWriter.WriteLong(guild.Id);
         pWriter.WriteUnicodeString(guild.Name);
         pWriter.WriteByte();
@@ -270,7 +270,7 @@ public static class GuildPacket
     public static PacketWriter InviteResponseConfirm(Player inviter, Player invitee, Guild guild, short response)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.InviteResponseConfirm);
+        pWriter.Write(Mode.InviteResponseConfirm);
         pWriter.WriteLong(guild.Id);
         pWriter.WriteUnicodeString(guild.Name);
         pWriter.WriteShort();
@@ -283,7 +283,7 @@ public static class GuildPacket
     public static PacketWriter InviteNotification(string inviteeName, short response)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.InviteNotification);
+        pWriter.Write(Mode.InviteNotification);
         pWriter.WriteUnicodeString(inviteeName);
         pWriter.WriteShort(response);
         return pWriter;
@@ -292,14 +292,14 @@ public static class GuildPacket
     public static PacketWriter LeaveConfirm()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.LeaveConfirm);
+        pWriter.Write(Mode.LeaveConfirm);
         return pWriter;
     }
 
     public static PacketWriter KickConfirm(Player member)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.KickConfirm);
+        pWriter.Write(Mode.KickConfirm);
         pWriter.WriteUnicodeString(member.Name);
         return pWriter;
     }
@@ -307,7 +307,7 @@ public static class GuildPacket
     public static PacketWriter KickNotification(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.KickNotification);
+        pWriter.Write(Mode.KickNotification);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
     }
@@ -315,7 +315,7 @@ public static class GuildPacket
     public static PacketWriter RankChangeConfirm(string memberName, byte rank)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.RankChangeConfirm);
+        pWriter.Write(Mode.RankChangeConfirm);
         pWriter.WriteUnicodeString(memberName);
         pWriter.WriteByte(rank);
         return pWriter;
@@ -324,7 +324,7 @@ public static class GuildPacket
     public static PacketWriter UpdateMemberName(string oldName, string newName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateMemberName);
+        pWriter.Write(Mode.UpdateMemberName);
         pWriter.WriteUnicodeString(oldName);
         pWriter.WriteUnicodeString(newName);
         return pWriter;
@@ -333,14 +333,14 @@ public static class GuildPacket
     public static PacketWriter CheckInBegin()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.CheckInBegin);
+        pWriter.Write(Mode.CheckInBegin);
         return pWriter;
     }
 
     public static PacketWriter MemberBroadcastJoinNotice(GuildMember member, string inviterName, bool displayNotice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.MemberBroadcastJoinNotice);
+        pWriter.Write(Mode.MemberBroadcastJoinNotice);
         pWriter.WriteUnicodeString(inviterName);
         pWriter.WriteUnicodeString(member.Player.Name);
         pWriter.WriteBool(displayNotice);
@@ -363,7 +363,7 @@ public static class GuildPacket
     public static PacketWriter MemberLeaveNotice(Player member)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.MemberLeaveNotice);
+        pWriter.Write(Mode.MemberLeaveNotice);
         pWriter.WriteUnicodeString(member.Name);
         return pWriter;
     }
@@ -371,7 +371,7 @@ public static class GuildPacket
     public static PacketWriter KickMember(Player member, Player leader)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.KickMember);
+        pWriter.Write(Mode.KickMember);
         pWriter.WriteUnicodeString(leader.Name);
         pWriter.WriteUnicodeString(member.Name);
         return pWriter;
@@ -380,7 +380,7 @@ public static class GuildPacket
     public static PacketWriter RankChangeNotice(string leaderName, string memberName, byte rank)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.RankChangeNotice);
+        pWriter.Write(Mode.RankChangeNotice);
         pWriter.WriteUnicodeString(leaderName);
         pWriter.WriteUnicodeString(memberName);
         pWriter.WriteByte(rank);
@@ -390,7 +390,7 @@ public static class GuildPacket
     public static PacketWriter UpdatePlayerMessage(Player player, string message)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdatePlayerMessage);
+        pWriter.Write(Mode.UpdatePlayerMessage);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteUnicodeString(message);
         return pWriter;
@@ -399,7 +399,7 @@ public static class GuildPacket
     public static PacketWriter MemberLoggedIn(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.MemberLoggedIn);
+        pWriter.Write(Mode.MemberLoggedIn);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
     }
@@ -407,7 +407,7 @@ public static class GuildPacket
     public static PacketWriter MemberLoggedOff(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.MemberLoggedOff);
+        pWriter.Write(Mode.MemberLoggedOff);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteLong(TimeInfo.Now());
         return pWriter;
@@ -416,7 +416,7 @@ public static class GuildPacket
     public static PacketWriter AssignNewLeader(Player newLeader, Player oldLeader)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.AssignNewLeader);
+        pWriter.Write(Mode.AssignNewLeader);
         pWriter.WriteUnicodeString(oldLeader.Name);
         pWriter.WriteUnicodeString(newLeader.Name);
         return pWriter;
@@ -425,7 +425,7 @@ public static class GuildPacket
     public static PacketWriter GuildNoticeChange(Player player, string notice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.GuildNoticeChange);
+        pWriter.Write(Mode.GuildNoticeChange);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteByte(0x1);
         pWriter.WriteUnicodeString(notice);
@@ -435,7 +435,7 @@ public static class GuildPacket
     public static PacketWriter GuildNoticeEmblemChange(string playerName, string emblemUrl)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.GuildNoticeEmblemChange);
+        pWriter.Write(Mode.GuildNoticeEmblemChange);
         pWriter.WriteByte();
         pWriter.WriteInt();
         pWriter.WriteUnicodeString(playerName);
@@ -446,7 +446,7 @@ public static class GuildPacket
     public static PacketWriter UpdateRankNotice(Guild guild, byte rankIndex)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateRankNotice);
+        pWriter.Write(Mode.UpdateRankNotice);
         pWriter.WriteByte();
         pWriter.WriteInt();
         pWriter.WriteUnicodeString(guild.LeaderName);
@@ -460,7 +460,7 @@ public static class GuildPacket
     public static PacketWriter ListGuildUpdate(Player player, bool toggle)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ListGuildUpdate);
+        pWriter.Write(Mode.ListGuildUpdate);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteBool(toggle);
         pWriter.WriteInt();
@@ -470,7 +470,7 @@ public static class GuildPacket
     public static PacketWriter UpdateMemberLocation(string playerName, int mapId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateMemberLocation);
+        pWriter.Write(Mode.UpdateMemberLocation);
         pWriter.WriteUnicodeString(playerName);
         pWriter.WriteInt(mapId);
         return pWriter;
@@ -479,7 +479,7 @@ public static class GuildPacket
     public static PacketWriter UpdatePlayer(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdatePlayer);
+        pWriter.Write(Mode.UpdatePlayer);
         pWriter.WriteUnicodeString(player.Name);
         WriteGuildMember(pWriter, player);
         return pWriter;
@@ -488,7 +488,7 @@ public static class GuildPacket
     public static PacketWriter GuildNameChange(string newName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.GuildNameChange);
+        pWriter.Write(Mode.GuildNameChange);
         pWriter.WriteUnicodeString(newName);
         return pWriter;
     }
@@ -496,7 +496,7 @@ public static class GuildPacket
     public static PacketWriter TrophyNotice()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.TrophyNotice);
+        pWriter.Write(Mode.TrophyNotice);
         pWriter.WriteUnicodeString(); // character name
         pWriter.WriteInt(); // trophy id
         pWriter.WriteInt(); // trophy value
@@ -508,7 +508,7 @@ public static class GuildPacket
     public static PacketWriter FinishCheckIn(GuildMember member)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.FinishCheckIn);
+        pWriter.Write(Mode.FinishCheckIn);
         pWriter.WriteUnicodeString(member.Player.Name);
         pWriter.WriteLong(member.AttendanceTimestamp);
         return pWriter;
@@ -517,7 +517,7 @@ public static class GuildPacket
     public static PacketWriter BattleMatchmaking(bool success)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.BattleMatchmaking);
+        pWriter.Write(Mode.BattleMatchmaking);
         pWriter.WriteBool(success);
         return pWriter;
     }
@@ -525,7 +525,7 @@ public static class GuildPacket
     public static PacketWriter BattleApplyNotice(string playerName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.BattleApplyNotice);
+        pWriter.Write(Mode.BattleApplyNotice);
         pWriter.WriteUnicodeString(playerName);
         return pWriter;
     }
@@ -533,7 +533,7 @@ public static class GuildPacket
     public static PacketWriter BattleCancelApplyNotice(string playerName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.BattleCancelApplyNotice);
+        pWriter.Write(Mode.BattleCancelApplyNotice);
         pWriter.WriteUnicodeString(playerName);
         return pWriter;
     }
@@ -541,7 +541,7 @@ public static class GuildPacket
     public static PacketWriter SendApplication(GuildApplication application, Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.SendApplication);
+        pWriter.Write(Mode.SendApplication);
         pWriter.WriteLong(application.Id);
         pWriter.WriteLong(application.GuildId);
         pWriter.WriteLong(player.AccountId);
@@ -563,7 +563,7 @@ public static class GuildPacket
     public static PacketWriter WithdrawApplicationGuildUpdate(long applicationId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.WithdrawApplicationGuildUpdate);
+        pWriter.Write(Mode.WithdrawApplicationGuildUpdate);
         pWriter.WriteLong(applicationId);
         return pWriter;
     }
@@ -571,7 +571,7 @@ public static class GuildPacket
     public static PacketWriter ApplicationResponseBroadcastNotice(string reviewerName, string applierName, byte response, long applicationId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ApplicationResponseBroadcastNotice);
+        pWriter.Write(Mode.ApplicationResponseBroadcastNotice);
         pWriter.WriteUnicodeString(reviewerName);
         pWriter.WriteUnicodeString(applierName);
         pWriter.WriteByte(response);
@@ -582,7 +582,7 @@ public static class GuildPacket
     public static PacketWriter ApplicationResponseToApplier(string guildName, long applicationId, byte response)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ApplicationResponseToApplier);
+        pWriter.Write(Mode.ApplicationResponseToApplier);
         pWriter.WriteUnicodeString(guildName);
         pWriter.WriteLong(applicationId);
         pWriter.WriteByte(response);
@@ -592,7 +592,7 @@ public static class GuildPacket
     public static PacketWriter UpdateGuildExp(int guildExp)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateGuildExp);
+        pWriter.Write(Mode.UpdateGuildExp);
         pWriter.WriteInt(guildExp);
         return pWriter;
     }
@@ -600,7 +600,7 @@ public static class GuildPacket
     public static PacketWriter UpdateGuildFunds(int guildFunds)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateGuildFunds);
+        pWriter.Write(Mode.UpdateGuildFunds);
         pWriter.WriteInt(guildFunds);
         return pWriter;
     }
@@ -608,7 +608,7 @@ public static class GuildPacket
     public static PacketWriter UpdatePlayerContribution(GuildMember member, int contribution)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdatePlayerContribution);
+        pWriter.Write(Mode.UpdatePlayerContribution);
         pWriter.WriteUnicodeString(member.Player.Name);
         pWriter.WriteInt(contribution);
         pWriter.WriteInt(member.DailyContribution);
@@ -619,7 +619,7 @@ public static class GuildPacket
     public static PacketWriter UpgradeBuff(int buffId, int buffLevel, string playerName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpgradeBuff);
+        pWriter.Write(Mode.UpgradeBuff);
         pWriter.WriteUnicodeString(playerName);
         pWriter.WriteInt(buffId);
         pWriter.WriteInt(buffLevel);
@@ -630,7 +630,7 @@ public static class GuildPacket
     public static PacketWriter StartMinigame(string playerName, int minigameId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.StartMiniGame);
+        pWriter.Write(Mode.StartMiniGame);
         pWriter.WriteUnicodeString(playerName);
         pWriter.WriteInt(minigameId);
         pWriter.WriteInt();
@@ -640,7 +640,7 @@ public static class GuildPacket
     public static PacketWriter ChangeHouse(string playerName, int houseRank, int houseTheme)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ChangeHouse);
+        pWriter.Write(Mode.ChangeHouse);
         pWriter.WriteUnicodeString(playerName);
         pWriter.WriteInt(houseRank);
         pWriter.WriteInt(houseTheme);
@@ -650,7 +650,7 @@ public static class GuildPacket
     public static PacketWriter UpgradeService(Player player, int serviceId, int serviceLevel)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpgradeService);
+        pWriter.Write(Mode.UpgradeService);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteInt(serviceId);
         pWriter.WriteInt(serviceLevel);
@@ -660,7 +660,7 @@ public static class GuildPacket
     public static PacketWriter UpdateBannerUrl(Player player, UGC ugc)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateBannerUrl);
+        pWriter.Write(Mode.UpdateBannerUrl);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteInt(ugc.GuildPosterId);
@@ -671,7 +671,7 @@ public static class GuildPacket
     public static PacketWriter RequestMiniGameWar(bool request)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.RequestMiniGameWar);
+        pWriter.Write(Mode.RequestMiniGameWar);
         pWriter.WriteBool(request);
         pWriter.WriteByte(0x1);
         return pWriter;
@@ -680,7 +680,7 @@ public static class GuildPacket
     public static PacketWriter TransferLeaderConfirm(Player newLeader)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.TransferLeaderConfirm);
+        pWriter.Write(Mode.TransferLeaderConfirm);
         pWriter.WriteUnicodeString(newLeader.Name);
         return pWriter;
     }
@@ -688,7 +688,7 @@ public static class GuildPacket
     public static PacketWriter SubmitApplication(GuildApplication application, string guildName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.SubmitApplication);
+        pWriter.Write(Mode.SubmitApplication);
         pWriter.WriteLong(application.Id);
         pWriter.WriteUnicodeString(guildName);
         return pWriter;
@@ -697,7 +697,7 @@ public static class GuildPacket
     public static PacketWriter WithdrawApplicationPlayerUpdate(GuildApplication application, string guildName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.WithdrawApplicationPlayerUpdate);
+        pWriter.Write(Mode.WithdrawApplicationPlayerUpdate);
         pWriter.WriteLong(application.Id);
         pWriter.WriteUnicodeString(guildName);
         return pWriter;
@@ -706,7 +706,7 @@ public static class GuildPacket
     public static PacketWriter ApplicationResponse(long guildApplicationId, string applierName, byte response)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ApplicationResponse);
+        pWriter.Write(Mode.ApplicationResponse);
         pWriter.WriteLong(guildApplicationId);
         pWriter.WriteUnicodeString(applierName);
         pWriter.WriteByte(response);
@@ -716,7 +716,7 @@ public static class GuildPacket
     public static PacketWriter GuildNoticeConfirm(string notice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.GuildNoticeConfirm);
+        pWriter.Write(Mode.GuildNoticeConfirm);
         pWriter.WriteByte(0x1);
         pWriter.WriteUnicodeString(notice);
         return pWriter;
@@ -725,7 +725,7 @@ public static class GuildPacket
     public static PacketWriter ChangeEmblemUrl(string emblemUrl)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ChangeEmblemUrl);
+        pWriter.Write(Mode.ChangeEmblemUrl);
         pWriter.WriteUnicodeString(emblemUrl);
         return pWriter;
     }
@@ -733,7 +733,7 @@ public static class GuildPacket
     public static PacketWriter UpdateRankConfirm(Guild guild, byte rankIndex)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateRankConfirm);
+        pWriter.Write(Mode.UpdateRankConfirm);
         pWriter.WriteByte(rankIndex);
         pWriter.WriteByte(rankIndex);
         pWriter.WriteUnicodeString(guild.Ranks[rankIndex].Name);
@@ -744,7 +744,7 @@ public static class GuildPacket
     public static PacketWriter ListGuildConfirm(bool toggle)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ListGuildConfirm);
+        pWriter.Write(Mode.ListGuildConfirm);
         pWriter.WriteBool(toggle);
         pWriter.WriteInt();
         return pWriter;
@@ -753,14 +753,14 @@ public static class GuildPacket
     public static PacketWriter SendMail()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.SendMail);
+        pWriter.Write(Mode.SendMail);
         return pWriter;
     }
 
     public static PacketWriter UpdateGuildTag2(Player player, string guildName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateGuildTag2);
+        pWriter.Write(Mode.UpdateGuildTag2);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteUnicodeString(guildName);
         return pWriter;
@@ -769,7 +769,7 @@ public static class GuildPacket
     public static PacketWriter UpdateGuildTag(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateGuildTag);
+        pWriter.Write(Mode.UpdateGuildTag);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
     }
@@ -777,7 +777,7 @@ public static class GuildPacket
     public static PacketWriter ErrorNotice(byte errorNotice, int param = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ErrorNotice);
+        pWriter.Write(Mode.ErrorNotice);
         pWriter.WriteByte(1);
         pWriter.WriteByte(errorNotice);
         pWriter.WriteInt(param);
@@ -787,7 +787,7 @@ public static class GuildPacket
     public static PacketWriter LoadApplications(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.LoadApplications);
+        pWriter.Write(Mode.LoadApplications);
         pWriter.WriteInt(player.GuildApplications.Count);
         foreach (GuildApplication application in player.GuildApplications)
         {
@@ -815,7 +815,7 @@ public static class GuildPacket
     public static PacketWriter DisplayGuildList(List<Guild> guilds)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.DisplayGuildList);
+        pWriter.Write(Mode.DisplayGuildList);
         pWriter.WriteInt(guilds.Count);
 
         foreach (Guild guild in guilds)
@@ -841,7 +841,7 @@ public static class GuildPacket
     public static PacketWriter UseBuffNotice(int buffID)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UseBuffNotice);
+        pWriter.Write(Mode.UseBuffNotice);
         pWriter.WriteInt(buffID);
         return pWriter;
     }
@@ -849,7 +849,7 @@ public static class GuildPacket
     public static PacketWriter ActivateBuff(int buffID)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.ActivateBuff);
+        pWriter.Write(Mode.ActivateBuff);
         pWriter.WriteInt(buffID);
         return pWriter;
     }
@@ -857,7 +857,7 @@ public static class GuildPacket
     public static PacketWriter List()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.List);
+        pWriter.Write(Mode.List);
         pWriter.WriteByte(0x1);
         pWriter.WriteLong();
         pWriter.WriteLong();
@@ -874,7 +874,7 @@ public static class GuildPacket
     public static PacketWriter UpdateGuildStatsNotice(int exp, int funds)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdateGuildStatsNotice);
+        pWriter.Write(Mode.UpdateGuildStatsNotice);
         pWriter.WriteInt(exp);
         pWriter.WriteInt(funds);
         return pWriter;
@@ -883,7 +883,7 @@ public static class GuildPacket
     public static PacketWriter StartMiniGame(int minigameId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.StartMiniGame);
+        pWriter.Write(Mode.StartMiniGame);
         pWriter.WriteInt(minigameId);
         return pWriter;
     }
@@ -891,7 +891,7 @@ public static class GuildPacket
     public static PacketWriter UpdatePlayerDonation( /*int totalDonationAmount*/)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Guild);
-        pWriter.Write(GuildPacketMode.UpdatePlayerDonation);
+        pWriter.Write(Mode.UpdatePlayerDonation);
         pWriter.WriteInt(0x3); // total amount of donations today
         pWriter.WriteLong(TimeInfo.Now() + Environment.TickCount);
         return pWriter;

--- a/MapleServer2/Packets/HandshakePacket.cs
+++ b/MapleServer2/Packets/HandshakePacket.cs
@@ -4,7 +4,7 @@ using MapleServer2.Enums;
 
 namespace MapleServer2.Packets;
 
-public class HandshakePacket
+public static class HandshakePacket
 {
     public static PacketWriter Handshake(uint version, uint riv, uint siv, uint blockIv, PatchType patchType, int handshakeSize)
     {

--- a/MapleServer2/Packets/HomeActionPacket.cs
+++ b/MapleServer2/Packets/HomeActionPacket.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public class HomeActionPacket
+public static class HomeActionPacket
 {
     private enum HomeActionMode : byte
     {

--- a/MapleServer2/Packets/HomeCommandPacket.cs
+++ b/MapleServer2/Packets/HomeCommandPacket.cs
@@ -4,9 +4,9 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public class HomeCommandPacket
+public static class HomeCommandPacket
 {
-    private enum HomeCommandMode : byte
+    private enum Mode : byte
     {
         Load = 0x00,
         UpdateArchitectScore = 0x01
@@ -15,7 +15,7 @@ public class HomeCommandPacket
     public static PacketWriter LoadHome(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.HomeCommand);
-        pWriter.Write(HomeCommandMode.Load);
+        pWriter.Write(Mode.Load);
         pWriter.WriteLong(player.AccountId);
         pWriter.WriteLong(); // last time player nominated home
 
@@ -25,7 +25,7 @@ public class HomeCommandPacket
     public static PacketWriter UpdateArchitectScore(int ownerObjectId, int architectScoreCurrent, int architectScoreTotal)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.HomeCommand);
-        pWriter.Write(HomeCommandMode.UpdateArchitectScore);
+        pWriter.Write(Mode.UpdateArchitectScore);
         pWriter.WriteInt(ownerObjectId);
         pWriter.WriteLong(TimeInfo.Now());
         pWriter.WriteInt(architectScoreCurrent);

--- a/MapleServer2/Packets/InstrumentPacket.cs
+++ b/MapleServer2/Packets/InstrumentPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class InstrumentPacket
 {
-    private enum InstrumentPacketMode : byte
+    private enum Mode : byte
     {
         StartImprovise = 0x0,
         PlayNote = 0x1,
@@ -23,7 +23,7 @@ public static class InstrumentPacket
     public static PacketWriter StartImprovise(IFieldObject<Instrument> instrument)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.StartImprovise);
+        pWriter.Write(Mode.StartImprovise);
         pWriter.WriteInt(instrument.ObjectId);
         pWriter.WriteInt(instrument.Value.PlayerObjectId);
         pWriter.Write(instrument.Coord);
@@ -35,7 +35,7 @@ public static class InstrumentPacket
     public static PacketWriter PlayNote(int note, IFieldObject<Player> player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.PlayNote);
+        pWriter.Write(Mode.PlayNote);
         pWriter.WriteInt(player.Value.Instrument.ObjectId);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteInt(note);
@@ -45,7 +45,7 @@ public static class InstrumentPacket
     public static PacketWriter StopImprovise(IFieldObject<Player> player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.StopImprovise);
+        pWriter.Write(Mode.StopImprovise);
         pWriter.WriteInt(player.Value.Instrument.ObjectId);
         pWriter.WriteInt(player.ObjectId);
         return pWriter;
@@ -54,7 +54,7 @@ public static class InstrumentPacket
     public static PacketWriter PlayScore(IFieldObject<Instrument> instrument)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.PlayScore);
+        pWriter.Write(Mode.PlayScore);
         pWriter.WriteBool(instrument.Value.IsCustomScore);
         pWriter.WriteInt(instrument.ObjectId);
         pWriter.WriteInt(instrument.Value.PlayerObjectId);
@@ -78,7 +78,7 @@ public static class InstrumentPacket
     public static PacketWriter StopScore(IFieldObject<Instrument> instrument)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.StopScore);
+        pWriter.Write(Mode.StopScore);
         pWriter.WriteInt(instrument.ObjectId);
         pWriter.WriteInt(instrument.Value.PlayerObjectId);
         return pWriter;
@@ -87,14 +87,14 @@ public static class InstrumentPacket
     public static PacketWriter LeaveEnsemble()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.LeaveEnsemble);
+        pWriter.Write(Mode.LeaveEnsemble);
         return pWriter;
     }
 
     public static PacketWriter Compose(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.Compose);
+        pWriter.Write(Mode.Compose);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
         return pWriter;
@@ -103,7 +103,7 @@ public static class InstrumentPacket
     public static PacketWriter UpdateScoreUses(long scoreItemUid, int usesRemaining)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.UpdateScoreUses);
+        pWriter.Write(Mode.UpdateScoreUses);
         pWriter.WriteLong(scoreItemUid);
         pWriter.WriteInt(usesRemaining);
         return pWriter;
@@ -112,7 +112,7 @@ public static class InstrumentPacket
     public static PacketWriter Fireworks(int objectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayInstrument);
-        pWriter.Write(InstrumentPacketMode.Fireworks);
+        pWriter.Write(Mode.Fireworks);
         pWriter.WriteInt(objectId);
         return pWriter;
     }

--- a/MapleServer2/Packets/InteractObjectPacket.cs
+++ b/MapleServer2/Packets/InteractObjectPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class InteractObjectPacket
 {
-    private enum InteractObjectMode : byte
+    private enum Mode : byte
     {
         Update = 0x04,
         Use = 0x05,
@@ -21,7 +21,7 @@ public static class InteractObjectPacket
     public static PacketWriter Update(InteractObject interactObject)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteString(interactObject.Id);
         pWriter.Write(interactObject.State);
         pWriter.Write(interactObject.Type);
@@ -32,7 +32,7 @@ public static class InteractObjectPacket
     public static PacketWriter Use(InteractObject interactObject, short result = 0, int numDrops = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Use);
+        pWriter.Write(Mode.Use);
         pWriter.WriteString(interactObject.Id);
         pWriter.Write(interactObject.Type);
 
@@ -48,7 +48,7 @@ public static class InteractObjectPacket
     public static PacketWriter Set(InteractObject interactObject)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Set);
+        pWriter.Write(Mode.Set);
         pWriter.WriteInt(interactObject.InteractId);
         pWriter.Write(interactObject.State);
         return pWriter;
@@ -57,7 +57,7 @@ public static class InteractObjectPacket
     public static PacketWriter LoadObjects(List<IFieldObject<InteractObject>> interactObjects)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Load);
+        pWriter.Write(Mode.Load);
         pWriter.WriteInt(interactObjects.Count);
         foreach (IFieldObject<InteractObject> interactObject in interactObjects)
         {
@@ -72,7 +72,7 @@ public static class InteractObjectPacket
         InteractObject interactObject = fieldInteractObject.Value;
 
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteString(interactObject.Id);
         pWriter.Write(interactObject.State);
         pWriter.Write(interactObject.Type);
@@ -97,7 +97,7 @@ public static class InteractObjectPacket
     public static PacketWriter Remove(InteractObject interactObject)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteString(interactObject.Id);
         pWriter.WriteUnicodeString();
 
@@ -107,7 +107,7 @@ public static class InteractObjectPacket
     public static PacketWriter Interact(InteractObject interactObject)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.InteractObject);
-        pWriter.Write(InteractObjectMode.Interact);
+        pWriter.Write(Mode.Interact);
         pWriter.WriteByte();
         pWriter.WriteString(interactObject.Id);
         pWriter.Write(interactObject.Type);

--- a/MapleServer2/Packets/ItemBreakPacket.cs
+++ b/MapleServer2/Packets/ItemBreakPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemBreakPacket
 {
-    private enum ItemBreakMode : byte
+    private enum Mode : byte
     {
         Add = 0x01,
         Remove = 0x02,
@@ -16,7 +16,7 @@ public static class ItemBreakPacket
     public static PacketWriter Add(long uid, short slot, int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemBreak);
-        pWriter.Write(ItemBreakMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteLong(uid);
         pWriter.WriteShort(slot);
         pWriter.WriteInt(amount);
@@ -27,7 +27,7 @@ public static class ItemBreakPacket
     public static PacketWriter Remove(long uid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemBreak);
-        pWriter.Write(ItemBreakMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong(uid);
 
         return pWriter;
@@ -36,7 +36,7 @@ public static class ItemBreakPacket
     public static PacketWriter Results(Dictionary<int, int> rewards)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemBreak);
-        pWriter.Write(ItemBreakMode.Results);
+        pWriter.Write(Mode.Results);
         pWriter.WriteInt(rewards.Count);
         foreach ((int id, int amount) in rewards)
         {
@@ -51,7 +51,7 @@ public static class ItemBreakPacket
     public static PacketWriter ShowRewards(Dictionary<int, int> rewards)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemBreak);
-        pWriter.Write(ItemBreakMode.ShowRewards);
+        pWriter.Write(Mode.ShowRewards);
         pWriter.WriteByte(1); // unknown
         pWriter.WriteInt(rewards.Count);
         foreach ((int id, int amount) in rewards)

--- a/MapleServer2/Packets/ItemEnchantPacket.cs
+++ b/MapleServer2/Packets/ItemEnchantPacket.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemEnchantPacket
 {
-    private enum ItemEnchantPacketMode : byte
+    private enum Mode : byte
     {
         BeginEnchant = 0x05,
         UpdateExp = 0x06,
@@ -22,7 +22,7 @@ public static class ItemEnchantPacket
     public static PacketWriter BeginEnchant(EnchantType type, Item item, ItemEnchant enchantInfo, Dictionary<StatAttribute, ItemStat> stats)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemEnchant);
-        pWriter.Write(ItemEnchantPacketMode.BeginEnchant);
+        pWriter.Write(Mode.BeginEnchant);
         pWriter.Write(type);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteByte((byte) enchantInfo.Ingredients.Count);
@@ -63,7 +63,7 @@ public static class ItemEnchantPacket
     public static PacketWriter UpdateExp(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemEnchant);
-        pWriter.Write(ItemEnchantPacketMode.UpdateExp);
+        pWriter.Write(Mode.UpdateExp);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteInt(item.EnchantExp);
         return pWriter;
@@ -72,7 +72,7 @@ public static class ItemEnchantPacket
     public static PacketWriter UpdateCharges(ItemEnchant itemEnchant)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemEnchant);
-        pWriter.Write(ItemEnchantPacketMode.UpdateCharges);
+        pWriter.Write(Mode.UpdateCharges);
         pWriter.WriteInt(itemEnchant.Rates.ChargesAdded);
         pWriter.WriteInt(itemEnchant.CatalystItemUids.Count);
         pWriter.WriteInt(itemEnchant.CatalystItemUids.Count);
@@ -87,7 +87,7 @@ public static class ItemEnchantPacket
     public static PacketWriter EnchantSuccess(Item item, List<ItemStat> enchants)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemEnchant);
-        pWriter.Write(ItemEnchantPacketMode.EnchantSuccess);
+        pWriter.Write(Mode.EnchantSuccess);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
 
@@ -104,7 +104,7 @@ public static class ItemEnchantPacket
     public static PacketWriter EnchantFail(Item item, ItemEnchant enchantInfo)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemEnchant);
-        pWriter.Write(ItemEnchantPacketMode.EnchantFail);
+        pWriter.Write(Mode.EnchantFail);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
         pWriter.WriteInt();
@@ -117,7 +117,7 @@ public static class ItemEnchantPacket
     public static PacketWriter Notice(short noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemEnchant);
-        pWriter.Write(ItemEnchantPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteShort(noticeId);
         return pWriter;
     }

--- a/MapleServer2/Packets/ItemExchangePacket.cs
+++ b/MapleServer2/Packets/ItemExchangePacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemExchangePacket
 {
-    private enum ItemExchangePacketMode : byte
+    private enum Mode : byte
     {
         Notice = 0x2
     }
@@ -13,7 +13,7 @@ public static class ItemExchangePacket
     public static PacketWriter Notice(short noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemExchange);
-        pWriter.Write(ItemExchangePacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteShort(noticeId);
         return pWriter;
     }

--- a/MapleServer2/Packets/ItemExtractionPacket.cs
+++ b/MapleServer2/Packets/ItemExtractionPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemExtractionPacket
 {
-    private enum ItemExtractionPacketMode : byte
+    private enum Mode : byte
     {
         Extract = 0x0,
         InsufficientAnvils = 0x2
@@ -15,7 +15,7 @@ public static class ItemExtractionPacket
     public static PacketWriter Extract(Item resultItem)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemExtraction);
-        pWriter.Write(ItemExtractionPacketMode.Extract);
+        pWriter.Write(Mode.Extract);
         pWriter.WriteLong(resultItem.Uid);
         pWriter.WriteLong(resultItem.Uid);
         pWriter.WriteShort();
@@ -34,7 +34,7 @@ public static class ItemExtractionPacket
     public static PacketWriter InsufficientAnvils()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemExtraction);
-        pWriter.Write(ItemExtractionPacketMode.InsufficientAnvils);
+        pWriter.Write(Mode.InsufficientAnvils);
         return pWriter;
     }
 }

--- a/MapleServer2/Packets/ItemInventoryPacket.cs
+++ b/MapleServer2/Packets/ItemInventoryPacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemInventoryPacket
 {
-    private enum InventoryMode : byte
+    private enum Mode : byte
     {
         Add = 0x00,
         Remove = 0x01,
@@ -26,7 +26,7 @@ public static class ItemInventoryPacket
     public static PacketWriter Add(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteInt(item.Id);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteShort(item.Slot);
@@ -41,7 +41,7 @@ public static class ItemInventoryPacket
     public static PacketWriter Remove(long uid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong(uid);
 
         return pWriter;
@@ -50,7 +50,7 @@ public static class ItemInventoryPacket
     public static PacketWriter UpdateAmount(long uid, int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.UpdateAmount);
+        pWriter.Write(Mode.UpdateAmount);
         pWriter.WriteLong(uid);
         pWriter.WriteInt(amount);
 
@@ -60,7 +60,7 @@ public static class ItemInventoryPacket
     public static PacketWriter Move(long dstUid, short srcSlot, long srcUid, short dstSlot)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.Move);
+        pWriter.Write(Mode.Move);
         pWriter.WriteLong(dstUid);
         pWriter.WriteShort(srcSlot);
         pWriter.WriteLong(srcUid);
@@ -72,7 +72,7 @@ public static class ItemInventoryPacket
     public static PacketWriter LoadItem(IReadOnlyCollection<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.LoadItem);
+        pWriter.Write(Mode.LoadItem);
 
         pWriter.WriteShort((short) items.Count);
         foreach (Item item in items)
@@ -91,7 +91,7 @@ public static class ItemInventoryPacket
     public static PacketWriter MarkItemNew(Item item, int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.MarkItemNew);
+        pWriter.Write(Mode.MarkItemNew);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteInt(amount);
         pWriter.WriteUnicodeString();
@@ -102,7 +102,7 @@ public static class ItemInventoryPacket
     public static PacketWriter LoadItemsToTab(InventoryTab tab, IReadOnlyCollection<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.LoadItemsToTab);
+        pWriter.Write(Mode.LoadItemsToTab);
         pWriter.WriteInt((int) tab);
         pWriter.WriteShort((short) items.Count);
         foreach (Item item in items)
@@ -120,7 +120,7 @@ public static class ItemInventoryPacket
     public static PacketWriter Expand()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.Expand);
+        pWriter.Write(Mode.Expand);
 
         return pWriter;
     }
@@ -128,7 +128,7 @@ public static class ItemInventoryPacket
     public static PacketWriter ResetTab(InventoryTab tab)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.ResetTab);
+        pWriter.Write(Mode.ResetTab);
         pWriter.WriteInt((int) tab); // index
 
         return pWriter;
@@ -137,7 +137,7 @@ public static class ItemInventoryPacket
     public static PacketWriter LoadTab(InventoryTab tab, short extraSlots)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.LoadTab);
+        pWriter.Write(Mode.LoadTab);
         pWriter.WriteByte((byte) tab);
         pWriter.WriteInt(extraSlots);
 
@@ -147,7 +147,7 @@ public static class ItemInventoryPacket
     public static PacketWriter UpdateItem(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemInventory);
-        pWriter.Write(InventoryMode.UpdateBind);
+        pWriter.Write(Mode.UpdateBind);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
         return pWriter;

--- a/MapleServer2/Packets/ItemLockPacket.cs
+++ b/MapleServer2/Packets/ItemLockPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemLockPacket
 {
-    private enum ItemLockMode : byte
+    private enum Mode : byte
     {
         Add = 0x01,
         Remove = 0x02,
@@ -17,7 +17,7 @@ public static class ItemLockPacket
     public static PacketWriter Add(long uid, short slot)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLock);
-        pWriter.Write(ItemLockMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteLong(uid);
         pWriter.WriteShort(slot);
 
@@ -27,7 +27,7 @@ public static class ItemLockPacket
     public static PacketWriter Remove(long uid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLock);
-        pWriter.Write(ItemLockMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong(uid);
 
         return pWriter;
@@ -36,7 +36,7 @@ public static class ItemLockPacket
     public static PacketWriter UpdateItems(List<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLock);
-        pWriter.Write(ItemLockMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteByte((byte) items.Count);
         foreach (Item item in items)
         {

--- a/MapleServer2/Packets/ItemRepackagePacket.cs
+++ b/MapleServer2/Packets/ItemRepackagePacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemRepackagePacket
 {
-    private enum ItemRepackagePacketMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Repackage = 0x2,
@@ -17,7 +17,7 @@ public static class ItemRepackagePacket
     public static PacketWriter Open(long itemUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemRepackage);
-        pWriter.Write(ItemRepackagePacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteLong(itemUid);
         return pWriter;
     }
@@ -25,7 +25,7 @@ public static class ItemRepackagePacket
     public static PacketWriter Repackage(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemRepackage);
-        pWriter.Write(ItemRepackagePacketMode.Repackage);
+        pWriter.Write(Mode.Repackage);
         pWriter.WriteShort();
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
@@ -35,7 +35,7 @@ public static class ItemRepackagePacket
     public static PacketWriter Notice(int noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemRepackage);
-        pWriter.Write(ItemRepackagePacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteByte();
         pWriter.WriteInt(noticeId);
         return pWriter;

--- a/MapleServer2/Packets/ItemSocketScrollPacket.cs
+++ b/MapleServer2/Packets/ItemSocketScrollPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemSocketScrollPacket
 {
-    private enum ItemSocketScrollMode : byte
+    private enum Mode : byte
     {
         OpenWindow = 0x0,
         UseScroll = 0x2,
@@ -17,7 +17,7 @@ public static class ItemSocketScrollPacket
     public static PacketWriter OpenWindow(long itemUid, int successRate, byte socketCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketScroll);
-        pWriter.Write(ItemSocketScrollMode.OpenWindow);
+        pWriter.Write(Mode.OpenWindow);
         pWriter.WriteLong(itemUid);
         pWriter.WriteInt(successRate);
         pWriter.WriteByte(socketCount);
@@ -27,7 +27,7 @@ public static class ItemSocketScrollPacket
     public static PacketWriter UseScroll(Item item, int successRate, bool success)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketScroll);
-        pWriter.Write(ItemSocketScrollMode.UseScroll);
+        pWriter.Write(Mode.UseScroll);
         pWriter.WriteBool(success);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteByte();
@@ -39,7 +39,7 @@ public static class ItemSocketScrollPacket
     public static PacketWriter Error(int errorId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketScroll);
-        pWriter.Write(ItemSocketScrollMode.Error);
+        pWriter.Write(Mode.Error);
         pWriter.WriteByte();
         pWriter.WriteInt(errorId);
         return pWriter;

--- a/MapleServer2/Packets/ItemSocketSystemPacket.cs
+++ b/MapleServer2/Packets/ItemSocketSystemPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class ItemSocketSystemPacket
 {
-    private enum ItemSocketSystemPacketMode : byte
+    private enum Mode : byte
     {
         UnlockSocket = 0x1,
         SelectUnlockSocketEquip = 0x3,
@@ -20,7 +20,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter UnlockSocket(Item item, byte slot, List<GemSocket> unlockedSockets, bool success = true)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.UnlockSocket);
+        pWriter.Write(Mode.UnlockSocket);
         pWriter.WriteBool(success);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteByte(slot);
@@ -48,7 +48,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter SelectGemUpgrade(long unkUid, byte slot, long equipUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.SelectGemUpgrade);
+        pWriter.Write(Mode.SelectGemUpgrade);
         pWriter.WriteLong(unkUid);
         pWriter.WriteByte(slot);
         pWriter.WriteLong(equipUid);
@@ -59,7 +59,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter SelectUnlockSocketEquip(long equipUid, byte slot, long itemUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.SelectUnlockSocketEquip);
+        pWriter.Write(Mode.SelectUnlockSocketEquip);
         pWriter.WriteLong(equipUid);
         pWriter.WriteByte(slot);
         pWriter.WriteLong(itemUid);
@@ -70,7 +70,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter UpgradeGem(long equipUid, byte slot, Item item, bool success = true)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.UpgradeGem);
+        pWriter.Write(Mode.UpgradeGem);
         pWriter.WriteLong(equipUid);
         pWriter.WriteByte(slot);
         pWriter.WriteBool(success);
@@ -97,7 +97,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter MountGem(long equipItemUid, Gemstone gem, byte slot)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.MountGem);
+        pWriter.Write(Mode.MountGem);
         pWriter.WriteLong(equipItemUid);
         pWriter.WriteByte(slot);
         pWriter.WriteByte(1);
@@ -120,7 +120,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter ExtractGem(long equipItemUid, long gemItemUid, byte slot)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.ExtractGem);
+        pWriter.Write(Mode.ExtractGem);
         pWriter.WriteLong(equipItemUid);
         pWriter.WriteByte(slot);
         pWriter.WriteLong(gemItemUid);
@@ -130,7 +130,7 @@ public static class ItemSocketSystemPacket
     public static PacketWriter Notice(int noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemSocketSystem);
-        pWriter.Write(ItemSocketSystemPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteByte(); // category?
         pWriter.WriteInt(noticeId);
         return pWriter;

--- a/MapleServer2/Packets/JobPacket.cs
+++ b/MapleServer2/Packets/JobPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class JobPacket
 {
-    private enum JobMode : byte
+    private enum Mode : byte
     {
         Update = 0x01,
         Unk = 0x02,
@@ -19,7 +19,7 @@ public static class JobPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Job);
         pWriter.WriteInt(fieldPlayer.ObjectId);
-        pWriter.Write(JobMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteJobInfo(fieldPlayer.Value, newSkillIds);
 
         return pWriter;
@@ -29,7 +29,7 @@ public static class JobPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Job);
         pWriter.WriteInt(fieldPlayer.ObjectId);
-        pWriter.Write(JobMode.Unk);
+        pWriter.Write(Mode.Unk);
         pWriter.WriteJobInfo(fieldPlayer.Value);
 
         return pWriter;
@@ -40,7 +40,7 @@ public static class JobPacket
         PacketWriter pWriter = PacketWriter.Of(SendOp.Job);
 
         pWriter.WriteInt(fieldPlayer.ObjectId);
-        pWriter.Write(JobMode.Close);
+        pWriter.Write(Mode.Close);
         pWriter.WriteJobInfo(fieldPlayer.Value);
 
         return pWriter;
@@ -51,7 +51,7 @@ public static class JobPacket
         PacketWriter pWriter = PacketWriter.Of(SendOp.Job);
 
         pWriter.WriteInt(fieldPlayer.ObjectId);
-        pWriter.Write(JobMode.Save);
+        pWriter.Write(Mode.Save);
         pWriter.WriteJobInfo(fieldPlayer.Value, newSkillIds);
 
         return pWriter;

--- a/MapleServer2/Packets/KeyTablePacket.cs
+++ b/MapleServer2/Packets/KeyTablePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class KeyTablePacket
 {
-    private enum KeyTablePacketMode : byte
+    private enum Mode : byte
     {
         SendFullOptions = 0x00,
         SendHotbars = 0x07,
@@ -16,7 +16,7 @@ public static class KeyTablePacket
     public static PacketWriter SendFullOptions(GameOptions options)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.KeyTable);
-        pWriter.Write(KeyTablePacketMode.SendFullOptions);
+        pWriter.Write(Mode.SendFullOptions);
         pWriter.WriteBool(false); // if true, load DefaultKey.xml
 
         // Key bindings
@@ -35,7 +35,7 @@ public static class KeyTablePacket
     public static PacketWriter SendHotbars(GameOptions options)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.KeyTable);
-        pWriter.Write(KeyTablePacketMode.SendHotbars);
+        pWriter.Write(Mode.SendHotbars);
         pWriter.WriteHotbars(options);
 
         return pWriter;
@@ -44,7 +44,7 @@ public static class KeyTablePacket
     public static PacketWriter AskKeyboardOrMouse()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.KeyTable);
-        pWriter.Write(KeyTablePacketMode.AskKeyboardOrMouse);
+        pWriter.Write(Mode.AskKeyboardOrMouse);
 
         return pWriter;
     }

--- a/MapleServer2/Packets/LapenshardPacket.cs
+++ b/MapleServer2/Packets/LapenshardPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class LapenshardPacket
 {
-    private enum LapenshardMode : byte
+    private enum Mode : byte
     {
         Load = 0,
         Equip = 1,
@@ -18,7 +18,7 @@ public static class LapenshardPacket
     public static PacketWriter Load(Item[] items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLapenshard);
-        pWriter.Write(LapenshardMode.Load);
+        pWriter.Write(Mode.Load);
         pWriter.WriteInt(items.Count(x => x is not null));
         foreach (Item item in items.Where(x => x is not null))
         {
@@ -31,7 +31,7 @@ public static class LapenshardPacket
     public static PacketWriter Equip(int slotId, int itemId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLapenshard);
-        pWriter.Write(LapenshardMode.Equip);
+        pWriter.Write(Mode.Equip);
         pWriter.WriteInt(slotId);
         pWriter.WriteInt(itemId);
         return pWriter;
@@ -40,7 +40,7 @@ public static class LapenshardPacket
     public static PacketWriter Unequip(int slotId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLapenshard);
-        pWriter.Write(LapenshardMode.Unequip);
+        pWriter.Write(Mode.Unequip);
         pWriter.WriteInt(slotId);
         return pWriter;
     }
@@ -48,7 +48,7 @@ public static class LapenshardPacket
     public static PacketWriter Select(int successRate)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLapenshard);
-        pWriter.Write(LapenshardMode.Select);
+        pWriter.Write(Mode.Select);
         pWriter.WriteInt(successRate);
         return pWriter;
     }
@@ -56,7 +56,7 @@ public static class LapenshardPacket
     public static PacketWriter Upgrade(int itemId, bool result)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ItemLapenshard);
-        pWriter.Write(LapenshardMode.Upgrade);
+        pWriter.Write(Mode.Upgrade);
         pWriter.WriteLong();
         pWriter.WriteInt(itemId);
         pWriter.WriteInt();

--- a/MapleServer2/Packets/LiftablePacket.cs
+++ b/MapleServer2/Packets/LiftablePacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class LiftablePacket
 {
-    private enum LiftableMode : byte
+    private enum Mode : byte
     {
         LoadLiftables = 0x00,
         UpdateEntity = 0x02,
@@ -18,7 +18,7 @@ public static class LiftablePacket
     public static PacketWriter LoadLiftables(List<IFieldObject<LiftableObject>> liftableObjects)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Liftable);
-        pWriter.Write(LiftableMode.LoadLiftables);
+        pWriter.Write(Mode.LoadLiftables);
         pWriter.Write(liftableObjects.Count);
         foreach (IFieldObject<LiftableObject> fieldLiftableObject in liftableObjects)
         {
@@ -41,7 +41,7 @@ public static class LiftablePacket
     public static PacketWriter UpdateEntityById(LiftableObject liftableObject)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Liftable);
-        pWriter.Write(LiftableMode.UpdateEntity);
+        pWriter.Write(Mode.UpdateEntity);
         pWriter.WriteString(liftableObject.EntityId);
         pWriter.WriteByte();
         pWriter.WriteInt(liftableObject.ItemCount);
@@ -55,7 +55,7 @@ public static class LiftablePacket
         LiftableObject liftableObject = fieldLiftableObject.Value;
 
         PacketWriter pWriter = PacketWriter.Of(SendOp.Liftable);
-        pWriter.Write(LiftableMode.UpdateEntity);
+        pWriter.Write(Mode.UpdateEntity);
         pWriter.WriteString($"4_{fieldLiftableObject.Coord.ToByte().AsHexadecimal()}");
         pWriter.WriteByte();
         pWriter.WriteInt(liftableObject.ItemCount);
@@ -69,7 +69,7 @@ public static class LiftablePacket
         LiftableObject liftableObject = fieldLiftableObject.Value;
 
         PacketWriter pWriter = PacketWriter.Of(SendOp.Liftable);
-        pWriter.Write(LiftableMode.Drop);
+        pWriter.Write(Mode.Drop);
         pWriter.WriteString($"4_{fieldLiftableObject.Coord.ToByte().AsHexadecimal()}");
         pWriter.WriteInt(liftableObject.ItemCount);
         pWriter.WriteUnicodeString(liftableObject.Metadata.MaskQuestId);
@@ -84,7 +84,7 @@ public static class LiftablePacket
     public static PacketWriter RemoveCube(IFieldObject<LiftableObject> fieldLiftableObject)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Liftable);
-        pWriter.Write(LiftableMode.RemoveCube);
+        pWriter.Write(Mode.RemoveCube);
         pWriter.WriteString($"4_{fieldLiftableObject.Coord.ToByte().AsHexadecimal()}");
 
         return pWriter;

--- a/MapleServer2/Packets/LimitBreakPacket.cs
+++ b/MapleServer2/Packets/LimitBreakPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class LimitBreakPacket
 {
-    private enum LimitBreakPacketMode : byte
+    private enum Mode : byte
     {
         SelectedItem = 0x00,
         LimitBreakItem = 0x01,
@@ -17,7 +17,7 @@ public static class LimitBreakPacket
     public static PacketWriter SelectedItem(long itemUid, Item item, long mesoCost, List<EnchantIngredient> ingredients)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.LimitBreak);
-        pWriter.Write(LimitBreakPacketMode.SelectedItem);
+        pWriter.Write(Mode.SelectedItem);
         pWriter.WriteLong(itemUid);
         pWriter.WriteLong(mesoCost);
         pWriter.WriteByte((byte) ingredients.Count);
@@ -36,7 +36,7 @@ public static class LimitBreakPacket
     public static PacketWriter LimitBreakItem(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.LimitBreak);
-        pWriter.Write(LimitBreakPacketMode.LimitBreakItem);
+        pWriter.Write(Mode.LimitBreakItem);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteItem(item);
         return pWriter;
@@ -45,7 +45,7 @@ public static class LimitBreakPacket
     public static PacketWriter Notice(short noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.LimitBreak);
-        pWriter.Write(LimitBreakPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteShort(noticeId);
         return pWriter;
     }

--- a/MapleServer2/Packets/LoadUgcMapPacket.cs
+++ b/MapleServer2/Packets/LoadUgcMapPacket.cs
@@ -5,7 +5,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public static class ResponseLoadUgcMapPacket
+public static class LoadUgcMapPacket
 {
     public static PacketWriter LoadUgcMap(Home home = null, bool inDecorPlanner = false)
     {

--- a/MapleServer2/Packets/MacroPacket.cs
+++ b/MapleServer2/Packets/MacroPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class MacroPacket
 {
-    private enum MacroPacketMode : byte
+    private enum Mode : byte
     {
         OpenSettings = 0x00,
         LoadControls = 0x02,
@@ -15,7 +15,7 @@ public static class MacroPacket
     public static PacketWriter OpenSettings(List<Macro> compactControls)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Macro);
-        pWriter.Write(MacroPacketMode.OpenSettings);
+        pWriter.Write(Mode.OpenSettings);
         WriteMacroList(pWriter, compactControls);
         return pWriter;
     }
@@ -23,7 +23,7 @@ public static class MacroPacket
     public static PacketWriter LoadControls(List<Macro> compactControls)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Macro);
-        pWriter.Write(MacroPacketMode.LoadControls);
+        pWriter.Write(Mode.LoadControls);
         WriteMacroList(pWriter, compactControls);
         return pWriter;
     }

--- a/MapleServer2/Packets/MailPacket.cs
+++ b/MapleServer2/Packets/MailPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class MailPacket
 {
-    private enum MailPacketMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Send = 0x1,
@@ -25,7 +25,7 @@ public static class MailPacket
     public static PacketWriter Open(List<Mail> box)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt(box.Count);
         foreach (Mail mail in box)
         {
@@ -37,7 +37,7 @@ public static class MailPacket
     public static PacketWriter Send(Mail mail)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Send);
+        pWriter.Write(Mode.Send);
         pWriter.WriteLong(mail.Id);
         return pWriter;
     }
@@ -45,7 +45,7 @@ public static class MailPacket
     public static PacketWriter Read(Mail mail)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Read);
+        pWriter.Write(Mode.Read);
         pWriter.WriteLong(mail.Id);
         pWriter.WriteLong(mail.ReadTimestamp);
         return pWriter;
@@ -54,7 +54,7 @@ public static class MailPacket
     public static PacketWriter Collect(Mail mail)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Collect);
+        pWriter.Write(Mode.Collect);
         pWriter.WriteLong(mail.Id);
         pWriter.WriteByte(1);
         pWriter.WriteByte();
@@ -65,7 +65,7 @@ public static class MailPacket
     public static PacketWriter UpdateReadTime(Mail mail)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.UpdateReadTime);
+        pWriter.Write(Mode.UpdateReadTime);
         pWriter.WriteLong(mail.Id);
         pWriter.WriteLong(mail.ReadTimestamp);
         return pWriter;
@@ -74,7 +74,7 @@ public static class MailPacket
     public static PacketWriter Delete(Mail mail)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Delete);
+        pWriter.Write(Mode.Delete);
         pWriter.WriteLong(mail.Id);
         return pWriter;
     }
@@ -82,7 +82,7 @@ public static class MailPacket
     public static PacketWriter Notify(int unreadCount, bool alert = false)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Notify);
+        pWriter.Write(Mode.Notify);
         pWriter.WriteInt(unreadCount);
         pWriter.WriteBool(alert);
         pWriter.WriteInt(); // Unknown maybe repeat of count?
@@ -92,28 +92,28 @@ public static class MailPacket
     public static PacketWriter ExpireNotification()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.ExpireNotification);
+        pWriter.Write(Mode.ExpireNotification);
         return pWriter;
     }
 
     public static PacketWriter StartOpen()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.StartOpen);
+        pWriter.Write(Mode.StartOpen);
         return pWriter;
     }
 
     public static PacketWriter EndOpen()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.EndOpen);
+        pWriter.Write(Mode.EndOpen);
         return pWriter;
     }
 
     public static PacketWriter Error(byte errorCode)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mail);
-        pWriter.Write(MailPacketMode.Error);
+        pWriter.Write(Mode.Error);
         pWriter.WriteByte(0x1);
         pWriter.WriteByte(errorCode);
         return pWriter;

--- a/MapleServer2/Packets/MapleopolyPacket.cs
+++ b/MapleServer2/Packets/MapleopolyPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class MapleopolyPacket
 {
-    private enum MapleopolyPacketMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         Roll = 0x2,
@@ -17,7 +17,7 @@ public static class MapleopolyPacket
     public static PacketWriter Open(int totalTileCount, int freeRollAmount, List<MapleopolyTile> tiles, int tokenItemId, int playerTokenAmount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mapleopoly);
-        pWriter.Write(MapleopolyPacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt(totalTileCount);
         pWriter.WriteInt(freeRollAmount);
         pWriter.WriteInt(tokenItemId);
@@ -38,7 +38,7 @@ public static class MapleopolyPacket
     public static PacketWriter Roll(int tileLocation, int roll1, int roll2)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mapleopoly);
-        pWriter.Write(MapleopolyPacketMode.Roll);
+        pWriter.Write(Mode.Roll);
         pWriter.WriteByte();
         pWriter.WriteInt(tileLocation);
         pWriter.WriteInt(roll1);
@@ -50,7 +50,7 @@ public static class MapleopolyPacket
     public static PacketWriter ProcessTile(int totalTileCount, int freeRollAmount, MapleopolyTile tile)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mapleopoly);
-        pWriter.Write(MapleopolyPacketMode.ProcessTile);
+        pWriter.Write(Mode.ProcessTile);
         pWriter.Write(tile.Type);
         pWriter.WriteInt(tile.TileParameter);
         pWriter.WriteInt(totalTileCount);
@@ -64,7 +64,7 @@ public static class MapleopolyPacket
     public static PacketWriter Notice(byte noticeId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mapleopoly);
-        pWriter.Write(MapleopolyPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.WriteByte(noticeId);
         return pWriter;
     }

--- a/MapleServer2/Packets/MassiveEventPacket.cs
+++ b/MapleServer2/Packets/MassiveEventPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class MassiveEventPacket
 {
-    private enum MassiveEventPacketMode : byte
+    private enum Mode : byte
     {
         RoundBar = 0x0,
         RoundBanner = 0x1,
@@ -18,7 +18,7 @@ public static class MassiveEventPacket
     public static PacketWriter RoundBar(int currentRound, int lastRound, int startFromRound)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MassiveEvent);
-        pWriter.Write(MassiveEventPacketMode.RoundBar);
+        pWriter.Write(Mode.RoundBar);
         pWriter.WriteInt(currentRound);
         pWriter.WriteInt(lastRound);
         pWriter.WriteInt(startFromRound);
@@ -29,7 +29,7 @@ public static class MassiveEventPacket
     public static PacketWriter Round(string text, int round, int countFrom, int soundType = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MassiveEvent);
-        pWriter.Write(MassiveEventPacketMode.RoundBanner);
+        pWriter.Write(Mode.RoundBanner);
         pWriter.WriteUnicodeString(text);
         pWriter.WriteInt(round);
         pWriter.WriteInt(countFrom);
@@ -40,7 +40,7 @@ public static class MassiveEventPacket
     public static PacketWriter TextBanner(EventBannerType type, string script, int duration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MassiveEvent);
-        pWriter.Write(MassiveEventPacketMode.TextBanner);
+        pWriter.Write(Mode.TextBanner);
         pWriter.Write(type);
         pWriter.WriteUnicodeString(script);
         pWriter.WriteInt(duration);
@@ -50,7 +50,7 @@ public static class MassiveEventPacket
     public static PacketWriter RoundHeader(int round, bool finalRound, int duration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MassiveEvent);
-        pWriter.Write(MassiveEventPacketMode.RoundHeader);
+        pWriter.Write(Mode.RoundHeader);
         pWriter.WriteInt(round);
         pWriter.WriteBool(finalRound);
         pWriter.WriteInt(duration);
@@ -60,7 +60,7 @@ public static class MassiveEventPacket
     public static PacketWriter PrepareCountdown(int countFrom)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MassiveEvent);
-        pWriter.Write(MassiveEventPacketMode.PrepareCountdown);
+        pWriter.Write(Mode.PrepareCountdown);
         pWriter.WriteInt(countFrom);
         return pWriter;
     }

--- a/MapleServer2/Packets/MasteryPacket.cs
+++ b/MapleServer2/Packets/MasteryPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class MasteryPacket
 {
-    private enum MasteryMode : byte
+    private enum Mode : byte
     {
         SetMasteryExp = 0x00,
         ClaimRewardBox = 0x01,
@@ -19,7 +19,7 @@ public static class MasteryPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mastery);
 
-        pWriter.Write(MasteryMode.SetMasteryExp);
+        pWriter.Write(Mode.SetMasteryExp);
         pWriter.Write(type);
         pWriter.WriteLong(totalExp);
 
@@ -30,7 +30,7 @@ public static class MasteryPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mastery);
 
-        pWriter.Write(MasteryMode.ClaimRewardBox);
+        pWriter.Write(Mode.ClaimRewardBox);
         pWriter.WriteInt(rewardBoxDetails);
         pWriter.WriteInt(item.Amount);
         pWriter.WriteInt(item.Id);
@@ -43,7 +43,7 @@ public static class MasteryPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mastery);
 
-        pWriter.Write(MasteryMode.GetCraftedItem);
+        pWriter.Write(Mode.GetCraftedItem);
         pWriter.WriteShort((short) type);
         pWriter.WriteInt(item.Amount);
         pWriter.WriteInt(item.Id);
@@ -55,7 +55,7 @@ public static class MasteryPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Mastery);
 
-        pWriter.Write(MasteryMode.MasteryNotice);
+        pWriter.Write(Mode.MasteryNotice);
         pWriter.WriteShort(noticeId);
         return pWriter;
     }

--- a/MapleServer2/Packets/MatchPartyPacket.cs
+++ b/MapleServer2/Packets/MatchPartyPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class MatchPartyPacket
 {
-    private enum MatchPartyPacketMode : byte
+    private enum Mode : byte
     {
         Create = 0x0,
         Remove = 0x1,
@@ -16,7 +16,7 @@ public static class MatchPartyPacket
     public static PacketWriter CreateListing(Party party)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MatchParty);
-        pWriter.Write(MatchPartyPacketMode.Create);
+        pWriter.Write(Mode.Create);
         WritePartyInformation(pWriter, party, false);
 
         return pWriter;
@@ -25,7 +25,7 @@ public static class MatchPartyPacket
     public static PacketWriter RemoveListing(Party party)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MatchParty);
-        pWriter.Write(MatchPartyPacketMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong(party.PartyFinderId);
 
         return pWriter;
@@ -34,7 +34,7 @@ public static class MatchPartyPacket
     public static PacketWriter SendListings(List<Party> parties)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MatchParty);
-        pWriter.Write(MatchPartyPacketMode.Refresh);
+        pWriter.Write(Mode.Refresh);
         pWriter.WriteInt(parties.Count);
         foreach (Party party in parties)
         {

--- a/MapleServer2/Packets/MeretMarketPacket.cs
+++ b/MapleServer2/Packets/MeretMarketPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class MeretMarketPacket
 {
-    private enum MeretMarketMode : byte
+    private enum Mode : byte
     {
         LoadPersonalListings = 0xB,
         LoadSales = 0xC,
@@ -30,7 +30,7 @@ public static class MeretMarketPacket
     public static PacketWriter LoadPersonalListings(List<UgcMarketItem> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.LoadPersonalListings);
+        pWriter.Write(Mode.LoadPersonalListings);
         pWriter.WriteLong();
         pWriter.WriteInt(items.Count);
         foreach (UgcMarketItem item in items)
@@ -44,7 +44,7 @@ public static class MeretMarketPacket
     public static PacketWriter LoadSales(List<UgcMarketSale> sales)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.LoadSales);
+        pWriter.Write(Mode.LoadSales);
         pWriter.WriteInt(sales.Count); // count
 
         foreach (UgcMarketSale sale in sales)
@@ -70,7 +70,7 @@ public static class MeretMarketPacket
     public static PacketWriter ListItem(UgcMarketItem item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.ListItem);
+        pWriter.Write(Mode.ListItem);
         WriteUgcMarketItem(pWriter, item);
         return pWriter;
     }
@@ -78,7 +78,7 @@ public static class MeretMarketPacket
     public static PacketWriter RemoveListing(long id)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.RemoveListing);
+        pWriter.Write(Mode.RemoveListing);
         pWriter.WriteInt();
         pWriter.WriteLong(id);
         pWriter.WriteLong(id);
@@ -88,7 +88,7 @@ public static class MeretMarketPacket
     public static PacketWriter RelistItem(UgcMarketItem item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.RelistItem);
+        pWriter.Write(Mode.RelistItem);
         WriteUgcMarketItem(pWriter, item);
         return pWriter;
     }
@@ -96,7 +96,7 @@ public static class MeretMarketPacket
     public static PacketWriter CollectProfit(UgcMarketSale sale)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.CollectProfit);
+        pWriter.Write(Mode.CollectProfit);
         pWriter.WriteLong(sale.Id);
         pWriter.WriteInt();
         pWriter.WriteLong(sale.Id);
@@ -107,7 +107,7 @@ public static class MeretMarketPacket
     public static PacketWriter UpdateExpiration(UgcMarketItem item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.UpdateExpiration);
+        pWriter.Write(Mode.UpdateExpiration);
         pWriter.WriteInt();
         pWriter.WriteLong(item.MarketId);
         pWriter.WriteLong(item.MarketId);
@@ -120,7 +120,7 @@ public static class MeretMarketPacket
     public static PacketWriter UpdateProfit(long saleId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.UpdateProfit);
+        pWriter.Write(Mode.UpdateProfit);
         pWriter.WriteLong(saleId);
         pWriter.WriteLong(saleId);
         return pWriter;
@@ -129,7 +129,7 @@ public static class MeretMarketPacket
     public static PacketWriter Initialize()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.Initialize);
+        pWriter.Write(Mode.Initialize);
         pWriter.WriteByte();
         return pWriter;
     }
@@ -137,7 +137,7 @@ public static class MeretMarketPacket
     public static PacketWriter LoadShopCategory(List<MeretMarketItem> items, int totalItems)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.LoadShopCategory);
+        pWriter.Write(Mode.LoadShopCategory);
         pWriter.WriteInt(items.Count);
         pWriter.WriteInt(totalItems);
         pWriter.WriteInt(1);
@@ -148,7 +148,7 @@ public static class MeretMarketPacket
     public static PacketWriter Purchase(int premiumMarketId, long ugcMarketItemId, long price, int totalQuantity, int itemIndex = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.Purchase);
+        pWriter.Write(Mode.Purchase);
         pWriter.WriteByte((byte) totalQuantity);
         pWriter.WriteInt(premiumMarketId);
         pWriter.WriteLong(ugcMarketItemId);
@@ -174,7 +174,7 @@ public static class MeretMarketPacket
     public static PacketWriter Promos(List<MeretMarketItem> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.Home);
+        pWriter.Write(Mode.Home);
         pWriter.WriteByte();
         pWriter.WriteByte(10);
         pWriter.WriteByte(1);
@@ -201,7 +201,7 @@ public static class MeretMarketPacket
     public static PacketWriter OpenDesignShop(List<UgcMarketItem> promoItems, List<UgcMarketItem> newItems)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.OpenDesignShop);
+        pWriter.Write(Mode.OpenDesignShop);
         pWriter.WriteInt(promoItems.Count + newItems.Count);
         foreach (UgcMarketItem item in promoItems)
         {
@@ -219,7 +219,7 @@ public static class MeretMarketPacket
     public static PacketWriter LoadCart()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.LoadCart);
+        pWriter.Write(Mode.LoadCart);
         pWriter.WriteInt(1);
         pWriter.WriteInt();
         pWriter.WriteInt(3);
@@ -230,7 +230,7 @@ public static class MeretMarketPacket
     public static PacketWriter ModeC9()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MeretMarket);
-        pWriter.Write(MeretMarketMode.ModeC9);
+        pWriter.Write(Mode.ModeC9);
         pWriter.WriteInt();
 
         return pWriter;

--- a/MapleServer2/Packets/MesoMarketPacket.cs
+++ b/MapleServer2/Packets/MesoMarketPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class MesoMarketPacket
 {
-    private enum MesoMarketPacketMode : byte
+    private enum Mode : byte
     {
         Error = 0x0,
         LoadMarket = 0x1,
@@ -22,7 +22,7 @@ public static class MesoMarketPacket
     public static PacketWriter Error(int errorCode)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.Error);
+        pWriter.Write(Mode.Error);
         pWriter.WriteInt(errorCode);
         return pWriter;
     }
@@ -30,7 +30,7 @@ public static class MesoMarketPacket
     public static PacketWriter LoadMarket()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.LoadMarket);
+        pWriter.Write(Mode.LoadMarket);
         pWriter.WriteFloat(float.Parse(ConstantsMetadataStorage.GetConstant("MesoMarketTax")));
         pWriter.WriteFloat(float.Parse(ConstantsMetadataStorage.GetConstant("MesoMarketPriceRange")));
         pWriter.WriteLong(long.Parse(ConstantsMetadataStorage.GetConstant("MesoMarketAveragePrice"))); // TODO: Calculate average price
@@ -47,7 +47,7 @@ public static class MesoMarketPacket
     public static PacketWriter AccountStats(int todaysListingCount, int monthlyPurchaseCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.AccountStats);
+        pWriter.Write(Mode.AccountStats);
         pWriter.WriteInt(todaysListingCount);
         pWriter.WriteInt(monthlyPurchaseCount);
         return pWriter;
@@ -56,7 +56,7 @@ public static class MesoMarketPacket
     public static PacketWriter MyListings(List<MesoMarketListing> listings)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.MyListings);
+        pWriter.Write(Mode.MyListings);
         pWriter.WriteInt(listings.Count);
         foreach (MesoMarketListing listing in listings)
         {
@@ -69,7 +69,7 @@ public static class MesoMarketPacket
     public static PacketWriter CreateListing(MesoMarketListing listing)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.CreateListing);
+        pWriter.Write(Mode.CreateListing);
         WriteListing(pWriter, listing);
         pWriter.WriteInt();
         return pWriter;
@@ -78,7 +78,7 @@ public static class MesoMarketPacket
     public static PacketWriter CancelListing(long listingId, int errorCode = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.CancelListing);
+        pWriter.Write(Mode.CancelListing);
         pWriter.WriteInt(errorCode);
         pWriter.WriteLong(listingId);
         return pWriter;
@@ -87,7 +87,7 @@ public static class MesoMarketPacket
     public static PacketWriter LoadListings(List<MesoMarketListing> listings)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.LoadListings);
+        pWriter.Write(Mode.LoadListings);
         pWriter.WriteInt(listings.Count);
         foreach (MesoMarketListing listing in listings)
         {
@@ -99,7 +99,7 @@ public static class MesoMarketPacket
     public static PacketWriter Purchase(long listingId, int errorCode = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MesoMarket);
-        pWriter.Write(MesoMarketPacketMode.Purchase);
+        pWriter.Write(Mode.Purchase);
         pWriter.WriteInt(errorCode);
         pWriter.WriteLong(listingId);
         pWriter.WriteInt(1);

--- a/MapleServer2/Packets/MountPacket.cs
+++ b/MapleServer2/Packets/MountPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class MountPacket
 {
-    private enum MountPacketMode : byte
+    private enum Mode : byte
     {
         StartRide = 0x0,
         StopRide = 0x1,
@@ -19,7 +19,7 @@ public static class MountPacket
     public static PacketWriter StartRide(IFieldObject<Player> player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseRide);
-        pWriter.Write(MountPacketMode.StartRide);
+        pWriter.Write(Mode.StartRide);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteMount(player.Value.Mount);
         return pWriter;
@@ -28,7 +28,7 @@ public static class MountPacket
     public static PacketWriter StopRide(IFieldObject<Player> player, bool forced = false)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseRide);
-        pWriter.Write(MountPacketMode.StopRide);
+        pWriter.Write(Mode.StopRide);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteByte();
         pWriter.WriteBool(forced);
@@ -38,7 +38,7 @@ public static class MountPacket
     public static PacketWriter ChangeRide(int playerObjectId, int mountId, long mountUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseRide);
-        pWriter.Write(MountPacketMode.ChangeRide);
+        pWriter.Write(Mode.ChangeRide);
         pWriter.WriteInt(playerObjectId);
         pWriter.WriteInt(mountId);
         pWriter.WriteLong(mountUid);
@@ -48,7 +48,7 @@ public static class MountPacket
     public static PacketWriter StartTwoPersonRide(int otherPlayerObjectId, int playerObjectId, byte index)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseRide);
-        pWriter.Write(MountPacketMode.StartTwoPersonRide);
+        pWriter.Write(Mode.StartTwoPersonRide);
         pWriter.WriteInt(otherPlayerObjectId);
         pWriter.WriteInt(playerObjectId);
         pWriter.WriteByte(index);
@@ -58,7 +58,7 @@ public static class MountPacket
     public static PacketWriter StopTwoPersonRide(int otherPlayerObjectId, int playerObjectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseRide);
-        pWriter.Write(MountPacketMode.StopTwoPersonRide);
+        pWriter.Write(Mode.StopTwoPersonRide);
         pWriter.WriteInt(otherPlayerObjectId);
         pWriter.WriteInt(playerObjectId);
         return pWriter;

--- a/MapleServer2/Packets/MushkingRoyaleSystemPacket.cs
+++ b/MapleServer2/Packets/MushkingRoyaleSystemPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public class MushkingRoyaleSystemPacket
 {
-    private enum MushkingRoyaleSystemPacketMode : byte
+    private enum Mode : byte
     {
         JoinSoloQueue = 0x0,
         WithdrawSoloQueue = 0x1,
@@ -29,28 +29,28 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter JoinSoloQueue()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.JoinSoloQueue);
+        pWriter.Write(Mode.JoinSoloQueue);
         return pWriter;
     }
 
     public static PacketWriter WithdrawSoloQueue()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.WithdrawSoloQueue);
+        pWriter.Write(Mode.WithdrawSoloQueue);
         return pWriter;
     }
 
     public static PacketWriter ClearMatchedQueue()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.ClearMatchedQueue);
+        pWriter.Write(Mode.ClearMatchedQueue);
         return pWriter;
     }
 
     public static PacketWriter MatchFound(int sessionId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.MatchFound);
+        pWriter.Write(Mode.MatchFound);
         pWriter.WriteLong(sessionId);
         pWriter.WriteBool(false); // false = 15 second window, true = 5 second window
         return pWriter;
@@ -59,7 +59,7 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter Results()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.Results);
+        pWriter.Write(Mode.Results);
         pWriter.WriteInt();
         pWriter.WriteInt();
         pWriter.WriteInt(); // previous points
@@ -95,7 +95,7 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter LastStandingNotice()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.LastStandingNotice);
+        pWriter.Write(Mode.LastStandingNotice);
         pWriter.WriteByte();
         pWriter.WriteInt(); // amount of users
         // start loop
@@ -108,7 +108,7 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter Unk16()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.Unk16);
+        pWriter.Write(Mode.Unk16);
         pWriter.WriteInt();
         pWriter.WriteInt(1);
         pWriter.WriteLong();
@@ -126,7 +126,7 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter LoadStats(MushkingRoyaleStats stats, long expGained = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.LoadStats);
+        pWriter.Write(Mode.LoadStats);
         pWriter.WriteLong(stats.Id);
         pWriter.WriteInt();
         pWriter.WriteBool(stats.IsGoldPassActive);
@@ -142,14 +142,14 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter NewSeasonNotice()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.NewSeasonNotice);
+        pWriter.Write(Mode.NewSeasonNotice);
         return pWriter;
     }
 
     public static PacketWriter SurvivalSessionStats(int playersRemaining, int totalPlayers)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.SurvivalSessionStats);
+        pWriter.Write(Mode.SurvivalSessionStats);
         pWriter.WriteInt(playersRemaining);
         pWriter.WriteInt(totalPlayers);
         pWriter.WriteByte();
@@ -159,7 +159,7 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter UpdateKills()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.UpdateKills);
+        pWriter.Write(Mode.UpdateKills);
         pWriter.WriteInt(); // kill count
         return pWriter;
     }
@@ -167,14 +167,14 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter Poisoned()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.Poisoned);
+        pWriter.Write(Mode.Poisoned);
         return pWriter;
     }
 
     public static PacketWriter LoadMedals(Account account)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.LoadMedals);
+        pWriter.Write(Mode.LoadMedals);
         pWriter.WriteByte((byte) Enum.GetNames(typeof(MedalSlot)).Length);
         foreach (MedalSlot slot in Enum.GetValues(typeof(MedalSlot)))
         {
@@ -193,7 +193,7 @@ public class MushkingRoyaleSystemPacket
     public static PacketWriter ClaimRewards(int silverStartLevel, int silverEndLevel, int goldStartLevel, int goldEndLevel)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.MushkingRoyaleSystem);
-        pWriter.Write(MushkingRoyaleSystemPacketMode.ClaimRewards);
+        pWriter.Write(Mode.ClaimRewards);
         pWriter.WriteInt(silverStartLevel);
         pWriter.WriteInt(silverEndLevel);
         pWriter.WriteInt(goldStartLevel);

--- a/MapleServer2/Packets/NewsNotificationPacket.cs
+++ b/MapleServer2/Packets/NewsNotificationPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class NewsNotificationPacket
 {
-    private enum NewsNotificationPacketMode : byte
+    private enum Mode : byte
     {
         OpenBrowser = 0x0,
         OpenSidebar = 0x2
@@ -17,7 +17,7 @@ public static class NewsNotificationPacket
         pWriter.WriteByte();
         pWriter.WriteUnicodeString("86BFAEA2-DC42-4AEA-ADD5-D234E8810E08"); // random key to display banners
         pWriter.WriteByte(0x1);
-        pWriter.Write(NewsNotificationPacketMode.OpenBrowser);
+        pWriter.Write(Mode.OpenBrowser);
         pWriter.WriteInt();
         return pWriter;
     }
@@ -28,7 +28,7 @@ public static class NewsNotificationPacket
         pWriter.WriteByte();
         pWriter.WriteUnicodeString("86BFAEA2-DC42-4AEA-ADD5-D234E8810E08"); // random key to display banners
         pWriter.WriteByte(0x1);
-        pWriter.Write(NewsNotificationPacketMode.OpenSidebar);
+        pWriter.Write(Mode.OpenSidebar);
         pWriter.WriteInt();
         return pWriter;
     }

--- a/MapleServer2/Packets/NoticePacket.cs
+++ b/MapleServer2/Packets/NoticePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class NoticePacket
 {
-    private enum NoticePacketMode : byte
+    private enum Mode : byte
     {
         Send = 0x04,
         Quit = 0x05
@@ -15,7 +15,7 @@ public static class NoticePacket
     public static PacketWriter Notice(string message, NoticeType type = NoticeType.Mint, short durationSec = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Notice);
-        pWriter.Write(NoticePacketMode.Send);
+        pWriter.Write(Mode.Send);
         pWriter.WriteShort((short) type);
         pWriter.WriteByte();
         pWriter.WriteInt();
@@ -31,7 +31,7 @@ public static class NoticePacket
     {
         parameters ??= new();
         PacketWriter pWriter = PacketWriter.Of(SendOp.Notice);
-        pWriter.Write(NoticePacketMode.Send);
+        pWriter.Write(Mode.Send);
         WriteNotice(pWriter, notice, type, parameters, durationSec);
         return pWriter;
     }
@@ -40,7 +40,7 @@ public static class NoticePacket
     {
         parameters ??= new();
         PacketWriter pWriter = PacketWriter.Of(SendOp.Notice);
-        pWriter.Write(NoticePacketMode.Quit);
+        pWriter.Write(Mode.Quit);
         WriteNotice(pWriter, notice, type, parameters, durationSec);
         return pWriter;
     }

--- a/MapleServer2/Packets/NpcTalkPacket.cs
+++ b/MapleServer2/Packets/NpcTalkPacket.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Packets;
 
 public static class NpcTalkPacket
 {
-    private enum NpcTalkMode : byte
+    private enum Mode : byte
     {
         Close = 0x00,
         Respond = 0x01,
@@ -21,7 +21,7 @@ public static class NpcTalkPacket
     public static PacketWriter Respond(IFieldObject<NpcMetadata> npc, DialogType dialogType, int contentIndex, ResponseSelection responseSelection, int scriptId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.NpcTalk);
-        pWriter.Write(NpcTalkMode.Respond);
+        pWriter.Write(Mode.Respond);
         pWriter.WriteInt(npc.ObjectId);
         pWriter.Write(dialogType);
         pWriter.WriteInt(scriptId);
@@ -34,7 +34,7 @@ public static class NpcTalkPacket
     public static PacketWriter ContinueChat(int scriptId, DialogType dialogType, ResponseSelection responseSelection, int contentIndex, int questId = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.NpcTalk);
-        pWriter.Write(NpcTalkMode.Continue);
+        pWriter.Write(Mode.Continue);
         pWriter.Write(dialogType);
         pWriter.WriteInt(questId);
         pWriter.WriteInt(scriptId);
@@ -47,7 +47,7 @@ public static class NpcTalkPacket
     public static PacketWriter Action(ActionType actionType, string window = "", string parameters = "", int portalId = 0, Item item = null)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.NpcTalk);
-        pWriter.Write(NpcTalkMode.Action);
+        pWriter.Write(Mode.Action);
         pWriter.Write(actionType);
         switch (actionType)
         {
@@ -73,7 +73,7 @@ public static class NpcTalkPacket
     public static PacketWriter CustomText(string script, string voiceId, string illustration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.NpcTalk);
-        pWriter.Write(NpcTalkMode.CustomText);
+        pWriter.Write(Mode.CustomText);
         pWriter.WriteUnicodeString(script);
         pWriter.WriteUnicodeString(voiceId);
         pWriter.WriteUnicodeString(illustration);
@@ -83,7 +83,7 @@ public static class NpcTalkPacket
     public static PacketWriter Close()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.NpcTalk);
-        pWriter.Write(NpcTalkMode.Close);
+        pWriter.Write(Mode.Close);
 
         return pWriter;
     }

--- a/MapleServer2/Packets/PCCafeBonusPacket.cs
+++ b/MapleServer2/Packets/PCCafeBonusPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class PCCafeBonusPacket
 {
-    private enum PCCafeBonusPacketMode : byte
+    private enum Mode : byte
     {
         LoadBenefits = 0x0,
         ClaimLoginTimeReward = 0x1,
@@ -16,7 +16,7 @@ public static class PCCafeBonusPacket
     public static PacketWriter LoadBenefits()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PCCafeBonus);
-        pWriter.Write(PCCafeBonusPacketMode.LoadBenefits);
+        pWriter.Write(Mode.LoadBenefits);
         pWriter.WriteByte();
         pWriter.WriteBool(true); // player is PCCafe user 
         pWriter.WriteInt();
@@ -58,7 +58,7 @@ public static class PCCafeBonusPacket
     public static PacketWriter ClaimLoginTimeReward(byte index)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PCCafeBonus);
-        pWriter.Write(PCCafeBonusPacketMode.ClaimLoginTimeReward);
+        pWriter.Write(Mode.ClaimLoginTimeReward);
         pWriter.WriteByte(index);
         pWriter.WriteInt();
         return pWriter;
@@ -67,7 +67,7 @@ public static class PCCafeBonusPacket
     public static PacketWriter ClaimPCCafeItem(int index)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PCCafeBonus);
-        pWriter.Write(PCCafeBonusPacketMode.ClaimPCCafeItem);
+        pWriter.Write(Mode.ClaimPCCafeItem);
         pWriter.WriteInt(index);
         return pWriter;
     }
@@ -75,7 +75,7 @@ public static class PCCafeBonusPacket
     public static PacketWriter Unk()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PCCafeBonus);
-        pWriter.Write(PCCafeBonusPacketMode.Unk);
+        pWriter.Write(Mode.Unk);
         pWriter.WriteBool(true); // is PC Cafe user
         pWriter.WriteInt();
         pWriter.WriteInt();

--- a/MapleServer2/Packets/PartyPacket.cs
+++ b/MapleServer2/Packets/PartyPacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class PartyPacket
 {
-    private enum PartyPacketMode : byte
+    private enum Mode : byte
     {
         Notice = 0x0,
         Join = 0x2,
@@ -37,7 +37,7 @@ public static class PartyPacket
     public static PacketWriter Notice(Player player, PartyNotice notice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Notice);
+        pWriter.Write(Mode.Notice);
         pWriter.Write(notice);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
@@ -48,7 +48,7 @@ public static class PartyPacket
         SkillTab skillTab = player.SkillTabs.First(x => x.TabId == player.ActiveSkillTabId);
 
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Join);
+        pWriter.Write(Mode.Join);
         pWriter.WriteCharacter(player);
         pWriter.WriteInt();
         pWriter.WriteSkills(skillTab, SkillType.Active);
@@ -61,7 +61,7 @@ public static class PartyPacket
     public static PacketWriter Leave(Player player, byte self)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Leave);
+        pWriter.Write(Mode.Leave);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteByte(self); //0 = Other leaving, 1 = Self leaving
         return pWriter;
@@ -70,7 +70,7 @@ public static class PartyPacket
     public static PacketWriter Kick(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Kick);
+        pWriter.Write(Mode.Kick);
         pWriter.WriteLong(player.CharacterId);
         return pWriter;
     }
@@ -78,7 +78,7 @@ public static class PartyPacket
     public static PacketWriter Create(Party party, bool joinNotice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Create);
+        pWriter.Write(Mode.Create);
         pWriter.WriteBool(joinNotice);
         pWriter.WriteInt(party.Id);
         pWriter.WriteLong(party.Leader.CharacterId);
@@ -102,7 +102,7 @@ public static class PartyPacket
     public static PacketWriter LoginNotice(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.LoginNotice);
+        pWriter.Write(Mode.LoginNotice);
         pWriter.WriteCharacter(player);
         pWriter.WriteLong();
         pWriter.WriteInt();
@@ -114,7 +114,7 @@ public static class PartyPacket
     public static PacketWriter LogoutNotice(long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.LogoutNotice);
+        pWriter.Write(Mode.LogoutNotice);
         pWriter.WriteLong(characterId);
         return pWriter;
     }
@@ -122,14 +122,14 @@ public static class PartyPacket
     public static PacketWriter Disband()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Disband);
+        pWriter.Write(Mode.Disband);
         return pWriter;
     }
 
     public static PacketWriter SetLeader(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.SetLeader);
+        pWriter.Write(Mode.SetLeader);
         pWriter.WriteLong(player.CharacterId);
         return pWriter;
     }
@@ -137,7 +137,7 @@ public static class PartyPacket
     public static PacketWriter SendInvite(Player sender, Party party)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.Invite);
+        pWriter.Write(Mode.Invite);
         pWriter.WriteUnicodeString(sender.Name);
         pWriter.WriteInt(party.Id);
         return pWriter;
@@ -146,7 +146,7 @@ public static class PartyPacket
     public static PacketWriter UpdateMemberLocation(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.UpdateMemberLocation);
+        pWriter.Write(Mode.UpdateMemberLocation);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteCharacter(player);
         WritePartyDungeonInfo(pWriter);
@@ -156,7 +156,7 @@ public static class PartyPacket
     public static PacketWriter UpdatePlayer(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.UpdatePlayer);
+        pWriter.Write(Mode.UpdatePlayer);
         pWriter.WriteLong(player.CharacterId);
 
         pWriter.WriteCharacter(player);
@@ -167,7 +167,7 @@ public static class PartyPacket
     public static PacketWriter UpdateDungeonInfo(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.UpdateDungeonInfo);
+        pWriter.Write(Mode.UpdateDungeonInfo);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteInt(); //unknown: but value 100 was frequent
         WritePartyDungeonInfo(pWriter);
@@ -177,7 +177,7 @@ public static class PartyPacket
     public static PacketWriter UpdateHitpoints(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.UpdateHitpoints);
+        pWriter.Write(Mode.UpdateHitpoints);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteLong(player.AccountId);
         pWriter.WriteInt(player.Stats[StatAttribute.Hp].Bonus);
@@ -189,7 +189,7 @@ public static class PartyPacket
     public static PacketWriter PartyHelp(int dungeonId, byte enabled = 1)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.PartyHelp);
+        pWriter.Write(Mode.PartyHelp);
         pWriter.WriteByte(enabled);
         pWriter.WriteInt(dungeonId);
         return pWriter;
@@ -198,7 +198,7 @@ public static class PartyPacket
     public static PacketWriter MatchParty(Party party, bool createListing)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.MatchParty);
+        pWriter.Write(Mode.MatchParty);
         pWriter.WriteBool(createListing);
         if (createListing)
         {
@@ -226,7 +226,7 @@ public static class PartyPacket
     public static PacketWriter DungeonFindParty()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.DungeonFindParty);
+        pWriter.Write(Mode.DungeonFindParty);
         pWriter.WriteInt(); // dungeon queue Id
         return pWriter;
     }
@@ -234,7 +234,7 @@ public static class PartyPacket
     public static PacketWriter DungeonHelperCooldown(int tickTime)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.DungeonHelperCooldown);
+        pWriter.Write(Mode.DungeonHelperCooldown);
         pWriter.WriteInt(tickTime);
         return pWriter;
     }
@@ -242,7 +242,7 @@ public static class PartyPacket
     public static PacketWriter JoinRequest(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.JoinRequest);
+        pWriter.Write(Mode.JoinRequest);
         pWriter.WriteUnicodeString(player.Name);
         return pWriter;
     }
@@ -250,7 +250,7 @@ public static class PartyPacket
     public static PacketWriter StartReadyCheck(Player leader, List<Player> members, int count)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.StartReadyCheck);
+        pWriter.Write(Mode.StartReadyCheck);
         pWriter.WriteByte(2); //unk
         pWriter.WriteInt(count);
         pWriter.WriteLong(TimeInfo.Now() + Environment.TickCount);
@@ -269,7 +269,7 @@ public static class PartyPacket
     public static PacketWriter ReadyCheck(Player player, byte accept)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.ReadyCheck);
+        pWriter.Write(Mode.ReadyCheck);
         pWriter.WriteLong(player.CharacterId);
         pWriter.WriteByte(accept);
         return pWriter;
@@ -278,7 +278,7 @@ public static class PartyPacket
     public static PacketWriter EndReadyCheck()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Party);
-        pWriter.Write(PartyPacketMode.EndReadyCheck);
+        pWriter.Write(Mode.EndReadyCheck);
         return pWriter;
     }
 

--- a/MapleServer2/Packets/PetPacket.cs
+++ b/MapleServer2/Packets/PetPacket.cs
@@ -6,9 +6,9 @@ using MapleServer2.Types;
 
 namespace MapleServer2.Packets;
 
-public static class ResponsePetPacket
+public static class PetPacket
 {
-    private enum ResponsePetMode : byte
+    private enum Mode : byte
     {
         Add = 0x00,
         Remove = 0x01,
@@ -22,7 +22,7 @@ public static class ResponsePetPacket
     public static PacketWriter Add(Pet pet)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteInt(pet.Owner.ObjectId);
         pWriter.WriteInt(pet.ObjectId);
         pWriter.WriteBool(true);
@@ -43,7 +43,7 @@ public static class ResponsePetPacket
     public static PacketWriter Remove(Pet pet)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteInt(pet.Owner.ObjectId);
         pWriter.WriteLong(pet.Item.Uid);
 
@@ -53,7 +53,7 @@ public static class ResponsePetPacket
     public static PacketWriter UpdateName(Pet pet)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.UpdateName);
+        pWriter.Write(Mode.UpdateName);
         pWriter.WriteInt(pet.Owner.ObjectId);
         pWriter.WriteUnicodeString(pet.Item.PetInfo.Name);
         pWriter.WriteLong();
@@ -68,7 +68,7 @@ public static class ResponsePetPacket
     public static PacketWriter LoadPetSettings(Pet pet)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.LoadPetSettings);
+        pWriter.Write(Mode.LoadPetSettings);
         pWriter.WriteInt(pet.Owner.ObjectId);
         pWriter.WriteUnicodeString(pet.Item.PetInfo.Name);
         pWriter.WriteLong(pet.Item.PetInfo.Exp);
@@ -85,7 +85,7 @@ public static class ResponsePetPacket
     public static PacketWriter UpdatePotions(Pet pet)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.PotionSettings);
+        pWriter.Write(Mode.PotionSettings);
         pWriter.WriteInt(pet.Owner.ObjectId);
         pWriter.WriteClass(pet.Item.PetInfo.PotionSettings);
 
@@ -95,7 +95,7 @@ public static class ResponsePetPacket
     public static PacketWriter UpdateLoot(Pet pet)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.LootSettings);
+        pWriter.Write(Mode.LootSettings);
         pWriter.WriteInt(pet.Owner.ObjectId);
         pWriter.WriteClass(pet.Item.PetInfo.LootSettings);
 
@@ -105,7 +105,7 @@ public static class ResponsePetPacket
     public static PacketWriter LoadAlbum()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponsePet);
-        pWriter.Write(ResponsePetMode.Album);
+        pWriter.Write(Mode.Album);
         pWriter.WriteInt(); // count
         for (int i = 0; i < 0; i++)
         {

--- a/MapleServer2/Packets/PetSkinPacket.cs
+++ b/MapleServer2/Packets/PetSkinPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class PetSkinPacket
 {
-    private enum PetSkinPacketMode : byte
+    private enum Mode : byte
     {
         Skin = 0x0
     }
@@ -14,7 +14,7 @@ public static class PetSkinPacket
     public static PacketWriter Extract(long petUid, Item badge)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PetSkin);
-        pWriter.Write(PetSkinPacketMode.Skin);
+        pWriter.Write(Mode.Skin);
         pWriter.WriteLong(petUid);
         pWriter.WriteLong(badge.Uid);
         pWriter.WriteInt(badge.PetSkinBadgeId);

--- a/MapleServer2/Packets/PlayerHostPacket.cs
+++ b/MapleServer2/Packets/PlayerHostPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class PlayerHostPacket
 {
-    private enum PlayerHostPacketMode : byte
+    private enum Mode : byte
     {
         OpenHongbao = 0x0,
         HongbaoGiftNotice = 0x2,
@@ -19,7 +19,7 @@ public static class PlayerHostPacket
     public static PacketWriter OpenHongbao(Player player, HongBao hongBao)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.OpenHongbao);
+        pWriter.Write(Mode.OpenHongbao);
         pWriter.WriteInt(hongBao.ItemId);
         pWriter.WriteInt(hongBao.Id);
         pWriter.WriteInt(hongBao.RewardId);
@@ -32,7 +32,7 @@ public static class PlayerHostPacket
     public static PacketWriter HongbaoGiftNotice(Player receiver, HongBao hongBao, int dividedRewardAmount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.HongbaoGiftNotice);
+        pWriter.Write(Mode.HongbaoGiftNotice);
         pWriter.WriteBool(hongBao.Active);
         if (hongBao.Active)
         {
@@ -48,7 +48,7 @@ public static class PlayerHostPacket
     public static PacketWriter StartMinigame(Player player, int minigameId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.StartMinigame);
+        pWriter.Write(Mode.StartMinigame);
         pWriter.WriteUnicodeString(player.Name);
         pWriter.WriteInt(minigameId);
         return pWriter;
@@ -57,7 +57,7 @@ public static class PlayerHostPacket
     public static PacketWriter MinigameRewardNotice(int minigameId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.MinigameRewardNotice);
+        pWriter.Write(Mode.MinigameRewardNotice);
         pWriter.WriteInt(minigameId);
         pWriter.WriteInt(); // amount of players in map
         return pWriter;
@@ -66,7 +66,7 @@ public static class PlayerHostPacket
     public static PacketWriter MinigameRewardReceive(int minigameId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.MinigameRewardReceive);
+        pWriter.Write(Mode.MinigameRewardReceive);
         pWriter.WriteInt(minigameId);
         pWriter.WriteInt(); // amount of players in map
         return pWriter;
@@ -75,7 +75,7 @@ public static class PlayerHostPacket
     public static PacketWriter AdBalloonWindow(AdBalloon balloon)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.AdBalloonWindow);
+        pWriter.Write(Mode.AdBalloonWindow);
         pWriter.WriteLong(balloon.Owner.AccountId);
         pWriter.WriteLong(balloon.Owner.CharacterId);
         pWriter.WriteUnicodeString(balloon.Owner.ProfileUrl);
@@ -94,7 +94,7 @@ public static class PlayerHostPacket
     public static PacketWriter AdBalloonPlace()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PlayerHost);
-        pWriter.Write(PlayerHostPacketMode.AdBalloonPlace);
+        pWriter.Write(Mode.AdBalloonPlace);
         pWriter.WriteInt();
         return pWriter;
     }

--- a/MapleServer2/Packets/PremiumClubPacket.cs
+++ b/MapleServer2/Packets/PremiumClubPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class PremiumClubPacket
 {
-    private enum PremiumClubPacketMode : byte
+    private enum Mode : byte
     {
         ActivatePremium = 0x0,
         Open = 0x1,
@@ -18,7 +18,7 @@ public static class PremiumClubPacket
     public static PacketWriter Open()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PremiumClub);
-        pWriter.Write(PremiumClubPacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt();
         return pWriter;
     }
@@ -26,7 +26,7 @@ public static class PremiumClubPacket
     public static PacketWriter ClaimItem(int benefitId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PremiumClub);
-        pWriter.Write(PremiumClubPacketMode.ClaimItem);
+        pWriter.Write(Mode.ClaimItem);
         pWriter.WriteInt(benefitId);
         return pWriter;
     }
@@ -34,7 +34,7 @@ public static class PremiumClubPacket
     public static PacketWriter OpenPurchaseWindow()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PremiumClub);
-        pWriter.Write(PremiumClubPacketMode.OpenPurchaseWindow);
+        pWriter.Write(Mode.OpenPurchaseWindow);
         pWriter.WriteInt();
         return pWriter;
     }
@@ -42,7 +42,7 @@ public static class PremiumClubPacket
     public static PacketWriter PurchaseMembership(int packageId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PremiumClub);
-        pWriter.Write(PremiumClubPacketMode.PurchaseMembership);
+        pWriter.Write(Mode.PurchaseMembership);
         pWriter.WriteInt(packageId);
         return pWriter;
     }
@@ -50,7 +50,7 @@ public static class PremiumClubPacket
     public static PacketWriter ActivatePremium(IFieldObject<Player> player, long expiration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PremiumClub);
-        pWriter.Write(PremiumClubPacketMode.ActivatePremium);
+        pWriter.Write(Mode.ActivatePremium);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteLong(expiration);
         return pWriter;

--- a/MapleServer2/Packets/PrestigePacket.cs
+++ b/MapleServer2/Packets/PrestigePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class PrestigePacket
 {
-    private enum PrestigePacketMode : byte
+    private enum Mode : byte
     {
         SetLevels = 0x00,
         Exp = 0x01,
@@ -19,7 +19,7 @@ public static class PrestigePacket
     public static PacketWriter SetLevels(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Prestige);
-        pWriter.Write(PrestigePacketMode.SetLevels);
+        pWriter.Write(Mode.SetLevels);
         pWriter.WriteLong(player.Levels.PrestigeExp);
         pWriter.WriteInt(player.Levels.PrestigeLevel);
         pWriter.WriteLong(player.Levels.PrestigeExp);
@@ -38,7 +38,7 @@ public static class PrestigePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Prestige);
 
-        pWriter.Write(PrestigePacketMode.Exp);
+        pWriter.Write(Mode.Exp);
         pWriter.WriteLong(prestigeExp);
         pWriter.WriteLong(amount);
 
@@ -49,7 +49,7 @@ public static class PrestigePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Prestige);
 
-        pWriter.Write(PrestigePacketMode.LevelUp);
+        pWriter.Write(Mode.LevelUp);
         pWriter.WriteInt(playerObjectId);
         pWriter.WriteInt(level);
 
@@ -60,7 +60,7 @@ public static class PrestigePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Prestige);
 
-        pWriter.Write(PrestigePacketMode.Reward);
+        pWriter.Write(Mode.Reward);
         pWriter.WriteByte(0x01); // Unknown maybe boolean for whether to accept?
         pWriter.WriteInt(1); // Amount of rewards to accept (multiple ranks)
         pWriter.WriteInt(rank);
@@ -71,7 +71,7 @@ public static class PrestigePacket
     public static PacketWriter UpdateMissions(List<PrestigeMission> missions)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Prestige);
-        pWriter.Write(PrestigePacketMode.UpdateMissions);
+        pWriter.Write(Mode.UpdateMissions);
         pWriter.WriteInt(missions.Count);
 
         foreach (PrestigeMission mission in missions)
@@ -87,7 +87,7 @@ public static class PrestigePacket
     public static PacketWriter WeeklyMissions(List<PrestigeMission> missions)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Prestige);
-        pWriter.Write(PrestigePacketMode.WeeklyMissions);
+        pWriter.Write(Mode.WeeklyMissions);
         pWriter.WriteInt(missions.Count);
 
         foreach (PrestigeMission mission in missions)

--- a/MapleServer2/Packets/PvpPacket.cs
+++ b/MapleServer2/Packets/PvpPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class PvpPacket
 {
-    private enum PvpMode : byte
+    private enum Mode : byte
     {
         Mode16 = 0x16,
         Mode17 = 0x17,
@@ -15,7 +15,7 @@ public static class PvpPacket
     public static PacketWriter Mode16()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PVP);
-        pWriter.Write(PvpMode.Mode16);
+        pWriter.Write(Mode.Mode16);
         pWriter.WriteInt();
         pWriter.WriteInt();
         pWriter.WriteInt();
@@ -27,7 +27,7 @@ public static class PvpPacket
     public static PacketWriter Mode17()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PVP);
-        pWriter.Write(PvpMode.Mode17);
+        pWriter.Write(Mode.Mode17);
         pWriter.WriteInt();
 
         return pWriter;
@@ -36,7 +36,7 @@ public static class PvpPacket
     public static PacketWriter Mode0C()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.PVP);
-        pWriter.Write(PvpMode.Mode0C);
+        pWriter.Write(Mode.Mode0C);
         pWriter.WriteByte();
 
         return pWriter;

--- a/MapleServer2/Packets/QuestPacket.cs
+++ b/MapleServer2/Packets/QuestPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class QuestPacket
 {
-    private enum QuestMode : byte
+    private enum Mode : byte
     {
         Dialog = 0x01,
         AcceptQuest = 0x02,
@@ -24,7 +24,7 @@ public static class QuestPacket
     public static PacketWriter SendDialogQuest(int objectId, List<QuestStatus> questList)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.Dialog);
+        pWriter.Write(Mode.Dialog);
         pWriter.WriteInt(objectId);
         pWriter.WriteInt(questList.Count);
         foreach (QuestStatus quest in questList)
@@ -38,7 +38,7 @@ public static class QuestPacket
     public static PacketWriter AcceptQuest(QuestStatus quest)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.AcceptQuest);
+        pWriter.Write(Mode.AcceptQuest);
         pWriter.WriteInt(quest.Id);
         pWriter.WriteLong(TimeInfo.Now());
         pWriter.WriteBool(quest.Accepted);
@@ -54,7 +54,7 @@ public static class QuestPacket
     public static PacketWriter UpdateCondition(int questId, List<Condition> conditions)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.UpdateCondition);
+        pWriter.Write(Mode.UpdateCondition);
         pWriter.WriteInt(questId);
         pWriter.WriteInt(conditions.Count);
         foreach (Condition condition in conditions)
@@ -69,7 +69,7 @@ public static class QuestPacket
     public static PacketWriter CompleteQuest(int questId, bool animation)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.CompleteQuest);
+        pWriter.Write(Mode.CompleteQuest);
         pWriter.WriteInt(questId);
         pWriter.WriteInt(animation ? 1 : 0);
         pWriter.WriteLong(TimeInfo.Now());
@@ -80,7 +80,7 @@ public static class QuestPacket
     public static PacketWriter ToggleTracking(int questId, bool tracked)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.ToggleTracking);
+        pWriter.Write(Mode.ToggleTracking);
         pWriter.WriteInt(questId);
         pWriter.WriteBool(tracked);
 
@@ -90,7 +90,7 @@ public static class QuestPacket
     public static PacketWriter StartList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.StartList);
+        pWriter.Write(Mode.StartList);
         pWriter.WriteLong(); // unknown, sometimes it has an value
 
         return pWriter;
@@ -99,7 +99,7 @@ public static class QuestPacket
     public static PacketWriter SendQuests(List<QuestStatus> questList)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.SendQuests);
+        pWriter.Write(Mode.SendQuests);
 
         pWriter.WriteInt(questList.Count);
         foreach (QuestStatus quest in questList)
@@ -124,7 +124,7 @@ public static class QuestPacket
     public static PacketWriter EndList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.EndList);
+        pWriter.Write(Mode.EndList);
         pWriter.WriteInt();
 
         return pWriter;
@@ -133,7 +133,7 @@ public static class QuestPacket
     public static PacketWriter Packet1F()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.FameMissions);
+        pWriter.Write(Mode.FameMissions);
         pWriter.WriteByte();
         pWriter.WriteInt();
 
@@ -143,7 +143,7 @@ public static class QuestPacket
     public static PacketWriter Packet20()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Quest);
-        pWriter.Write(QuestMode.FameMissions2);
+        pWriter.Write(Mode.FameMissions2);
         pWriter.WriteByte();
         pWriter.WriteInt();
 

--- a/MapleServer2/Packets/QuizEventPacket.cs
+++ b/MapleServer2/Packets/QuizEventPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class QuizEventPacket
 {
-    private enum QuizEventPacketMode : byte
+    private enum Mode : byte
     {
         Question = 0x0,
         Answer = 0x1
@@ -14,7 +14,7 @@ public static class QuizEventPacket
     public static PacketWriter Question(string category, string question, int duration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.QuizEvent);
-        pWriter.Write(QuizEventPacketMode.Question);
+        pWriter.Write(Mode.Question);
         pWriter.WriteUnicodeString(category);
         pWriter.WriteUnicodeString(question);
         pWriter.WriteUnicodeString();
@@ -25,7 +25,7 @@ public static class QuizEventPacket
     public static PacketWriter Answer(bool answer, string answerText, int duration)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.QuizEvent);
-        pWriter.Write(QuizEventPacketMode.Answer);
+        pWriter.Write(Mode.Answer);
         pWriter.WriteBool(answer);
         pWriter.WriteUnicodeString(answerText);
         pWriter.WriteInt(duration);

--- a/MapleServer2/Packets/RegionSkillPacket.cs
+++ b/MapleServer2/Packets/RegionSkillPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class RegionSkillPacket
 {
-    private enum RegionSkillMode : byte
+    private enum Mode : byte
     {
         Add = 0x0,
         Remove = 0x1
@@ -17,7 +17,7 @@ public static class RegionSkillPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RegionSkill);
 
-        pWriter.Write(RegionSkillMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteInt(skill.SkillObjectId);
         pWriter.WriteInt(skill.CasterObjectId);
         pWriter.WriteInt(skill.ServerTick);
@@ -43,7 +43,7 @@ public static class RegionSkillPacket
     public static PacketWriter Remove(int sourceObjectId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RegionSkill);
-        pWriter.Write(RegionSkillMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteInt(sourceObjectId); // Uid regionEffect
         return pWriter;
     }

--- a/MapleServer2/Packets/ResultsPacket.cs
+++ b/MapleServer2/Packets/ResultsPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class ResultsPacket
 {
-    private enum ResultsPacketMode : byte
+    private enum Mode : byte
     {
         Timed = 0x0,
         Rounds = 0x1,
@@ -16,7 +16,7 @@ public static class ResultsPacket
     public static PacketWriter Timed(bool success, List<Item> itemRewards, bool bonus, List<Item> itemRewardsBonus = null)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Results);
-        pWriter.Write(ResultsPacketMode.Timed);
+        pWriter.Write(Mode.Timed);
         pWriter.WriteBool(success);
         pWriter.WriteInt(); // dungeonID
         pWriter.WriteByte();
@@ -66,7 +66,7 @@ public static class ResultsPacket
     public static PacketWriter Rounds(int roundsCleared, int totalRounds)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Results);
-        pWriter.Write(ResultsPacketMode.Rounds);
+        pWriter.Write(Mode.Rounds);
         pWriter.WriteInt(roundsCleared);
         pWriter.WriteInt(totalRounds);
         pWriter.WriteInt(1); // amount of rewards (meso and/or exp)
@@ -91,7 +91,7 @@ public static class ResultsPacket
     public static PacketWriter Untimed(bool success)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Results);
-        pWriter.Write(ResultsPacketMode.Untimed);
+        pWriter.Write(Mode.Untimed);
         pWriter.WriteBool(success);
         pWriter.WriteInt(); // dungeonID
         pWriter.WriteInt();

--- a/MapleServer2/Packets/RevivalConfirmPacket.cs
+++ b/MapleServer2/Packets/RevivalConfirmPacket.cs
@@ -3,7 +3,7 @@ using MapleServer2.Constants;
 
 namespace MapleServer2.Packets;
 
-public class RevivalConfirmPacket
+public static class RevivalConfirmPacket
 {
     public static PacketWriter Send(int objectId, long unk)
     {

--- a/MapleServer2/Packets/RockPaperScissorsPacket.cs
+++ b/MapleServer2/Packets/RockPaperScissorsPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class RockPaperScissorsPacket
 {
-    private enum RpsPacketMode : short
+    private enum Mode : short
     {
         Open = 0x0,
         RequestMatch = 0x1,
@@ -22,14 +22,14 @@ public static class RockPaperScissorsPacket
     public static PacketWriter Open()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.Open);
+        pWriter.Write(Mode.Open);
         return pWriter;
     }
 
     public static PacketWriter RequestMatch(long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.RequestMatch);
+        pWriter.Write(Mode.RequestMatch);
         pWriter.WriteLong(characterId);
         return pWriter;
     }
@@ -37,7 +37,7 @@ public static class RockPaperScissorsPacket
     public static PacketWriter ConfirmMatch(long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.ConfirmMatch);
+        pWriter.Write(Mode.ConfirmMatch);
         pWriter.WriteLong(characterId);
         return pWriter;
     }
@@ -45,7 +45,7 @@ public static class RockPaperScissorsPacket
     public static PacketWriter DenyMatch(long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.DenyMatch);
+        pWriter.Write(Mode.DenyMatch);
         pWriter.WriteLong(characterId);
         return pWriter;
     }
@@ -53,14 +53,14 @@ public static class RockPaperScissorsPacket
     public static PacketWriter BeginMatch()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.BeginMatch);
+        pWriter.Write(Mode.BeginMatch);
         return pWriter;
     }
 
     public static PacketWriter CancelRequestMatch(long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.CancelRequestMatch);
+        pWriter.Write(Mode.CancelRequestMatch);
         pWriter.WriteLong(characterId);
         return pWriter;
     }
@@ -68,7 +68,7 @@ public static class RockPaperScissorsPacket
     public static PacketWriter Notice(byte noticeId, long characterId = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.CancelRequestMatch);
+        pWriter.Write(Mode.CancelRequestMatch);
         pWriter.WriteLong(characterId);
         pWriter.WriteByte(noticeId);
         return pWriter;
@@ -77,7 +77,7 @@ public static class RockPaperScissorsPacket
     public static PacketWriter MatchResults(RpsResult result, RpsChoice playerChoice, RpsChoice opponentChoice)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.MatchResults);
+        pWriter.Write(Mode.MatchResults);
         pWriter.Write(result);
         pWriter.Write(playerChoice);
         pWriter.Write(opponentChoice);
@@ -87,7 +87,7 @@ public static class RockPaperScissorsPacket
     public static PacketWriter ConfirmMatch2(long characterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RockPaperScissors);
-        pWriter.Write(RpsPacketMode.ConfirmMatch2);
+        pWriter.Write(Mode.ConfirmMatch2);
         pWriter.WriteLong(characterId);
         return pWriter;
     }

--- a/MapleServer2/Packets/RouletteGamePacket.cs
+++ b/MapleServer2/Packets/RouletteGamePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class RouletteGamePacket
 {
-    private enum RouletteGameMode : byte
+    private enum Mode : byte
     {
         OpenWheel = 0x01,
         SpinWheel = 0x02
@@ -15,7 +15,7 @@ public static class RouletteGamePacket
     public static PacketWriter OpenWheel(List<RouletteGameItem> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RouletteGame);
-        pWriter.Write(RouletteGameMode.OpenWheel);
+        pWriter.Write(Mode.OpenWheel);
         pWriter.WriteByte();
         pWriter.WriteInt(items.Count);
         foreach (RouletteGameItem item in items)
@@ -31,7 +31,7 @@ public static class RouletteGamePacket
     public static PacketWriter SpinWheel(List<int> indexes, List<RouletteGameItem> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.RouletteGame);
-        pWriter.Write(RouletteGameMode.SpinWheel);
+        pWriter.Write(Mode.SpinWheel);
         pWriter.WriteInt(indexes.Count);
         for (int i = 0; i < indexes.Count; i++)
         {

--- a/MapleServer2/Packets/SendCubesPacket.cs
+++ b/MapleServer2/Packets/SendCubesPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class SendCubesPacket
 {
-    private enum SendCubesMode : byte
+    private enum Mode : byte
     {
         LoadCubes = 0x0,
         AvailablePlots = 0x01,
@@ -17,7 +17,7 @@ public static class SendCubesPacket
     public static PacketWriter LoadCubes(List<Cube> cubes)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cubes);
-        pWriter.Write(SendCubesMode.LoadCubes);
+        pWriter.Write(Mode.LoadCubes);
         pWriter.WriteByte();
         pWriter.WriteInt(cubes.Count);
         foreach (Cube cube in cubes)
@@ -46,7 +46,7 @@ public static class SendCubesPacket
     public static PacketWriter LoadAvailablePlots(List<Home> homes, List<byte> plotNumbers)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cubes);
-        pWriter.Write(SendCubesMode.AvailablePlots);
+        pWriter.Write(Mode.AvailablePlots);
         pWriter.WriteInt(plotNumbers.Count);
         foreach (int plotId in plotNumbers)
         {
@@ -60,7 +60,7 @@ public static class SendCubesPacket
     public static PacketWriter LoadPlots(List<Home> homes, int mapId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cubes);
-        pWriter.Write(SendCubesMode.LoadPlots);
+        pWriter.Write(Mode.LoadPlots);
         pWriter.WriteInt(homes.Count);
         foreach (Home home in homes)
         {
@@ -76,7 +76,7 @@ public static class SendCubesPacket
     public static PacketWriter Expiration(List<Home> homes)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Cubes);
-        pWriter.Write(SendCubesMode.Expiration);
+        pWriter.Write(Mode.Expiration);
         pWriter.WriteInt(homes.Count);
         foreach (Home home in homes)
         {

--- a/MapleServer2/Packets/ShopPacket.cs
+++ b/MapleServer2/Packets/ShopPacket.cs
@@ -9,7 +9,7 @@ namespace MapleServer2.Packets;
 
 public static class ShopPacket
 {
-    private enum ShopMode : byte
+    private enum Mode : byte
     {
         Open = 0x0,
         LoadProducts = 0x1,
@@ -21,7 +21,7 @@ public static class ShopPacket
     public static PacketWriter Open(Shop shop, int npcId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Shop);
-        pWriter.Write(ShopMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt(npcId);
         pWriter.WriteInt(shop.Id);
         pWriter.WriteLong(shop.NextRestock);
@@ -45,7 +45,7 @@ public static class ShopPacket
     public static PacketWriter Reload()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Shop);
-        pWriter.Write(ShopMode.Reload);
+        pWriter.Write(Mode.Reload);
         pWriter.WriteByte();
         pWriter.WriteByte();
 
@@ -63,7 +63,7 @@ public static class ShopPacket
     public static PacketWriter Buy(int itemId, int quantity, int price, ShopCurrencyType shopCurrencyType)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Shop);
-        pWriter.Write(ShopMode.Buy);
+        pWriter.Write(Mode.Buy);
         pWriter.WriteInt(itemId);
         pWriter.WriteInt(quantity);
         pWriter.WriteInt(price * quantity);
@@ -76,7 +76,7 @@ public static class ShopPacket
     public static PacketWriter Sell(Item item, int quantity)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Shop);
-        pWriter.Write(ShopMode.Sell);
+        pWriter.Write(Mode.Sell);
         pWriter.WriteInt(quantity);
         pWriter.WriteShort();
         pWriter.WriteInt(item.Id);
@@ -92,7 +92,7 @@ public static class ShopPacket
     public static PacketWriter LoadProducts(ShopItem product)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Shop);
-        pWriter.Write(ShopMode.LoadProducts);
+        pWriter.Write(Mode.LoadProducts);
         pWriter.WriteByte(1);
         pWriter.WriteInt(product.Uid);
         pWriter.WriteInt(product.ItemId);

--- a/MapleServer2/Packets/SkillBookTreePacket.cs
+++ b/MapleServer2/Packets/SkillBookTreePacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class SkillBookTreePacket
 {
-    private enum SkillBookTreeMode : byte
+    private enum Mode : byte
     {
         Open = 0x00,
         Save = 0x01,
@@ -19,7 +19,7 @@ public static class SkillBookTreePacket
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillBookTree);
 
         // Writes only skills that are learned and for the job rank tab that is opened also doesn't write default passive skills
-        pWriter.Write(SkillBookTreeMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteInt(player.SkillTabs.Count);
         pWriter.WriteLong(player.ActiveSkillTabId);
         pWriter.WriteInt(player.SkillTabs.Count);
@@ -44,7 +44,7 @@ public static class SkillBookTreePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillBookTree);
 
-        pWriter.Write(SkillBookTreeMode.Save);
+        pWriter.Write(Mode.Save);
         pWriter.WriteLong(player.ActiveSkillTabId);
         pWriter.WriteLong(selectedTab);
         pWriter.WriteInt(2); // Set Client Mode (1 = unsaved points, 2 = no unsaved points)
@@ -55,7 +55,7 @@ public static class SkillBookTreePacket
     public static PacketWriter Rename(long id, string name)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillBookTree);
-        pWriter.Write(SkillBookTreeMode.Rename);
+        pWriter.Write(Mode.Rename);
         pWriter.WriteLong(id);
         pWriter.WriteUnicodeString(name);
         pWriter.WriteByte();
@@ -67,7 +67,7 @@ public static class SkillBookTreePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillBookTree);
 
-        pWriter.Write(SkillBookTreeMode.AddTab);
+        pWriter.Write(Mode.AddTab);
         pWriter.WriteInt(2);
         pWriter.WriteLong(player.ActiveSkillTabId);
 

--- a/MapleServer2/Packets/SkillDamagePacket.cs
+++ b/MapleServer2/Packets/SkillDamagePacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class SkillDamagePacket
 {
-    private enum SkillDamageMode : byte
+    private enum Mode : byte
     {
         SyncDamage = 0x0,
         Damage = 0x1,
@@ -25,7 +25,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.SyncDamage);
+        pWriter.Write(Mode.SyncDamage);
         pWriter.WriteLong(skillCast.SkillSn);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteInt(skillCast.SkillId);
@@ -53,7 +53,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.Damage);
+        pWriter.Write(Mode.Damage);
         pWriter.WriteLong(skillCast.SkillSn);
         pWriter.WriteInt(attackCount);
         pWriter.WriteInt(skillCast.CasterObjectId);
@@ -90,7 +90,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.DotDamage);
+        pWriter.Write(Mode.DotDamage);
         pWriter.WriteInt(ownerId);
         pWriter.WriteInt(targetId);
         pWriter.WriteInt(tick);
@@ -104,7 +104,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.Heal);
+        pWriter.Write(Mode.Heal);
         pWriter.WriteInt(status.Source);
         pWriter.WriteInt(status.Target);
         pWriter.WriteInt(status.UniqueId);
@@ -119,7 +119,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.RegionDamage);
+        pWriter.Write(Mode.RegionDamage);
         pWriter.WriteLong(); // always 0??
         pWriter.WriteInt(skillCast.CasterObjectId);
         pWriter.WriteInt(skillCast.SkillObjectId);
@@ -151,7 +151,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.RegionDamage);
+        pWriter.Write(Mode.RegionDamage);
         pWriter.WriteLong(skillCast.SkillSn);
         pWriter.WriteInt(skillCast.SkillId);
         pWriter.WriteShort(skillCast.SkillLevel);
@@ -176,7 +176,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillDamage);
 
-        pWriter.Write(SkillDamageMode.UnkMode7);
+        pWriter.Write(Mode.UnkMode7);
         pWriter.WriteInt(unkInt);
         pWriter.WriteInt(count);
         for (int i = 0; i < count; i++)
@@ -191,7 +191,7 @@ public static class SkillDamagePacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SkillUse);
 
-        pWriter.Write(SkillDamageMode.UnkMode8);
+        pWriter.Write(Mode.UnkMode8);
         pWriter.WriteLong(unkLong);
         pWriter.WriteBool(unkBool);
         if (unkBool)

--- a/MapleServer2/Packets/StatPointPacket.cs
+++ b/MapleServer2/Packets/StatPointPacket.cs
@@ -8,7 +8,7 @@ namespace MapleServer2.Packets;
 
 public static class StatPointPacket
 {
-    private enum StatPointPacketMode : byte
+    private enum Mode : byte
     {
         TotalPoints = 0x0,
         StatDistribution = 0x1
@@ -20,7 +20,7 @@ public static class StatPointPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StatPoint);
 
-        pWriter.Write(StatPointPacketMode.TotalPoints);
+        pWriter.Write(Mode.TotalPoints);
         pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints);
         pWriter.WriteInt(character.StatPointDistribution.OtherStats.Count);
 
@@ -38,7 +38,7 @@ public static class StatPointPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StatPoint);
 
-        pWriter.Write(StatPointPacketMode.StatDistribution);
+        pWriter.Write(Mode.StatDistribution);
         pWriter.WriteInt(character.StatPointDistribution.TotalStatPoints);
         pWriter.WriteInt(character.StatPointDistribution.GetStatTypeCount());
 

--- a/MapleServer2/Packets/StorageInventoryPacket.cs
+++ b/MapleServer2/Packets/StorageInventoryPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class StorageInventoryPacket
 {
-    private enum ItemStorageMode : byte
+    private enum Mode : byte
     {
         Add = 0x00,
         Remove = 0x01,
@@ -25,7 +25,7 @@ public static class StorageInventoryPacket
     public static PacketWriter Add(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Add);
+        pWriter.Write(Mode.Add);
         pWriter.WriteLong();
         pWriter.WriteInt(item.Id);
         pWriter.WriteLong(item.Uid);
@@ -39,7 +39,7 @@ public static class StorageInventoryPacket
     public static PacketWriter Remove(long uid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong();
         pWriter.WriteLong(uid);
 
@@ -49,7 +49,7 @@ public static class StorageInventoryPacket
     public static PacketWriter Move(long srcUid, short srcSlot, long dstUid, short dstSlot)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Move);
+        pWriter.Write(Mode.Move);
         pWriter.WriteLong();
         pWriter.WriteLong(srcUid);
         pWriter.WriteShort(srcSlot);
@@ -62,7 +62,7 @@ public static class StorageInventoryPacket
     public static PacketWriter UpdateMesos(long amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Mesos);
+        pWriter.Write(Mode.Mesos);
         pWriter.WriteLong(amount);
 
         return pWriter;
@@ -71,7 +71,7 @@ public static class StorageInventoryPacket
     public static PacketWriter ItemCount(short itemCount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.ItemCount);
+        pWriter.Write(Mode.ItemCount);
         pWriter.WriteLong();
         pWriter.WriteShort(itemCount);
 
@@ -82,7 +82,7 @@ public static class StorageInventoryPacket
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
 
-        pWriter.Write(ItemStorageMode.LoadItems);
+        pWriter.Write(Mode.LoadItems);
         pWriter.LoadHelper(items);
 
         return pWriter;
@@ -91,7 +91,7 @@ public static class StorageInventoryPacket
     public static PacketWriter ExpandAnim()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.ExpandAnim);
+        pWriter.Write(Mode.ExpandAnim);
 
         return pWriter;
     }
@@ -99,7 +99,7 @@ public static class StorageInventoryPacket
     public static PacketWriter Sort(Item[] items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Sort);
+        pWriter.Write(Mode.Sort);
         pWriter.LoadHelper(items);
 
         return pWriter;
@@ -108,7 +108,7 @@ public static class StorageInventoryPacket
     public static PacketWriter UpdateItem(Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.UpdateItem);
+        pWriter.Write(Mode.UpdateItem);
         pWriter.WriteLong();
         pWriter.WriteLong(item.Uid);
         pWriter.WriteInt(item.Amount);
@@ -119,7 +119,7 @@ public static class StorageInventoryPacket
     public static PacketWriter Update()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Update);
+        pWriter.Write(Mode.Update);
 
         return pWriter;
     }
@@ -127,7 +127,7 @@ public static class StorageInventoryPacket
     public static PacketWriter Expand(int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.StorageInventory);
-        pWriter.Write(ItemStorageMode.Expand);
+        pWriter.Write(Mode.Expand);
         pWriter.WriteInt(amount);
 
         return pWriter;

--- a/MapleServer2/Packets/SuperChatPacket.cs
+++ b/MapleServer2/Packets/SuperChatPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class SuperChatPacket
 {
-    private enum SuperChatMode : byte
+    private enum Mode : byte
     {
         Select = 0x0,
         Deselect = 0x1
@@ -15,7 +15,7 @@ public static class SuperChatPacket
     public static PacketWriter Select(IFieldObject<Player> player, int itemId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SuperWorldChat);
-        pWriter.Write(SuperChatMode.Select);
+        pWriter.Write(Mode.Select);
         pWriter.WriteInt(player.ObjectId);
         pWriter.WriteInt(itemId);
         return pWriter;
@@ -24,7 +24,7 @@ public static class SuperChatPacket
     public static PacketWriter Deselect(IFieldObject<Player> player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SuperWorldChat);
-        pWriter.Write(SuperChatMode.Deselect);
+        pWriter.Write(Mode.Deselect);
         pWriter.WriteInt(player.ObjectId);
         return pWriter;
     }

--- a/MapleServer2/Packets/SystemShopPacket.cs
+++ b/MapleServer2/Packets/SystemShopPacket.cs
@@ -5,7 +5,7 @@ namespace MapleServer2.Packets;
 
 public static class SystemShopPacket
 {
-    private enum SystemShopPacketMode : byte
+    private enum Mode : byte
     {
         Open = 0x0A
     }
@@ -13,7 +13,7 @@ public static class SystemShopPacket
     public static PacketWriter Open()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SystemShop);
-        pWriter.Write(SystemShopPacketMode.Open);
+        pWriter.Write(Mode.Open);
         pWriter.WriteByte(0x1);
         return pWriter;
     }

--- a/MapleServer2/Packets/TimeSyncPacket.cs
+++ b/MapleServer2/Packets/TimeSyncPacket.cs
@@ -10,7 +10,7 @@ namespace MapleServer2.Packets;
 // perhaps setting some initial state?
 public static class TimeSyncPacket
 {
-    private enum TimeSyncPacketMode : byte
+    private enum Mode : byte
     {
         SetSessionServerTick = 0x0,
         SetInitial1 = 0x1,
@@ -21,7 +21,7 @@ public static class TimeSyncPacket
     public static PacketWriter SetSessionServerTick(int key)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseTimeSync);
-        pWriter.Write(TimeSyncPacketMode.SetSessionServerTick);
+        pWriter.Write(Mode.SetSessionServerTick);
         pWriter.WriteInt(Environment.TickCount);
         pWriter.WriteLong(TimeInfo.Now());
         pWriter.WriteByte();
@@ -34,7 +34,7 @@ public static class TimeSyncPacket
     public static PacketWriter SetInitial1()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseTimeSync);
-        pWriter.Write(TimeSyncPacketMode.SetInitial1);
+        pWriter.Write(Mode.SetInitial1);
         pWriter.WriteInt(Environment.TickCount);
         pWriter.WriteLong(TimeInfo.Now());
         pWriter.WriteByte();
@@ -46,7 +46,7 @@ public static class TimeSyncPacket
     public static PacketWriter Request()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseTimeSync);
-        pWriter.Write(TimeSyncPacketMode.Request);
+        pWriter.Write(Mode.Request);
         pWriter.WriteInt(Environment.TickCount);
         pWriter.WriteLong(TimeInfo.Now());
         pWriter.WriteByte();
@@ -58,7 +58,7 @@ public static class TimeSyncPacket
     public static PacketWriter SetInitial2()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ResponseTimeSync);
-        pWriter.Write(TimeSyncPacketMode.SetInitial2);
+        pWriter.Write(Mode.SetInitial2);
         pWriter.WriteLong(TimeInfo.Now());
 
         return pWriter;

--- a/MapleServer2/Packets/TradePacket.cs
+++ b/MapleServer2/Packets/TradePacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class TradePacket
 {
-    private enum TradePacketMode : byte
+    private enum Mode : byte
     {
         TradeRequest = 0x0,
         Notice = 0x1,
@@ -26,7 +26,7 @@ public static class TradePacket
     public static PacketWriter TradeRequest(string playerName, long playerCharacterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.TradeRequest);
+        pWriter.Write(Mode.TradeRequest);
         pWriter.WriteUnicodeString(playerName);
         pWriter.WriteLong(playerCharacterId);
         return pWriter;
@@ -35,14 +35,14 @@ public static class TradePacket
     public static PacketWriter RequestSent()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.RequestSent);
+        pWriter.Write(Mode.RequestSent);
         return pWriter;
     }
 
     public static PacketWriter RequestDeclined(string characterName)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.RequestDeclined);
+        pWriter.Write(Mode.RequestDeclined);
         pWriter.WriteUnicodeString(characterName);
         return pWriter;
     }
@@ -50,7 +50,7 @@ public static class TradePacket
     public static PacketWriter RequestAccepted(long playerCharacterId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.RequestAccepted);
+        pWriter.Write(Mode.RequestAccepted);
         pWriter.WriteLong(playerCharacterId);
         return pWriter;
     }
@@ -58,7 +58,7 @@ public static class TradePacket
     public static PacketWriter TradeStatus(bool tradeIsComplete)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.TradeStatus);
+        pWriter.Write(Mode.TradeStatus);
         pWriter.WriteBool(tradeIsComplete);
         return pWriter;
     }
@@ -66,7 +66,7 @@ public static class TradePacket
     public static PacketWriter AddItemToTrade(Item item, int index, bool selfInventory)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.AddItemToTrade);
+        pWriter.Write(Mode.AddItemToTrade);
         pWriter.WriteBool(selfInventory);
         pWriter.WriteInt(item.Id);
         pWriter.WriteLong(item.Uid);
@@ -81,7 +81,7 @@ public static class TradePacket
     public static PacketWriter RemoveItemToTrade(Item item, int index, bool selfInventory)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.RemoveItemToTrade);
+        pWriter.Write(Mode.RemoveItemToTrade);
         pWriter.WriteBool(selfInventory);
         pWriter.WriteInt(index);
         pWriter.WriteLong(item.Uid);
@@ -91,7 +91,7 @@ public static class TradePacket
     public static PacketWriter AddMesosToTrade(long mesos, bool selfInventory)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.AddMesosToTrade);
+        pWriter.Write(Mode.AddMesosToTrade);
         pWriter.WriteBool(selfInventory);
         pWriter.WriteLong(mesos);
         return pWriter;
@@ -100,7 +100,7 @@ public static class TradePacket
     public static PacketWriter FinalizeOffer(bool selfInventory)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.FinalizeOffer);
+        pWriter.Write(Mode.FinalizeOffer);
         pWriter.WriteBool(selfInventory);
         return pWriter;
     }
@@ -108,7 +108,7 @@ public static class TradePacket
     public static PacketWriter OfferedAltered(bool self)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.OfferedAltered);
+        pWriter.Write(Mode.OfferedAltered);
         pWriter.WriteBool(self);
         return pWriter;
     }
@@ -116,7 +116,7 @@ public static class TradePacket
     public static PacketWriter FinalizeTrade(bool selfInventory)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trade);
-        pWriter.Write(TradePacketMode.FinalizeTrade);
+        pWriter.Write(Mode.FinalizeTrade);
         pWriter.WriteBool(selfInventory);
         return pWriter;
     }

--- a/MapleServer2/Packets/TrophyPacket.cs
+++ b/MapleServer2/Packets/TrophyPacket.cs
@@ -6,7 +6,7 @@ namespace MapleServer2.Packets;
 
 public static class TrophyPacket
 {
-    private enum TrophyPacketMode : byte
+    private enum Mode : byte
     {
         TableStart = 0x0,
         TableContent = 0x1,
@@ -23,7 +23,7 @@ public static class TrophyPacket
     public static PacketWriter WriteTableStart()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trophy);
-        pWriter.Write(TrophyPacketMode.TableStart);
+        pWriter.Write(Mode.TableStart);
 
         return pWriter;
     }
@@ -32,7 +32,7 @@ public static class TrophyPacket
     public static PacketWriter WriteTableContent(List<Trophy> trophies)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trophy);
-        pWriter.Write(TrophyPacketMode.TableContent);
+        pWriter.Write(Mode.TableContent);
         pWriter.WriteInt(trophies.Count);
 
         foreach (Trophy trophy in trophies)
@@ -48,7 +48,7 @@ public static class TrophyPacket
     public static PacketWriter WriteUpdate(Trophy trophy)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trophy);
-        pWriter.Write(TrophyPacketMode.Update);
+        pWriter.Write(Mode.Update);
         pWriter.WriteInt(trophy.Id);
         WriteIndividualTrophy(pWriter, trophy);
 
@@ -58,7 +58,7 @@ public static class TrophyPacket
     public static PacketWriter ToggleFavorite(Trophy trophy, bool favorited)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Trophy);
-        pWriter.Write(TrophyPacketMode.Favorite);
+        pWriter.Write(Mode.Favorite);
         pWriter.WriteInt(trophy.Id);
         pWriter.WriteBool(favorited);
 

--- a/MapleServer2/Packets/UGCPacket.cs
+++ b/MapleServer2/Packets/UGCPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class UGCPacket
 {
-    private enum UGCMode : byte
+    private enum Mode : byte
     {
         CreateUgc = 0x02,
         SetUGCUrl = 0x04,
@@ -25,7 +25,7 @@ public static class UGCPacket
     public static PacketWriter SetEndpoint(string uploadEndpoint, string resourceEndpoint, string locale = "na")
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.SetEndpoint); // Function
+        pWriter.Write(Mode.SetEndpoint); // Function
         pWriter.WriteUnicodeString(uploadEndpoint); // Serves some random irrq.aspx
         pWriter.WriteUnicodeString(resourceEndpoint); // Serves resources
         pWriter.WriteUnicodeString(locale); // locale
@@ -43,7 +43,7 @@ public static class UGCPacket
     public static PacketWriter CreateUGC(UGC ugc)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.CreateUgc);
+        pWriter.Write(Mode.CreateUgc);
         pWriter.Write(ugc.Type);
         pWriter.WriteLong(ugc.Uid);
         pWriter.WriteUnicodeString(ugc.Guid.ToString());
@@ -54,7 +54,7 @@ public static class UGCPacket
     public static PacketWriter SetUGCUrl(UGC ugc)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.SetUGCUrl);
+        pWriter.Write(Mode.SetUGCUrl);
         pWriter.Write(ugc.Type);
         pWriter.WriteLong(ugc.Uid);
         pWriter.WriteUnicodeString(ugc.Url);
@@ -65,7 +65,7 @@ public static class UGCPacket
     public static PacketWriter ActivateBanner(UGCBanner ugcBanner)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.ActivateBanner);
+        pWriter.Write(Mode.ActivateBanner);
         pWriter.WriteActiveBannerSlot(ugcBanner);
 
         return pWriter;
@@ -74,7 +74,7 @@ public static class UGCPacket
     public static PacketWriter UpdateUGCBanner(UGCBanner ugcBanner)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.UpdateUGCBanner);
+        pWriter.Write(Mode.UpdateUGCBanner);
         pWriter.WriteUGCBanner(ugcBanner.Id, ugcBanner.Slots);
 
         return pWriter;
@@ -97,7 +97,7 @@ public static class UGCPacket
     public static PacketWriter SetProfilePictureUrl(int objectId, long characterId, string url)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.ProfilePicture);
+        pWriter.Write(Mode.ProfilePicture);
         pWriter.WriteInt(objectId);
         pWriter.WriteLong(characterId);
         pWriter.WriteUnicodeString(url);
@@ -108,7 +108,7 @@ public static class UGCPacket
     public static PacketWriter UpdateUGCItem(IFieldObject<Player> fieldPlayer, Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.UpdateUGCItem);
+        pWriter.Write(Mode.UpdateUGCItem);
         pWriter.WriteInt(fieldPlayer.ObjectId);
         pWriter.WriteUGCItem(item);
         pWriter.WriteClass(item.Ugc);
@@ -119,7 +119,7 @@ public static class UGCPacket
     public static PacketWriter UpdateUGCFurnishing(IFieldObject<Player> fieldPlayer, Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.UpdateUGCFurnishing);
+        pWriter.Write(Mode.UpdateUGCFurnishing);
         pWriter.WriteInt(fieldPlayer.ObjectId);
         pWriter.WriteUGCItem(item);
         pWriter.WriteClass(item.Ugc);
@@ -130,7 +130,7 @@ public static class UGCPacket
     public static PacketWriter UpdateUGCMount(IFieldObject<Player> fieldPlayer, Item item)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.UpdateUGCMount);
+        pWriter.Write(Mode.UpdateUGCMount);
         pWriter.WriteInt(fieldPlayer.ObjectId);
         pWriter.WriteUGCItem(item);
         pWriter.WriteClass(item.Ugc);
@@ -169,7 +169,7 @@ public static class UGCPacket
     public static PacketWriter LoadUGCBanner(List<UGCBanner> banners)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.LoadBanners);
+        pWriter.Write(Mode.LoadBanners);
 
         int counter1 = 0;
         pWriter.WriteInt(counter1);
@@ -209,7 +209,7 @@ public static class UGCPacket
     public static PacketWriter ReserveBannerSlots(long bannerId, List<BannerSlot> bannerSlots)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UGC);
-        pWriter.Write(UGCMode.UpdateBanner);
+        pWriter.Write(Mode.UpdateBanner);
         pWriter.WriteLong(bannerId);
         pWriter.WriteInt(bannerSlots.Count);
         foreach (BannerSlot slot in bannerSlots)

--- a/MapleServer2/Packets/UserEnvPacket.cs
+++ b/MapleServer2/Packets/UserEnvPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class UserEnvPacket
 {
-    private enum UserEnvPacketMode : byte
+    private enum Mode : byte
     {
         AddTitle = 0x0,
         UpdateTitles = 0x1,
@@ -18,7 +18,7 @@ public static class UserEnvPacket
     public static PacketWriter AddTitle(int titleId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UserEnvironment);
-        pWriter.Write(UserEnvPacketMode.AddTitle);
+        pWriter.Write(Mode.AddTitle);
         pWriter.WriteInt(titleId);
         return pWriter;
     }
@@ -26,7 +26,7 @@ public static class UserEnvPacket
     public static PacketWriter UpdateTitle(GameSession session, int titleId)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UserEnvironment);
-        pWriter.Write(UserEnvPacketMode.UpdateTitles);
+        pWriter.Write(Mode.UpdateTitles);
         pWriter.WriteInt(session.Player.FieldPlayer.ObjectId);
         pWriter.WriteInt(titleId);
         return pWriter;
@@ -36,7 +36,7 @@ public static class UserEnvPacket
     public static PacketWriter SetTitles(Player player)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UserEnvironment);
-        pWriter.Write(UserEnvPacketMode.SetTitles);
+        pWriter.Write(Mode.SetTitles);
         pWriter.WriteInt(player.Titles.Count);
         foreach (int titleId in player.Titles)
         {
@@ -91,7 +91,7 @@ public static class UserEnvPacket
     public static PacketWriter UpdateLifeSkills(List<GatheringCount> gatherings)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.UserEnvironment);
-        pWriter.Write(UserEnvPacketMode.LifeSkills);
+        pWriter.Write(Mode.LifeSkills);
         pWriter.WriteInt(gatherings.Count);
         foreach (GatheringCount gathering in gatherings)
         {

--- a/MapleServer2/Packets/WalletPacket.cs
+++ b/MapleServer2/Packets/WalletPacket.cs
@@ -4,7 +4,7 @@ using MapleServer2.Constants;
 
 namespace MapleServer2.Packets;
 
-internal class WalletPacket
+internal static class WalletPacket
 {
     public static PacketWriter UpdateWallet(CurrencyType type, long amount)
     {

--- a/MapleServer2/Packets/WardrobePacket.cs
+++ b/MapleServer2/Packets/WardrobePacket.cs
@@ -6,15 +6,15 @@ namespace MapleServer2.Packets;
 
 public static class WardrobePacket
 {
-    private enum WardrobePacketMode : byte
+    private enum Mode : byte
     {
-        Load = 0x5,
+        Load = 0x5
     }
 
     public static PacketWriter Load(Wardrobe wardrobe)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.Wardrobe);
-        pWriter.Write(WardrobePacketMode.Load);
+        pWriter.Write(Mode.Load);
         pWriter.WriteClass(wardrobe);
         return pWriter;
     }

--- a/MapleServer2/Packets/WarehouseInventoryPacket.cs
+++ b/MapleServer2/Packets/WarehouseInventoryPacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class WarehouseInventoryPacket
 {
-    private enum WarehouseInventoryPacketMode : byte
+    private enum Mode : byte
     {
         StartList = 0x1,
         Count = 0x2,
@@ -21,7 +21,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter StartList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.StartList);
+        pWriter.Write(Mode.StartList);
 
         return pWriter;
     }
@@ -29,7 +29,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter Count(int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.Count);
+        pWriter.Write(Mode.Count);
         pWriter.WriteInt(amount);
 
         return pWriter;
@@ -38,7 +38,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter Load(Item item, int counter)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.Load);
+        pWriter.Write(Mode.Load);
         pWriter.WriteInt(item.Id);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteByte(1); // unknown
@@ -51,7 +51,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter Remove(long itemUid)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.Remove);
+        pWriter.Write(Mode.Remove);
         pWriter.WriteLong(itemUid);
 
         return pWriter;
@@ -60,7 +60,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter GainItemMessage(Item item, int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.GainItemMessage);
+        pWriter.Write(Mode.GainItemMessage);
         pWriter.WriteLong(item.Uid);
         pWriter.WriteInt(amount);
 
@@ -70,7 +70,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter UpdateAmount(long itemUid, int amount)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.UpdateAmount);
+        pWriter.Write(Mode.UpdateAmount);
         pWriter.WriteLong(itemUid);
         pWriter.WriteInt(amount);
 
@@ -80,7 +80,7 @@ public static class WarehouseInventoryPacket
     public static PacketWriter EndList()
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.WarehouseInventory);
-        pWriter.Write(WarehouseInventoryPacketMode.EndList);
+        pWriter.Write(Mode.EndList);
 
         return pWriter;
     }

--- a/MapleServer2/Types/Player.cs
+++ b/MapleServer2/Types/Player.cs
@@ -328,7 +328,7 @@ public class Player
 
         Session.FieldManager.RemovePlayer(this);
         DatabaseManager.Characters.Update(this);
-        Session.Send(RequestFieldEnterPacket.RequestEnter(FieldPlayer));
+        Session.Send(FieldEnterPacket.RequestEnter(FieldPlayer));
         Party?.BroadcastPacketParty(PartyPacket.UpdateMemberLocation(this));
         Guild?.BroadcastPacketGuild(GuildPacket.UpdateMemberLocation(Name, MapId));
         foreach (Club club in Clubs)


### PR DESCRIPTION
- Removed request/response in "RequestXHandler"/"ResponseXPacket". It's pretty obvious its a request and response at this point. This should hopefully keep some consistency with all the other handlers and packets
- Renamed all modes to be "Mode" rather than a descriptor of the mode within the handler/packet. Again, this is also pretty obvious the mode is for that specific instance.
- Updated some packets to be static for consistency
- #721 