### PR TITLE
Fix: issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,23 +8,23 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!--A clear and concise description of what the bug is.-->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!--Steps to reproduce the behavior:
 Example:
 1. Use X item...
 2. Enter X map...
-3. Error happens
+3. Error happens-->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!--A clear and concise description of what you expected to happen.-->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!--If applicable, add screenshots to help explain your problem.-->
 
 **Stack trace of the error**
-Copy the error from the console of MapleServer2
+<!--Copy the error from the console of MapleServer2-->
 
 **Latest commit id**
-If you are using git, open the MapleServer 2 folder in the command prompt and do: `git log --oneline` and copy the first line
+<!--If you are using git, open the MapleServer 2 folder in the command prompt and do: `git log --oneline` and copy the first line-->


### PR DESCRIPTION
Use comment tags to hide the guide text from the finished issue.